### PR TITLE
Fixed test error on ruby 1.9.2 due to mocha

### DIFF
--- a/test/command_test.rb
+++ b/test/command_test.rb
@@ -205,6 +205,7 @@ class CommandTest < Test::Unit::TestCase
     new_channel = Proc.new do |times|
       ch = mock("channel")
       returns = [false] * (times-1)
+      ch.stubs(:to_ary)
       ch.stubs(:[]).with(:closed).returns(*(returns + [true]))
       ch.expects(:[]).with(:status).returns(0)
       ch


### PR DESCRIPTION
A simple fix to the tests in ruby 1.9.2, doesn't affect any functionality of capistrano.
