### PR TITLE
Fetch tags for a remote cache

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/git.rb
+++ b/lib/capistrano/recipes/deploy/scm/git.rb
@@ -181,7 +181,7 @@ module Capistrano
           end
 
           # since we're in a local branch already, just reset to specified revision rather than merge
-          execute << "#{git} fetch #{verbose} #{remote} && #{git} reset #{verbose} --hard #{revision}"
+          execute << "#{git} fetch #{verbose} #{remote} && #{git} fetch --tags #{verbose} #{remote} && #{git} reset #{verbose} --hard #{revision}"
 
           if variable(:git_enable_submodules)
             execute << "#{git} submodule #{verbose} init"


### PR DESCRIPTION
This enables people to deploy via a tag using a remote cache
(cached_copy). Before this change an error with the message "fatal:
Could not parse object ..." was thrown, because the tag wasn't known in
the cached copy.
