### PR TITLE
Allow variables to hold false as a value

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/base.rb
+++ b/lib/capistrano/recipes/deploy/scm/base.rb
@@ -163,9 +163,9 @@ module Capistrano
           # consideration the current mode ("normal" vs. "local").
           def variable(name, default = nil)
             if local? && configuration.exists?("local_#{name}".to_sym)
-              return configuration["local_#{name}".to_sym] || default
+              return configuration["local_#{name}".to_sym].nil? ? default : configuration["local_#{name}".to_sym]
             else
-              configuration[name] || default
+              configuration[name].nil? ? default : configuration[name]
             end
           end
 

--- a/test/deploy/scm/git_test.rb
+++ b/test/deploy/scm/git_test.rb
@@ -43,6 +43,15 @@ class DeploySCMGitTest < Test::Unit::TestCase
     assert_equal "#{git} clone -q git@somehost.com:project.git /var/www && cd /var/www && #{git} checkout -q -b deploy #{rev} && #{git} submodule -q init && #{git} submodule -q sync && #{git} submodule -q update --init --recursive", @source.checkout(rev, dest).gsub(/\s+/, ' ')
   end
 
+  def test_checkout_submodules_without_recursive
+    @config[:repository] = "git@somehost.com:project.git"
+    dest = "/var/www"
+    rev = 'c2d9e79'
+    @config[:git_enable_submodules] = true
+    @config[:git_submodules_recursive] = false
+    assert_equal "git clone -q git@somehost.com:project.git /var/www && cd /var/www && git checkout -q -b deploy #{rev} && git submodule -q init && git submodule -q sync && git submodule -q update --init", @source.checkout(rev, dest).gsub(/\s+/, ' ')
+  end
+
   def test_checkout_with_verbose_should_not_use_q_switch
     @config[:repository] = "git@somehost.com:project.git"
     @config[:scm_verbose] = true


### PR DESCRIPTION
Capistrano::Deploy::SCM::Base#variable would previously override
variables set to false with that variable's default value.

For example, this line would have no effect:
set :git_submodules_recursive, false
