### PR TITLE
fix for the deploy:migrate task on ruby 1.9.2

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -377,6 +377,7 @@ namespace :deploy do
   task :migrate, :roles => :db, :only => { :primary => true } do
     migrate_env = fetch(:migrate_env, "")
     migrate_target = fetch(:migrate_target, :latest)
+    rake_cmd = fetch(:rake)
 
     directory = case migrate_target.to_sym
       when :current then current_path
@@ -384,7 +385,7 @@ namespace :deploy do
       else raise ArgumentError, "unknown migration target #{migrate_target.inspect}"
       end
 
-    run "cd #{directory} && #{rake} RAILS_ENV=#{rails_env} #{migrate_env} db:migrate"
+    run "cd #{directory} && #{rake_cmd} RAILS_ENV=#{rails_env} #{migrate_env} db:migrate"
   end
 
   desc <<-DESC


### PR DESCRIPTION
When I call deploy:migrate, it fails with the following error:

```
failed: "env PATH=$HOME/.gems/bin:$PATH sh -c 'cd /server/path/releases/20110827120149 && #<Capistrano::Configuration::Namespaces::Namespace:0x000001009d4238> RAILS_ENV=production  db:migrate'" on /server/
```

For some reason, the rake accessor in the deploy.rb code is resolving to #Capistrano::Configuration::Namespaces::Namespace:0x000001009d4238.

I've fixed this by invoking fetch(:rake) instead of calling the accessor

> ruby -v

ruby 1.9.2p180 (2011-02-18 revision 30909) [x86_64-darwin10.7.0]

My app's dependencies:

GIT
  remote: git@github.com:benilovj/capistrano.git
  revision: 74a5e1a1476d8f16f7bc2c4ec0db0a5004508be8
  specs:
    capistrano (2.8.0)
      highline
      net-scp (>= 1.0.0)
      net-sftp (>= 2.0.0)
      net-ssh (>= 2.0.14)
      net-ssh-gateway (>= 1.1.0)

GEM
  remote: http://rubygems.org/
  specs:
    activemodel (3.1.0.rc4)
      activesupport (= 3.1.0.rc4)
      bcrypt-ruby (~> 2.1.4)
      builder (~> 3.0.0)
      i18n (~> 0.6)
    activerecord (3.1.0.rc4)
      activemodel (= 3.1.0.rc4)
      activesupport (= 3.1.0.rc4)
      arel (~> 2.1.1)
      tzinfo (~> 0.3.27)
    activesupport (3.1.0.rc4)
      multi_json (~> 1.0)
    arel (2.1.4)
    bcrypt-ruby (2.1.4)
    builder (3.0.0)
    diff-lcs (1.1.2)
    haml (3.1.2)
    highline (1.6.2)
    hpricot (0.8.4)
    i18n (0.6.0)
    mechanize (2.0.1)
      net-http-digest_auth (~> 1.1, >= 1.1.1)
      net-http-persistent (~> 1.8)
      nokogiri (~> 1.4)
      webrobots (~> 0.0, >= 0.0.9)
    multi_json (1.0.3)
    net-http-digest_auth (1.1.1)
    net-http-persistent (1.8)
    net-scp (1.0.4)
      net-ssh (>= 1.99.1)
    net-sftp (2.0.5)
      net-ssh (>= 2.0.9)
    net-ssh (2.2.1)
    net-ssh-gateway (1.1.0)
      net-ssh (>= 1.99.1)
    nokogiri (1.5.0)
    rack (1.2.1)
    rake (0.9.1)
    rspec (2.6.0)
      rspec-core (~> 2.6.0)
      rspec-expectations (~> 2.6.0)
      rspec-mocks (~> 2.6.0)
    rspec-core (2.6.4)
    rspec-expectations (2.6.0)
      diff-lcs (~> 1.1.2)
    rspec-mocks (2.6.0)
    sass (3.1.7)
    sinatra (1.2.6)
      rack (~> 1.1)
      tilt (>= 1.2.2, < 2.0)
    sqlite3 (1.3.4)
    tilt (1.3.2)
    tzinfo (0.3.29)
    webrobots (0.0.10)
      nokogiri (>= 1.4.4)
