### PR TITLE
DRY up the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,4 @@
 
 source :gemcutter
 
-gem 'net-ssh'
-gem 'net-ssh-gateway'
-gem 'net-sftp'
-gem 'net-scp'
-gem 'highline'
-
-group :test do
-  gem "mocha"
-end
+gemspec


### PR DESCRIPTION
Bundler now gets all of it's dependencies from capistrano.gemspec. This fixes a messy dependency tree when including capistrano via bundler in a client application.

Previously, including Capistrano in our application Gemfile resulted in a dependency list of:

```
capistrano (2.5.20)
  highline
  highline
  net-scp
  net-scp (>= 1.0.0)
  net-sftp
  net-sftp (>= 2.0.0)
  net-ssh (>= 2.0.14)
  net-ssh
  net-ssh-gateway
  net-ssh-gateway (>= 1.0.0)
```

After this change the dependency list is:

```
capistrano (2.5.20)
  highline
  net-scp (>= 1.0.0)
  net-sftp (>= 2.0.0)
  net-ssh (>= 2.0.14)
  net-ssh-gateway (>= 1.0.0)
```
