### PR TITLE
Provide separate arguments per scm command 

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/base.rb
+++ b/lib/capistrano/recipes/deploy/scm/base.rb
@@ -186,13 +186,12 @@ module Capistrano
             variable(:repository)
           end
 
-          def arguments
-            variable(:scm_arguments)
-          end
-
-          def command_arguments(command)
-            variable_name = "scm_arguments_#{command.to_s}".to_sym
-            variable(variable_name)
+          def arguments(command = :all)
+            value = variable(:scm_arguments)
+            if value.is_a?(Hash)
+              value = value[command]
+            end
+            value
           end
       end
 

--- a/lib/capistrano/recipes/deploy/scm/subversion.rb
+++ b/lib/capistrano/recipes/deploy/scm/subversion.rb
@@ -21,29 +21,29 @@ module Capistrano
         # Returns the command that will check out the given revision to the
         # given destination.
         def checkout(revision, destination)
-          scm :checkout, arguments, command_arguments(:checkout), verbose, authentication, "-r#{revision}", repository, destination
+          scm :checkout, arguments, arguments(:checkout), verbose, authentication, "-r#{revision}", repository, destination
         end
 
         # Returns the command that will do an "svn update" to the given
         # revision, for the working copy at the given destination.
         def sync(revision, destination)
-          scm :update, arguments, command_arguments(:update), verbose, authentication, "-r#{revision}", destination
+          scm :update, arguments, arguments(:update), verbose, authentication, "-r#{revision}", destination
         end
 
         # Returns the command that will do an "svn export" of the given revision
         # to the given destination.
         def export(revision, destination)
-          scm :export, arguments, command_arguments(:export), verbose, authentication, "-r#{revision}", repository, destination
+          scm :export, arguments, arguments(:export), verbose, authentication, "-r#{revision}", repository, destination
         end
 
         # Returns the command that will do an "svn diff" for the two revisions.
         def diff(from, to=nil)
-          scm :diff, repository, command_arguments(:diff), authentication, "-r#{from}:#{to || head}"
+          scm :diff, repository, arguments(:diff), authentication, "-r#{from}:#{to || head}"
         end
 
         # Returns an "svn log" command for the two revisions.
         def log(from, to=nil)
-          scm :log, repository, command_arguments(:log), authentication, "-r#{from}:#{to || head}"
+          scm :log, repository, arguments(:log), authentication, "-r#{from}:#{to || head}"
         end
 
         # Attempts to translate the given revision identifier to a "real"
@@ -52,7 +52,7 @@ module Capistrano
         # executed (svn info), and will extract the revision from the response.
         def query_revision(revision)
           return revision if revision =~ /^\d+$/
-          command = scm(:info, arguments, command_arguments(:info), repository, authentication, "-r#{revision}")
+          command = scm(:info, arguments, arguments(:info), repository, authentication, "-r#{revision}")
           result = yield(command)
           yaml = YAML.load(result)
           raise "tried to run `#{command}' and got unexpected result #{result.inspect}" unless Hash === yaml


### PR DESCRIPTION
See issue: https://github.com/capistrano/capistrano/issues/78

In a nutshell, now :scm_arguments variable value can be a hash, whose keys are command names (symbols) and hash values are the arguments to pass to each command, like this:

``` ruby
#deploy.rb
.....
set :scm_arguments, {:all => '--revision 1234', :export => '--ignore-externals' }
....
```

This will add to _all_ svn commands argument `--revision 1234` and to _export_ command `--ignore-externals` argument.
