### PR TITLE
git SCM class correctly respects scm_verbose setting

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/git.rb
+++ b/lib/capistrano/recipes/deploy/scm/git.rb
@@ -274,7 +274,7 @@ module Capistrano
           # If verbose output is requested, return nil, otherwise return the
           # command-line switch for "quiet" ("-q").
           def verbose
-            variable(:scm_verbose, true) ? "-q" : nil
+            variable(:scm_verbose) ? nil : "-q"
           end
       end
     end

--- a/test/deploy/scm/git_test.rb
+++ b/test/deploy/scm/git_test.rb
@@ -43,9 +43,17 @@ class DeploySCMGitTest < Test::Unit::TestCase
     assert_equal "#{git} clone -q git@somehost.com:project.git /var/www && cd /var/www && #{git} checkout -q -b deploy #{rev} && #{git} submodule -q init && #{git} submodule -q sync && #{git} submodule -q update --init --recursive", @source.checkout(rev, dest).gsub(/\s+/, ' ')
   end
 
-  def test_checkout_with_verbose_should_use_q_switch
+  def test_checkout_with_verbose_should_not_use_q_switch
     @config[:repository] = "git@somehost.com:project.git"
     @config[:scm_verbose] = true
+    dest = "/var/www"
+    rev = 'c2d9e79'
+    assert_equal "git clone git@somehost.com:project.git /var/www && cd /var/www && git checkout -b deploy #{rev}", @source.checkout(rev, dest)
+  end
+
+  def test_checkout_with_verbose_off_should_use_q_switch
+    @config[:repository] = "git@somehost.com:project.git"
+    @config[:scm_verbose] = false
     dest = "/var/www"
     rev = 'c2d9e79'
     assert_equal "git clone -q git@somehost.com:project.git /var/www && cd /var/www && git checkout -q -b deploy #{rev}", @source.checkout(rev, dest)


### PR DESCRIPTION
Now if we set in capfile:

```
set :scm_verbose, true
```

indeed git will be more verbose.
