### PR TITLE
Capistrano copy strategy does not preserve symlinks

### DIFF
--- a/lib/capistrano/recipes/deploy/strategy/copy.rb
+++ b/lib/capistrano/recipes/deploy/strategy/copy.rb
@@ -192,8 +192,8 @@ module Capistrano
 
             type = configuration[:copy_compression] || :gzip
             case type
-            when :gzip, :gz   then Compression.new("tar.gz",  [local_tar, 'chzf'], [remote_tar, 'xzf'])
-            when :bzip2, :bz2 then Compression.new("tar.bz2", [local_tar, 'chjf'], [remote_tar, 'xjf'])
+            when :gzip, :gz   then Compression.new("tar.gz",  [local_tar, 'czf'], [remote_tar, 'xzf'])
+            when :bzip2, :bz2 then Compression.new("tar.bz2", [local_tar, 'cjf'], [remote_tar, 'xjf'])
             when :zip         then Compression.new("zip",     %w(zip -qr), %w(unzip -q))
             else raise ArgumentError, "invalid compression type #{type.inspect}"
             end


### PR DESCRIPTION
Some of the web applications we work with have symlinks in them.

Capistrano does not preserve this symlinks when deploying using tar.gz or tar.bz2 which prevents the applications from working correctly.

Removing the "h" flag from Tar resolves this issue.

copy.rb has been updated, tested and proved to be working.
