### PR TITLE
Add str support to respond to

### DIFF
--- a/lib/capistrano/configuration/variables.rb
+++ b/lib/capistrano/configuration/variables.rb
@@ -112,7 +112,7 @@ module Capistrano
       private :protect
 
       def respond_to_with_variables?(sym, include_priv=false) #:nodoc:
-        @variables.has_key?(sym) || respond_to_without_variables?(sym, include_priv)
+        @variables.has_key?(sym.to_sym) || respond_to_without_variables?(sym, include_priv)
       end
 
       def method_missing_with_variables(sym, *args, &block) #:nodoc:

--- a/test/configuration/variables_test.rb
+++ b/test/configuration/variables_test.rb
@@ -54,6 +54,12 @@ class ConfigurationVariablesTest < Test::Unit::TestCase
     assert @config.respond_to?(:sample)
   end
   
+  def test_respond_to_should_be_true_when_passed_a_string
+    assert !@config.respond_to?('sample')
+    @config[:sample] = :value
+    assert @config.respond_to?('sample')
+  end
+  
   def test_respond_to_with_include_priv_paramter
     assert !@config.respond_to?(:sample, true)
   end


### PR DESCRIPTION
Ruby's `respond_to?` takes either symbols or strings. Capistrano's always returns false on strings. This adds a `to_sym` to `Capistrano::Configuration#respond_to?`'s parameter before checking to see if it is in @variables.
