### PR TITLE
It should be possible to continue executing task chain on NoMatchingServersError

### DIFF
--- a/lib/capistrano/configuration/actions/invocation.rb
+++ b/lib/capistrano/configuration/actions/invocation.rb
@@ -111,6 +111,9 @@ module Capistrano
         # * :except - specifies a condition limiting which hosts will be selected to
         #   run the command. This is the inverse of :only (hosts that do _not_ match
         #   the condition will be selected).
+        # * :on_no_matching_servers - if :continue, will continue to execute tasks if
+        #   no matching servers are found for the host criteria. The default is to raise
+        #   a NoMatchingServersError exception.
         # * :once - if true, only the first matching server will be selected. The default
         #   is false (all matching servers will be selected).
         # * :max_hosts - specifies the maximum number of hosts that should be selected

--- a/lib/capistrano/configuration/connections.rb
+++ b/lib/capistrano/configuration/connections.rb
@@ -153,7 +153,7 @@ module Capistrano
           servers = find_servers_for_task(task, options)
 
           if servers.empty?
-            if ENV['HOSTFILTER']
+            if ENV['HOSTFILTER'] || task.options.merge(options)[:on_no_matching_servers] == :continue
               logger.info "skipping `#{task.fully_qualified_name}' because no servers matched"
               return
             else
@@ -167,7 +167,10 @@ module Capistrano
           end
         else
           servers = find_servers(options)
-          raise Capistrano::NoMatchingServersError, "no servers found to match #{options.inspect}" if servers.empty?
+          if servers.empty?
+            raise Capistrano::NoMatchingServersError, "no servers found to match #{options.inspect}" if options[:on_no_matching_servers] != :continue
+            return
+          end
         end
 
         servers = [servers.first] if options[:once]


### PR DESCRIPTION
We find it somewhat illogical to halt executing the task chain when this exception is raised.

There are two ways I would assume this would work.
1) Treat it the same as a task failing and rollback
2) Assume that the reason no servers match is intentional and continue executing the rest of the tasks (which seemed the most logical assumption to us)

Is this a valid issue or am I missing something?

Maybe an option similar to :on_error => :continue should be available to override the default behaviour?

Cheers in advance.

Levent
