### PR TITLE
Fix/Support relative path for copy_cache and copy_dir options. Add copy_keep option

### DIFF
--- a/test/deploy/strategy/copy_test.rb
+++ b/test/deploy/strategy/copy_test.rb
@@ -68,6 +68,16 @@ class DeployStrategyCopyTest < Test::Unit::TestCase
     @strategy.deploy!
   end
 
+  def test_deploy_with_defaults_and_copy_keep_should_keep_release_copy
+    @config[:copy_keep] = true
+    Dir.expects(:tmpdir).returns("/temp/dir")
+    @source.expects(:checkout).with("154", "/temp/dir/1234567890").returns(:local_checkout)
+    @strategy.expects(:system).with(:local_checkout)
+
+    prepare_standard_compress_and_copy!(@config[:copy_keep])
+    @strategy.deploy!
+  end
+
   def test_deploy_with_exclusions_should_remove_patterns_from_destination
     @config[:copy_exclude] = ".git"
     Dir.expects(:tmpdir).returns("/temp/dir")
@@ -232,9 +242,28 @@ class DeployStrategyCopyTest < Test::Unit::TestCase
     @strategy.deploy!
   end
 
-  def test_with_copy_cache_with_custom_cache_dir_should_use_specified_cache_dir
+  def test_with_copy_cache_with_custom_absolute_cache_dir_path_should_use_specified_cache_dir
     @config[:copy_cache] = "/u/caches/captest"
 
+    Dir.stubs(:tmpdir).returns("/temp/dir")
+    File.expects(:exists?).with("/u/caches/captest").returns(true)
+    Dir.expects(:chdir).with("/u/caches/captest").yields
+
+    @source.expects(:sync).with("154", "/u/caches/captest").returns(:local_sync)
+    @strategy.expects(:system).with(:local_sync)
+
+    FileUtils.expects(:mkdir_p).with("/temp/dir/1234567890")
+
+    prepare_directory_tree!("/u/caches/captest")
+
+    prepare_standard_compress_and_copy!
+    @strategy.deploy!
+  end
+
+  def test_with_copy_cache_with_custom_relative_cache_dir_path_should_use_specified_cache_dir
+    @config[:copy_cache] = "caches/captest"
+
+    Dir.stubs(:pwd).returns("/u")
     Dir.stubs(:tmpdir).returns("/temp/dir")
     File.expects(:exists?).with("/u/caches/captest").returns(true)
     Dir.expects(:chdir).with("/u/caches/captest").yields
@@ -276,17 +305,17 @@ class DeployStrategyCopyTest < Test::Unit::TestCase
       File.expects(:directory?).with("app").returns(true)
       FileUtils.expects(:mkdir).with("/temp/dir/1234567890/app")
       File.expects(:directory?).with("foo.txt").returns(false)
-      FileUtils.expects(:ln).with("#{cache}/foo.txt", "/temp/dir/1234567890/foo.txt")
+      FileUtils.expects(:ln).with("foo.txt", "/temp/dir/1234567890/foo.txt")
 
       Dir.expects(:glob).with("app/*", File::FNM_DOTMATCH).returns(["app/.", "app/..", "app/bar.txt"])
 
       unless exclude
         File.expects(:directory?).with("app/bar.txt").returns(false)
-        FileUtils.expects(:ln).with("#{cache}/app/bar.txt", "/temp/dir/1234567890/app/bar.txt")
+        FileUtils.expects(:ln).with("app/bar.txt", "/temp/dir/1234567890/app/bar.txt")
       end
     end
 
-    def prepare_standard_compress_and_copy!
+    def prepare_standard_compress_and_copy!(copy_keep=false)
       Dir.expects(:chdir).with("/temp/dir").yields
       @strategy.expects(:system).with("tar chzf 1234567890.tar.gz 1234567890")
       @strategy.expects(:upload).with("/temp/dir/1234567890.tar.gz", "/tmp/1234567890.tar.gz")
@@ -297,6 +326,6 @@ class DeployStrategyCopyTest < Test::Unit::TestCase
       File.expects(:open).with("/temp/dir/1234567890/REVISION", "w").yields(mock_file)
 
       FileUtils.expects(:rm).with("/temp/dir/1234567890.tar.gz")
-      FileUtils.expects(:rm_rf).with("/temp/dir/1234567890")
+      FileUtils.expects(:rm_rf).with("/temp/dir/1234567890") unless copy_keep
     end
 end


### PR DESCRIPTION
### Fix copy_cache
- Was only working with absolute path and path starting with '../'
- Error reported: `link': No such file or directory
### Fix copy_dir
- Was only working with absolute path
- Error reported: `link': File name too long

In order to allow relative and absolute paths, I had to transform the cache path and the copy path in absolute paths to fit the actual code.
### Add copy_keep
- Default to false
- When set to true, the release copy dir is not deleted
- The release copy archive is always deleted (not changed)

In addition, I changed the **tmpdir** method name by **copy_dir** which match perfectly with to the option name.
### Example of configuration

```
set :deploy_via, :copy
set :copy_cache, "application/cache"
set :copy_dir, "application/releases"
set :copy_keep, true
```

What do you think?
