### PR TITLE
Update Servers#find_servers to not throw exception on unknown roles

### DIFF
--- a/lib/capistrano/configuration/servers.rb
+++ b/lib/capistrano/configuration/servers.rb
@@ -54,13 +54,14 @@ module Capistrano
             filter_server_list(hosts.uniq)
           end
         else
-					roles = role_list_from(ENV['ROLES'] || options[:roles] || self.roles.keys)
-					roles = roles & Array(options[:roles]) if preserve_roles && !options[:roles].nil?
+          roles = role_list_from(ENV['ROLES'] || options[:roles] || self.roles.keys)
+          roles = roles & Array(options[:roles]) if preserve_roles && !options[:roles].nil?
 
           only   = options[:only] || {}
           except = options[:except] || {}
           
-          servers = roles.inject([]) { |list, role| list.concat(self.roles[role]) }
+          # If we don't have a def for a role it means its bogus, skip it so higher level can handle
+          servers = roles.inject([]) { |list, role| list.concat(self.roles[role] || []) }
           servers = servers.select { |server| only.all? { |key,value| server.options[key] == value } }
           servers = servers.reject { |server| except.any? { |key,value| server.options[key] == value } }
 
@@ -103,7 +104,6 @@ module Capistrano
         roles = build_list(roles)
         roles.map do |role|
           role = String === role ? role.strip.to_sym : role
-          raise ArgumentError, "unknown role `#{role}'" unless self.roles.key?(role)
           role
         end
       end

--- a/test/configuration/servers_test.rb
+++ b/test/configuration/servers_test.rb
@@ -39,11 +39,11 @@ class ConfigurationServersTest < Test::Unit::TestCase
     assert_equal %w(web1 web2).sort, @config.find_servers_for_task(task).map { |s| s.host }.sort
   end
 
-  def test_task_with_unknown_role_should_raise_exception
+  # NOTE Rather than throw an error, as it used to, we return an
+  #  empty array so that if a task is okay with a missing role it can continue on
+  def test_task_with_unknown_role_should_return_empty_array
     task = new_task(:testing, @config, :roles => :bogus)
-    assert_raises(ArgumentError) do
-      @config.find_servers_for_task(task)
-    end
+    assert_equal [], @config.find_servers_for_task(task)
   end
 
   def test_task_with_hosts_option_should_apply_only_to_those_hosts


### PR DESCRIPTION
This is some additional work on pull request #51: https://github.com/capistrano/capistrano/pull/51

Basically I've added support for this uncovered this scenario:

  task :foo, :roles => :bar, :on_no_matching_severs => :continue do
    ...
  end

With no :bar role if you run

  cap foo

It throws an exception for unknown role 'foo'; that isn't in the spirit of this feature addition, since what we likely have is a stage file with :bar role not defined, and so what we really want it to say is the 'no matching serves' message instead.

NOTE: This would in the case of no :on_no_matching_servers generate NoMatchingServers exception now instead of the missing role one that was generated before.  I personally don't think this is a problem, and I actually thing NoMatchingServers is more accurate since there is no way to express the complete enumerated set of roles, but I wanted to warn in case people really depending on the missing role exception instead of the no matching servers
