### PR TITLE
Broken test when using rake 0.9.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gemspec
 # are merged here.
 #
 group :development do
-  gem 'rake'
+  gem 'rake', '0.8.7'
   gem 'ruby-debug',   :platform => :mri_18
   gem 'ruby-debug19', :platform => :mri_19
 end


### PR DESCRIPTION
`tests/recipes_test` fails when ran with rake 0.9.2 with the following error:

```
  1) Error:
test_current_releases_does_not_cause_error_on_dry_run(RecipesTest):
ArgumentError: defining a task named `symlink' would shadow an existing method with that name
    ./lib/capistrano/configuration/namespaces.rb:97:in `task'
    /Users/andrew/code/capistrano/lib/capistrano/recipes/deploy.rb:271:in `load'
    ./lib/capistrano/configuration/namespaces.rb:76:in `instance_eval'
    ./lib/capistrano/configuration/namespaces.rb:76:in `namespace'
    /Users/andrew/code/capistrano/lib/capistrano/recipes/deploy.rb:161:in `load'
    ./lib/capistrano/configuration/loading.rb:172:in `load_from_file'
    ./lib/capistrano/configuration/loading.rb:89:in `load'
    ./lib/capistrano/configuration/loading.rb:86:in `load'
    ./lib/capistrano/configuration/loading.rb:86:in `each'
    ./lib/capistrano/configuration/loading.rb:86:in `load'
    /Users/andrew/code/capistrano/test/recipes_test.rb:13:in `test_current_releases_does_not_cause_error_on_dry_run'
    /Users/andrew/.rvm/gems/ruby-1.8.7-p352/gems/mocha-0.9.12/lib/mocha/integration/test_unit/ruby_version_186_and_above.rb:22:in `__send__'
    /Users/andrew/.rvm/gems/ruby-1.8.7-p352/gems/mocha-0.9.12/lib/mocha/integration/test_unit/ruby_version_186_and_above.rb:22:in `run'
```

This is because rake 0.9.2 has a method called [symlink](https://github.com/jimweirich/rake/blob/master/lib/rake/contrib/sys.rb#L69) which causes [all_methods](https://github.com/capistrano/capistrano/blob/master/lib/capistrano/configuration/namespaces.rb#L166) to wrongly suggest that capistrano already has a task defined called `symlink`.

In practise this doesn't effect the way that capistrano works because it is ran as a standalone command line app and never mixes methods with other libraries, but it's not ideal.

The following patch simply locks the development dependency of rake to 0.8.7 which sorts the problem for the moment and will get [travis-ci](http://travis-ci.org/#!/capistrano/capistrano) working again.
