### PR TITLE
Added a way to set the default Transfer :via method through a variable

### DIFF
--- a/lib/capistrano/configuration/actions/file_transfer.rb
+++ b/lib/capistrano/configuration/actions/file_transfer.rb
@@ -35,6 +35,9 @@ module Capistrano
         end
 
         def transfer(direction, from, to, options={}, &block)
+          via = variables[:transfer_via]
+          options.merge!(:via => via) if via
+
           execute_on_servers(options) do |servers|
             targets = servers.map { |s| sessions[s] }
             if dry_run

--- a/test/configuration/actions/file_transfer_test.rb
+++ b/test/configuration/actions/file_transfer_test.rb
@@ -10,6 +10,7 @@ class ConfigurationActionsFileTransferTest < Test::Unit::TestCase
   def setup
     @config = MockConfig.new
     @config.stubs(:logger).returns(stub_everything)
+    @config.stubs(:variables).returns({})
   end
 
   def test_put_should_delegate_to_upload
@@ -57,5 +58,19 @@ class ConfigurationActionsFileTransferTest < Test::Unit::TestCase
     @config.expects(:execute_on_servers).with(:foo => "bar").yields([:a, :b, :c])
     Capistrano::Transfer.expects(:process).with(:up, "testl.txt", "testr.txt", [1,2,3], {:foo => "bar", :logger => @config.logger})
     @config.transfer(:up, "testl.txt", "testr.txt", :foo => "bar")
+  end
+
+  def test_transfer_should_not_override_via_when_transfer_via_variable_not_set
+    @config.stubs(:execute_on_servers).yields([])
+    @config.expects(:variables).returns({})
+    Capistrano::Transfer.expects(:process).with(anything, anything, anything, anything, {:logger => @config.logger})
+    @config.transfer(anything, anything, anything)
+  end
+
+  def test_transfer_should_override_via_when_transfer_via_variable_set
+    @config.stubs(:execute_on_servers).yields([])
+    @config.expects(:variables).returns({:transfer_via => :foo})
+    Capistrano::Transfer.expects(:process).with(anything, anything, anything, anything, {:via => :foo, :logger => @config.logger})
+    @config.transfer(anything, anything, anything)
   end
 end

--- a/test/configuration/actions/invocation_test.rb
+++ b/test/configuration/actions/invocation_test.rb
@@ -7,8 +7,9 @@ class ConfigurationActionsInvocationTest < Test::Unit::TestCase
     attr_reader :options
     attr_accessor :debug
     attr_accessor :dry_run
-		attr_accessor :preserve_roles
+    attr_accessor :preserve_roles
     attr_accessor :servers
+    attr_accessor :variables
 
     def initialize
       @options = {}
@@ -59,6 +60,7 @@ class ConfigurationActionsInvocationTest < Test::Unit::TestCase
     config = make_config
     config.dry_run = true
     config.servers = %w[ foo ]
+    config.variables = {}
     config.expects(:sessions).returns({ 'foo-server' => 'bar' })
     ::Capistrano::Transfer.expects(:process).never
     config.put "foo", "bar", :mode => 0644


### PR DESCRIPTION
I added in a feature to allow people to default all transfer to :scp by setting a variable :transfer_via => :scp in their cap scripts.  The only way I could see to do that was through the FileTransfer module which has access to the variables, not sure if that's the best way.

I stopped short of removing the default assignment of :sftp to via from the Transfer class so that if it's ever used directly it will still work.
