### PR TITLE
Restore support for git 1.6.x.x

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/git.rb
+++ b/lib/capistrano/recipes/deploy/scm/git.rb
@@ -149,9 +149,9 @@ module Capistrano
             execute << "#{git} submodule #{verbose} init"
             execute << "#{git} submodule #{verbose} sync"
             if false == variable(:git_submodules_recursive)
-              execute << "#{git} submodule #{verbose} update --init"
+              execute << "#{git} submodule #{verbose} update"
             else
-              execute << "#{git} submodule #{verbose} update --init --recursive"
+              execute << "#{git} submodule #{verbose} update --recursive"
             end
           end
 
@@ -192,9 +192,9 @@ module Capistrano
             execute << "for mod in `#{git} submodule status | awk '{ print $2 }'`; do #{git} config -f .git/config submodule.${mod}.url `#{git} config -f .gitmodules --get submodule.${mod}.url` && echo Synced $mod; done"
             execute << "#{git} submodule #{verbose} sync"
             if false == variable(:git_submodules_recursive)
-              execute << "#{git} submodule #{verbose} update --init"
+              execute << "#{git} submodule #{verbose} update"
             else
-              execute << "#{git} submodule #{verbose} update --init --recursive"
+              execute << "#{git} submodule #{verbose} update --recursive"
             end
           end
 

--- a/test/deploy/scm/git_test.rb
+++ b/test/deploy/scm/git_test.rb
@@ -40,7 +40,7 @@ class DeploySCMGitTest < Test::Unit::TestCase
 
     # with submodules
     @config[:git_enable_submodules] = true
-    assert_equal "#{git} clone -q git@somehost.com:project.git /var/www && cd /var/www && #{git} checkout -q -b deploy #{rev} && #{git} submodule -q init && #{git} submodule -q sync && #{git} submodule -q update --init --recursive", @source.checkout(rev, dest).gsub(/\s+/, ' ')
+    assert_equal "#{git} clone -q git@somehost.com:project.git /var/www && cd /var/www && #{git} checkout -q -b deploy #{rev} && #{git} submodule -q init && #{git} submodule -q sync && #{git} submodule -q update --recursive", @source.checkout(rev, dest).gsub(/\s+/, ' ')
   end
 
   def test_checkout_with_verbose_should_not_use_q_switch
@@ -118,7 +118,7 @@ class DeploySCMGitTest < Test::Unit::TestCase
 
     # with submodules
     @config[:git_enable_submodules] = true
-    assert_equal "cd #{dest} && #{git} fetch -q origin && #{git} fetch --tags -q origin && #{git} reset -q --hard #{rev} && #{git} submodule -q init && for mod in `#{git} submodule status | awk '{ print $2 }'`; do #{git} config -f .git/config submodule.${mod}.url `#{git} config -f .gitmodules --get submodule.${mod}.url` && echo Synced $mod; done && #{git} submodule -q sync && #{git} submodule -q update --init --recursive && #{git} clean -q -d -x -f", @source.sync(rev, dest)
+    assert_equal "cd #{dest} && #{git} fetch -q origin && #{git} fetch --tags -q origin && #{git} reset -q --hard #{rev} && #{git} submodule -q init && for mod in `#{git} submodule status | awk '{ print $2 }'`; do #{git} config -f .git/config submodule.${mod}.url `#{git} config -f .gitmodules --get submodule.${mod}.url` && echo Synced $mod; done && #{git} submodule -q sync && #{git} submodule -q update --recursive && #{git} clean -q -d -x -f", @source.sync(rev, dest)
   end
 
   def test_sync_with_remote
@@ -155,7 +155,7 @@ class DeploySCMGitTest < Test::Unit::TestCase
     @config[:git_enable_submodules] = true
     dest = "/var/www"
     rev = 'c2d9e79'
-    assert_equal "git clone -q -o username git@somehost.com:project.git /var/www && cd /var/www && git checkout -q -b deploy #{rev} && git submodule -q init && git submodule -q sync && git submodule -q update --init --recursive", @source.checkout(rev, dest)
+    assert_equal "git clone -q -o username git@somehost.com:project.git /var/www && cd /var/www && git checkout -q -b deploy #{rev} && git submodule -q init && git submodule -q sync && git submodule -q update --recursive", @source.checkout(rev, dest)
   end
 
   # Tests from base_test.rb, makin' sure we didn't break anything up there!


### PR DESCRIPTION
Fixes #96

Revert "improving behavior with git submodules"
This reverts commit 05c707cf625a90a6b78653dae75e453c308f881c.

Conflicts:

```
lib/capistrano/recipes/deploy/scm/git.rb
test/deploy/scm/git_test.rb
```
