### PR TITLE
On a dry run, don't throw an error when trying to use the current_release

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -56,7 +56,7 @@ _cset(:current_path)      { File.join(deploy_to, current_dir) }
 _cset(:release_path)      { File.join(releases_path, release_name) }
 
 _cset(:releases)          { capture("ls -x #{releases_path}", :except => { :no_release => true }).split.sort }
-_cset(:current_release)   { File.join(releases_path, releases.last) }
+_cset(:current_release)   { releases.length > 0 ? File.join(releases_path, releases.last) : nil }
 _cset(:previous_release)  { releases.length > 1 ? File.join(releases_path, releases[-2]) : nil }
 
 _cset(:current_revision)  { capture("cat #{current_path}/REVISION",     :except => { :no_release => true }).chomp }

--- a/test/recipes_test.rb
+++ b/test/recipes_test.rb
@@ -1,0 +1,25 @@
+require 'utils'
+require 'capistrano/configuration'
+
+class RecipesTest < Test::Unit::TestCase
+
+  def setup
+    @config = Capistrano::Configuration.new
+    @config.stubs(:logger).returns(stub_everything)
+  end
+
+  def test_current_releases_does_not_cause_error_on_dry_run
+    @config.dry_run = true
+    @config.load 'deploy'
+    @config.load do
+      set :application, "foo"
+      task :dry_run_test do
+        fetch :current_release
+      end
+    end
+
+    assert_nothing_raised do
+      @config.dry_run_test
+    end
+  end
+end


### PR DESCRIPTION
I ran into an issue when I required bundler/capistrano and then tried to do a dry run of cap deploy because the bundler tasks use the current_release variable, and that tries to do File.join on releases.last, and releases is an empty array on a dry run.

Here are my minimal steps to reproduce: https://gist.github.com/1032697

I couldn't find anyplace that was testing lib/capistrano/recipes/deploy.rb, so I started a new test file.

I also see the note that "Pull requests on Github will be ignored without a corresponding ticket" in capistrano.lighthouseapp.com, but when I go to that url, it gives me a signup page asking me if I'd like to start a new lighthouse site called capistrano. I'm not sure if lighthouse isn't used anymore or if this is a problem with lighthouse, but if there is something else I need to do for this pull request I would be happy to do so.

I would love any feedback on this patch and I will gladly make any modifications necessary for this pull request to be acceptable.
