### PR TITLE
Remove call to String#grep for ruby 1.9

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/cvs.rb
+++ b/lib/capistrano/recipes/deploy/scm/cvs.rb
@@ -69,7 +69,8 @@ module Capistrano
         def query_revision(revision)
           return revision if revision_type(revision) == :date
           revision = yield(scm(cvs_root, :log, "-r#{revision}")).
-                       grep(/^date:/).
+                       split("\n").
+                       select { |line| line =~ /^date:/ }.
                        map { |line| line[/^date: (.*?);/, 1] }.
                        sort.last + " UTC"
           return revision


### PR DESCRIPTION
Hi,

cvs.rb hasn't moved for two years so it could probably use some tests at some point, but this is just a quick fix to replace #grep with #split/#select to get me moving again. It's not a perfect replica (1.8 #grep retained trailing newlines whereas #split does not) but it's "good enough" here. (I checked that #scm (in base.rb) always provides a string as input to this method).

Martin.
