### PR TITLE
Modified deploy:setup to respect :group_writable

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -183,7 +183,8 @@ namespace :deploy do
   task :setup, :except => { :no_release => true } do
     dirs = [deploy_to, releases_path, shared_path]
     dirs += shared_children.map { |d| File.join(shared_path, d) }
-    run "#{try_sudo} mkdir -p #{dirs.join(' ')} && #{try_sudo} chmod g+w #{dirs.join(' ')}"
+    run "#{try_sudo} mkdir -p #{dirs.join(' ')}"
+    run "#{try_sudo} chmod g+w #{dirs.join(' ')}" if fetch(:group_writable, true)
   end
 
   desc <<-DESC


### PR DESCRIPTION
This is regarding issue #46.

I've modified the `deploy:setup` task to only execute `chmod g+w` on directories if the `:group_writable` configuration variable is true (or not set). This modification is backwards compatible for those not setting `:group_writable`.

Thanks!
