### PR TITLE
SSH Key passphrase as a predefined configuration variable

### DIFF
--- a/lib/capistrano/ssh.rb
+++ b/lib/capistrano/ssh.rb
@@ -87,6 +87,7 @@ module Capistrano
       begin
         connection_options = ssh_options.merge(
           :password => password_value,
+          :passphrase => options[:passphrase],
           :auth_methods => ssh_options[:auth_methods] || methods.shift
         )
 


### PR DESCRIPTION
Although current version of Capistrano supports `:scm_passphrase`, it only applies to source control systems.

If one is trying to login remote SSH server with a SSH key that was generated with a passphrase, Capistrano will prompt user for the passphrase. It would become annoying if there are lots of servers to be deployed.

Of course, it can be set inside `:ssh_options`, but while there are predefined configuration variables like `:user` and `:password`, I can see no reason why not to add a new predefined configuration variable `:passphrase`.
