### PR TITLE
Allow setting of Net::SSH verboseness...

### DIFF
--- a/lib/capistrano/ssh.rb
+++ b/lib/capistrano/ssh.rb
@@ -69,6 +69,8 @@ module Capistrano
       # Once we've loaded the config, we don't need Net::SSH to do it again.
       ssh_options[:config] = false
 
+      ssh_options[:verbose] = :debug if options[:verbose] && options[:verbose] > 0
+
       user = server.user || options[:user] || ssh_options[:username] ||
              ssh_options[:user] || ServerDefinition.default_user
       port = server.port || options[:port] || ssh_options[:port]

--- a/test/ssh_test.rb
+++ b/test/ssh_test.rb
@@ -82,6 +82,15 @@ class SSHTest < Test::Unit::TestCase
     assert_equal success, Capistrano::SSH.connect(@server, :ssh_options => ssh_options, :user => "jamis", :port => 1235)
   end
 
+  def test_connect_with_verbose_option_should_set_verbose_option_on_ssh
+    Net::SSH.expects(:start).with(@server.host, "default-user", @options).returns(success = Object.new)
+    assert_equal success, Capistrano::SSH.connect(@server, :verbose => 0)
+    Net::SSH.expects(:start).with(@server.host, "default-user", @options.merge(:verbose => :debug)).returns(success = Object.new)
+    assert_equal success, Capistrano::SSH.connect(@server, :verbose => 1)
+    Net::SSH.expects(:start).with(@server.host, "default-user", @options.merge(:verbose => :debug)).returns(success = Object.new)
+    assert_equal success, Capistrano::SSH.connect(@server, :verbose => 2)
+  end
+
   def test_connect_with_ssh_options_should_see_server_options_override_ssh_options
     ssh_options = { :username => "JamisMan", :port => 8125, :forward_agent => true }
     server = server("jamis@capistrano:1235")


### PR DESCRIPTION
If you set any level of verboseness on cap using -v, then Net::SSH will set :verbose => :debug.
