### PR TITLE
Rails 3.1 Asset Pipeline support

### DIFF
--- a/bin/capify
+++ b/bin/capify
@@ -38,6 +38,10 @@ end
 files = {
   "Capfile" => unindent(<<-FILE),
     load 'deploy' if respond_to?(:namespace) # cap2 differentiator
+
+    # Uncomment if you are using Rails' asset pipeline
+    # load 'deploy/assets'
+
     Dir['vendor/gems/*/recipes/*.rb','vendor/plugins/*/recipes/*.rb'].each { |plugin| load(plugin) }
 
     load 'config/deploy' # remove this line to skip loading any of the default tasks

--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -28,7 +28,9 @@ _cset :deploy_via, :checkout
 _cset(:deploy_to) { "/u/apps/#{application}" }
 _cset(:revision)  { source.head }
 
-# Maintenance base filename
+_cset :rails_env, "production"
+_cset :rake, "rake"
+
 _cset :maintenance_basename, "maintenance"
 
 # =========================================================================
@@ -384,8 +386,6 @@ namespace :deploy do
       set :migrate_target, :latest
   DESC
   task :migrate, :roles => :db, :only => { :primary => true } do
-    rake = fetch(:rake, "rake")
-    rails_env = fetch(:rails_env, "production")
     migrate_env = fetch(:migrate_env, "")
     migrate_target = fetch(:migrate_target, :latest)
 
@@ -395,7 +395,7 @@ namespace :deploy do
       else raise ArgumentError, "unknown migration target #{migrate_target.inspect}"
       end
 
-    run "cd #{directory}; #{rake} RAILS_ENV=#{rails_env} #{migrate_env} db:migrate"
+    run "cd #{directory} && #{rake} RAILS_ENV=#{rails_env} #{migrate_env} db:migrate"
   end
 
   desc <<-DESC

--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -1,0 +1,57 @@
+load 'deploy' unless defined?(_cset)
+
+_cset :asset_env, "RAILS_GROUPS=assets"
+_cset :assets_prefix, "assets"
+
+before 'deploy:finalize_update', 'deploy:assets:symlink'
+after 'deploy:update_code', 'deploy:assets:precompile'
+
+namespace :deploy do
+  namespace :assets do
+    desc <<-DESC
+      [internal] This task will set up a symlink to the shared directory \
+      for the assets directory. Assets are shared across deploys to avoid \
+      mid-deploy mismatches between old application html asking for assets \
+      and getting a 404 file not found error. The assets cache is shared \
+      for efficiency. If you cutomize the assets path prefix, override the \
+      :assets_prefix variable to match.
+    DESC
+    task :symlink, :roles => :web, :except => { :no_release => true } do
+      run <<-CMD
+        rm -rf #{latest_release}/public/#{assets_prefix} &&
+        mkdir -p #{latest_release}/public &&
+        mkdir -p #{shared_path}/assets &&
+        ln -s #{shared_path}/assets #{latest_release}/public/#{assets_prefix}
+      CMD
+    end
+
+    desc <<-DESC
+      Run the asset precompilation rake task. You can specify the full path \
+      to the rake executable by setting the rake variable. You can also \
+      specify additional environment variables to pass to rake via the \
+      asset_env variable. The defaults are:
+
+        set :rake,      "rake"
+        set :rails_env, "production"
+        set :asset_env, "RAILS_GROUPS=assets"
+    DESC
+    task :precompile, :roles => :web, :except => { :no_release => true } do
+      run "cd #{latest_release} && #{rake} RAILS_ENV=#{rails_env} #{asset_env} assets:precompile"
+    end
+
+    desc <<-DESC
+      Run the asset clean rake task. Use with caution, this will delete \
+      all of your compiled assets. You can specify the full path \
+      to the rake executable by setting the rake variable. You can also \
+      specify additional environment variables to pass to rake via the \
+      asset_env variable. The defaults are:
+
+        set :rake,      "rake"
+        set :rails_env, "production"
+        set :asset_env, "RAILS_GROUPS=assets"
+    DESC
+    task :clean, :roles => :web, :except => { :no_release => true } do
+      run "cd #{latest_release} && #{rake} RAILS_ENV=#{rails_env} #{asset_env} assets:clean"
+    end
+  end
+end


### PR DESCRIPTION
I haven't dug into the details yet, but deploying Rails 3.1 will need some special consideration for the new asset pipeline support. I think it will mainly be symlinking a public/assets folder to the shared folder and running a precompile rake task. The tricky thing will be not breaking Rails < 3.1 apps.
