### PR TITLE
Enable git externals for repositories using it

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/git.rb
+++ b/lib/capistrano/recipes/deploy/scm/git.rb
@@ -199,6 +199,11 @@ module Capistrano
             execute << "#{git} submodule #{verbose} update"
           end
 
+          if variable(:git_enable_externals)
+            execute << "#{git} external init"
+            execute << "#{git} external update"
+          end
+
           # Make sure there's nothing else lying around in the repository (for
           # example, a submodule that has subsequently been removed).
           execute << "#{git} clean #{verbose} -d -x -f"


### PR DESCRIPTION
Allows users using git externals to deploy their projects with capistrano instead of having to add custom tasks or deploy strategies.

This is similar to the :git_enable_submodules.
