### PR TITLE
Remove hard-coded branch in the checkout method.

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/git.rb
+++ b/lib/capistrano/recipes/deploy/scm/git.rb
@@ -143,7 +143,7 @@ module Capistrano
           execute << "#{git} clone #{verbose} #{args.join(' ')} #{variable(:repository)} #{destination}"
 
           # checkout into a local branch rather than a detached HEAD
-          execute << "cd #{destination} && #{git} checkout #{verbose} -b deploy #{revision}"
+          execute << "cd #{destination} && #{git} checkout #{verbose} -b #{branch} #{revision}"
           
           if variable(:git_enable_submodules)
             execute << "#{git} submodule #{verbose} init"


### PR DESCRIPTION
Not sure how no one noticed this one.

Remove hard-coded branch in the checkout method. Now uses the #{branch} variable.
