### PR TITLE
Fix for issue #59 regarding tearing down already-dead connections

### DIFF
--- a/lib/capistrano/configuration/connections.rb
+++ b/lib/capistrano/configuration/connections.rb
@@ -138,8 +138,11 @@ module Capistrano
       # Destroys sessions for each server in the list.
       def teardown_connections_to(servers)
         servers.each do |server|
-          sessions[server].close
-          sessions.delete(server)
+          begin
+            sessions.delete(server).close
+          rescue IOError
+            # the TCP connection is already dead
+          end
         end
       end
 

--- a/test/configuration/connections_test.rb
+++ b/test/configuration/connections_test.rb
@@ -355,6 +355,24 @@ class ConfigurationConnectionsTest < Test::Unit::TestCase
     assert_equal 2, block_called
   end
   
+  def test_execute_on_servers_should_cope_with_already_dropped_connections_when_attempting_to_close_them
+    cap1 = server("cap1")
+    cap2 = server("cap2")
+    connection1 = mock()
+    connection2 = mock()
+    connection3 = mock()
+    connection4 = mock()
+    connection1.expects(:close).raises(IOError)
+    connection2.expects(:close)
+    connection3.expects(:close)
+    connection4.expects(:close)
+    @config.current_task = mock_task(:max_hosts => 1)
+    @config.expects(:find_servers_for_task).times(2).with(@config.current_task, {}).returns([cap1, cap2])
+    Capistrano::SSH.expects(:connect).times(4).returns(connection1).then.returns(connection2).then.returns(connection3).then.returns(connection4)
+    @config.execute_on_servers {}
+    @config.execute_on_servers {}
+  end
+  
   def test_connect_should_honor_once_option
     assert @config.sessions.empty?
     @config.current_task = mock_task


### PR DESCRIPTION
Issue #59, when asked to teardown the connection to a server, if the connection is already dead (eg. due to a timeout or the server rebooting) resulting in an IOError, just remove it from the connection list
