### PR TITLE
Fix for expanding git revisions when passed from the command line

### DIFF
--- a/test/deploy/scm/git_test.rb
+++ b/test/deploy/scm/git_test.rb
@@ -61,26 +61,25 @@ class DeploySCMGitTest < Test::Unit::TestCase
     assert_equal "git log master..branch", @source.log('master', 'branch')
   end
 
-  def test_query_revision_from_local
-    revision = @source.query_revision('d11006') do |o|
-      assert_equal "git rev-parse --revs-only d11006", o
-      "d11006102c07c94e5d54dd0ee63dca825c93ed61"
-    end
-    assert_equal "d11006102c07c94e5d54dd0ee63dca825c93ed61", revision
-  end
-
-  def test_query_revision_falls_back_to_remote
+  def test_query_revision_from_remote
     revision = @source.query_revision('HEAD') do |o|
-      return nil if o == "git rev-parse --revs-only HEAD"
       assert_equal "git ls-remote . HEAD", o
       "d11006102c07c94e5d54dd0ee63dca825c93ed61\tHEAD"
     end
     assert_equal "d11006102c07c94e5d54dd0ee63dca825c93ed61", revision
   end
 
-  def test_query_revision_from_remote_has_whitespace
+  def test_query_revision_falls_back_to_local
+    revision = @source.query_revision('d11006') do |o|
+      return nil if o == "git ls-remote . d11006"
+      assert_equal "git rev-parse --revs-only d11006", o
+      "d11006102c07c94e5d54dd0ee63dca825c93ed61"
+    end
+    assert_equal "d11006102c07c94e5d54dd0ee63dca825c93ed61", revision
+  end
+
+  def test_query_revision_has_whitespace
     revision = @source.query_revision('HEAD') do |o|
-      return nil if o == "git rev-parse --revs-only HEAD"
       assert_equal "git ls-remote . HEAD", o
       "d11006102c07c94e5d54dd0ee63dca825c93ed61\tHEAD\r"
     end


### PR DESCRIPTION
Capistrano didn't expand shortened revisions when they were passed on the command line, i.e. when rolling back code with `cap deploy -s revision=d7e99f`. 
You needed to pass the whole 40 char revision since `git ls-remote` can't help with expanding a historical revision.
`query_revision()` now tries searching the local repository if a remote SHA cannot be obtained. 
(`git ls-remote` is still tried first though, and still gets the latest `master` or `HEAD` from the remote server)

(tests included.)
