### PR TITLE
Make rsync copy non-excluded hidden files in the root directory

### DIFF
--- a/lib/capistrano/recipes/deploy/strategy/remote_cache.rb
+++ b/lib/capistrano/recipes/deploy/strategy/remote_cache.rb
@@ -39,14 +39,14 @@ module Capistrano
 
           def copy_repository_cache
             logger.trace "copying the cached version to #{configuration[:release_path]}"
-            if copy_exclude.empty? 
+            if copy_exclude.empty?
               run "cp -RPp #{repository_cache} #{configuration[:release_path]} && #{mark}"
             else
               exclusions = copy_exclude.map { |e| "--exclude=\"#{e}\"" }.join(' ')
-              run "rsync -lrpt #{exclusions} #{repository_cache}/* #{configuration[:release_path]} && #{mark}"
+              run "rsync -lrpt #{exclusions} #{repository_cache}/ #{configuration[:release_path]} && #{mark}"
             end
           end
-          
+
           def copy_exclude
             @copy_exclude ||= Array(configuration.fetch(:copy_exclude, []))
           end


### PR DESCRIPTION
The asterisk on the end of the rsync command means that hidden files in the root directory are skipped. Hidden files in subdirectories are not.

```
run "rsync -lrpt #{exclusions} #{repository_cache}/* #{configuration[:release_path]} && #{mark}"
```

This is unexpected. The whole reason rsync is used is because excludes are specified (else it uses the copy method). So you can exclude nothing, or you can exclude what you specify plus (unintentionally) all hidden files in the root directory.

This is annoying to have to work around. People are doing things like checking in a file named `production.htaccess` and having it be renamed as part of the deploy process. It should copy hidden files when using the rsync method. This should be 100% expected behavior, because this is how it works when you exclude nothing.
