### PR TITLE
sync implementation (with rsync) for none deploy strategy

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/none.rb
+++ b/lib/capistrano/recipes/deploy/scm/none.rb
@@ -35,7 +35,7 @@ module Capistrano
 	# For rsync copy cache to work we need this implemented
 	def sync(revision, destination)
 	  if system("which rsync > /dev/null 2>&1")
-	    "rsync -a --delete #{repository}/ #{destination}/"
+	    "rsync -az --delete #{repository}/ #{destination}/"
 	  else 
 	    raise NotImplementedError, "Can't find rsync - `sync' is not implemented by #{self.class.name}"
 	  end


### PR DESCRIPTION
In case you might find this useful... Just testing for rsync and using it for implementing sync, in case the none strategy is used. 

It made -for instance- the rsync-with-remote-cache [1] work if the none strategy is used. Although SCM is heavily recommended, sometimes the none strategy can be really useful (binary files, for instance).  

Let me know if I need to improve this, it is a quite trivial change as far as I believe... :)

[1] https://github.com/vigetlabs/capistrano_rsync_with_remote_cache/tree . 
