### PR TITLE
Run a build script in Copy deploy strategy

### DIFF
--- a/test/deploy/strategy/copy_test.rb
+++ b/test/deploy/strategy/copy_test.rb
@@ -288,6 +288,20 @@ class DeployStrategyCopyTest < Test::Unit::TestCase
     @strategy.deploy!
   end
 
+  def test_with_build_script_should_run_script
+    @config[:build_script] = "mkdir bin"
+
+    Dir.expects(:tmpdir).returns("/temp/dir")
+    @source.expects(:checkout).with("154", "/temp/dir/1234567890").returns(:local_checkout)
+    @strategy.expects(:system).with(:local_checkout)
+
+    Dir.expects(:chdir).with("/temp/dir/1234567890").yields
+    @strategy.expects(:system).with("mkdir bin")
+
+    prepare_standard_compress_and_copy!
+    @strategy.deploy!
+  end
+
   private
 
     def prepare_directory_tree!(cache, exclude=false)


### PR DESCRIPTION
Use the :build_script configuration variable

The build script will be run before compression/exclusion of files,
if a :copy_cache is used, the build will run in the cache directory.

The reason for this is because it is very common to run a build script once before deploying (and not after deploying using the finalize_update task). Let me know if this is a good idea or if you have a better/smarter/prettier solution. We could consider extending this to also accept a block as a build_script.

Thanks for the feedback
