### PR TITLE
Makes Capistrano respect dry_run in file transfers

### DIFF
--- a/lib/capistrano/configuration/actions/file_transfer.rb
+++ b/lib/capistrano/configuration/actions/file_transfer.rb
@@ -37,7 +37,11 @@ module Capistrano
         def transfer(direction, from, to, options={}, &block)
           execute_on_servers(options) do |servers|
             targets = servers.map { |s| sessions[s] }
-            Transfer.process(direction, from, to, targets, options.merge(:logger => logger), &block)
+            if dry_run
+              logger.debug "transfering: #{[direction, from, to, targets, options.merge(:logger => logger).inspect ] * ', '}"
+            else
+              Transfer.process(direction, from, to, targets, options.merge(:logger => logger), &block)
+            end
           end
         end
 

--- a/test/configuration/actions/file_transfer_test.rb
+++ b/test/configuration/actions/file_transfer_test.rb
@@ -4,7 +4,7 @@ require 'capistrano/configuration/actions/file_transfer'
 class ConfigurationActionsFileTransferTest < Test::Unit::TestCase
   class MockConfig
     include Capistrano::Configuration::Actions::FileTransfer
-    attr_accessor :sessions
+    attr_accessor :sessions, :dry_run
   end
 
   def setup


### PR DESCRIPTION
If cap is called with -n capistrano now doesn't transfer any files to
and from the server, but logs the action instead.
