### PR TITLE
add support for labels in perforce scm

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/perforce.rb
+++ b/lib/capistrano/recipes/deploy/scm/perforce.rb
@@ -122,7 +122,15 @@ module Capistrano
           end
 
           def rev_no(revision)
-            return "@#{variable(:p4_label)}" if variable(:p4_label)
+            if variable(:p4_label)
+              p4_label = if variable(:p4_label) =~ /\A@/
+                variable(:p4_label)
+              else
+                "@#{variable(:p4_label)}"
+              end
+              return p4_label
+            end
+
             case revision.to_s
             when "head"
               "#head"

--- a/test/deploy/scm/perforce_test.rb
+++ b/test/deploy/scm/perforce_test.rb
@@ -1,0 +1,23 @@
+require "utils"
+require 'capistrano/recipes/deploy/scm/perforce'
+
+class DeploySCMPerforceTest < Test::Unit::TestCase
+  class TestSCM < Capistrano::Deploy::SCM::Perforce
+    default_command "perforce"
+  end
+  def setup
+    @config = { :repository => "." }
+    @source = TestSCM.new(@config)
+  end
+
+  def test_p4_label
+    @config[:p4_label] = "some_p4_label"
+    assert_equal "@some_p4_label", @source.send(:rev_no, 'foo')
+  end
+
+  def test_p4_label_with_symbol
+    @config[:p4_label] = "@some_p4_label"
+    assert_equal "@some_p4_label", @source.send(:rev_no, 'foo')
+  end
+
+end


### PR DESCRIPTION
Hi,

We deploy using perforce labels.  This little modification allows us to specify the label and get the label in the p4 commands as needed.

I added a perforce test file, none currently exist, and made some tests.  Although I am testing a private method, I suppose it's better than what was there - which is nothing.
