### PR TITLE
Added shared_tmp configuration variable to released 'tmp' directory be sy

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -47,7 +47,8 @@ _cset(:release_name)      { set :deploy_timestamped, true; Time.now.utc.strftime
 
 _cset :version_dir,       "releases"
 _cset :shared_dir,        "shared"
-_cset :shared_children,   %w(system log pids)
+_cset :shared_tmp,        false
+_cset(:shared_children)   { %w(system log pids) + (shared_tmp ? ["tmp"] : []) }
 _cset :current_dir,       "current"
 
 _cset(:releases_path)     { File.join(deploy_to, version_dir) }
@@ -238,12 +239,17 @@ namespace :deploy do
   task :finalize_update, :except => { :no_release => true } do
     run "chmod -R g+w #{latest_release}" if fetch(:group_writable, true)
 
+    if shared_children.include?("tmp")
+      tmp_cmd = "ln -s #{shared_path}/tmp #{latest_release}/tmp"
+    else
+      tmp_cmd = "mkdir -p #{latest_release}/tmp"
+    end
     # mkdir -p is making sure that the directories are there for some SCM's that don't
     # save empty folders
     run <<-CMD
       rm -rf #{latest_release}/log #{latest_release}/public/system #{latest_release}/tmp/pids &&
       mkdir -p #{latest_release}/public &&
-      mkdir -p #{latest_release}/tmp &&
+      #{tmp_cmd} &&
       ln -s #{shared_path}/log #{latest_release}/log &&
       ln -s #{shared_path}/system #{latest_release}/public/system &&
       ln -s #{shared_path}/pids #{latest_release}/tmp/pids


### PR DESCRIPTION
Added shared_tmp configuration variable to released 'tmp' directory be symlink to shared/tmp.
This is a possible patch for the issue:
https://capistrano.lighthouseapp.com/projects/8716/tickets/158-turn-tmp-into-a-symlink-to-sharedtmp

e.g. 
deploy.rb
set :shared_tmp, true
- shared/tmp is created at deploy:setup
- symlink #{latest_release}/tmp -> shared/tmp instead of mkdir at deploy

After writing the patch I noticed that there is version_three branch. So this patch can be less valuable.
