### PR TITLE
Refactor copy strategy to allow distribution method to be changed in subclasses

### DIFF
--- a/lib/capistrano/recipes/deploy/strategy/copy.rb
+++ b/lib/capistrano/recipes/deploy/strategy/copy.rb
@@ -101,8 +101,7 @@ module Capistrano
           logger.trace "compressing #{destination} to #{filename}"
           Dir.chdir(tmpdir) { system(compress(File.basename(destination), File.basename(filename)).join(" ")) }
 
-          upload(filename, remote_filename)
-          run "cd #{configuration[:releases_path]} && #{decompress(remote_filename).join(" ")} && rm #{remote_filename}"
+          distribute!
         ensure
           FileUtils.rm filename rescue nil
           FileUtils.rm_rf destination rescue nil
@@ -210,6 +209,12 @@ module Capistrano
           # preserve the directory structure in the file.
           def decompress(file)
             compression.decompress_command + [file]
+          end
+          
+          # Distributes the file to the remote servers
+          def distribute!
+            upload(filename, remote_filename)
+            run "cd #{configuration[:releases_path]} && #{decompress(remote_filename).join(" ")} && rm #{remote_filename}"
           end
       end
 


### PR DESCRIPTION
This patch adds a private distribute! method to the Copy deploy strategy.  This method is responsible for uploading and unpacking the distribution on the remote servers.  Factoring out the distribution into a method allows subclasses to override it for specialized scenarios (like an S3 based deployment strategy.)
