### PR TITLE
Check for git submodule --recursive support

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/git.rb
+++ b/lib/capistrano/recipes/deploy/scm/git.rb
@@ -151,7 +151,8 @@ module Capistrano
             if false == variable(:git_submodules_recursive)
               execute << "#{git} submodule #{verbose} update --init"
             else
-              execute << "#{git} submodule #{verbose} update --init --recursive"
+              execute << %Q(export GIT_RECURSIVE=$([ ! "`#{git} --version`" \\< "git version 1.6.5" ] && echo --recursive))
+              execute << "#{git} submodule #{verbose} update --init $GIT_RECURSIVE"
             end
           end
 
@@ -194,7 +195,8 @@ module Capistrano
             if false == variable(:git_submodules_recursive)
               execute << "#{git} submodule #{verbose} update --init"
             else
-              execute << "#{git} submodule #{verbose} update --init --recursive"
+              execute << %Q(export GIT_RECURSIVE=$([ ! "`#{git} --version`" \\< "git version 1.6.5" ] && echo --recursive))
+              execute << "#{git} submodule #{verbose} update --init $GIT_RECURSIVE"
             end
           end
 

--- a/test/deploy/scm/git_test.rb
+++ b/test/deploy/scm/git_test.rb
@@ -40,7 +40,7 @@ class DeploySCMGitTest < Test::Unit::TestCase
 
     # with submodules
     @config[:git_enable_submodules] = true
-    assert_equal "#{git} clone -q git@somehost.com:project.git /var/www && cd /var/www && #{git} checkout -q -b deploy #{rev} && #{git} submodule -q init && #{git} submodule -q sync && #{git} submodule -q update --init --recursive", @source.checkout(rev, dest).gsub(/\s+/, ' ')
+    assert_equal "#{git} clone -q git@somehost.com:project.git /var/www && cd /var/www && #{git} checkout -q -b deploy #{rev} && #{git} submodule -q init && #{git} submodule -q sync && export GIT_RECURSIVE=$([ ! \"`#{git} --version`\" \\< \"git version 1.6.5\" ] && echo --recursive) && #{git} submodule -q update --init $GIT_RECURSIVE", @source.checkout(rev, dest).gsub(/\s+/, ' ')
   end
 
   def test_checkout_with_verbose_should_not_use_q_switch
@@ -118,7 +118,7 @@ class DeploySCMGitTest < Test::Unit::TestCase
 
     # with submodules
     @config[:git_enable_submodules] = true
-    assert_equal "cd #{dest} && #{git} fetch -q origin && #{git} fetch --tags -q origin && #{git} reset -q --hard #{rev} && #{git} submodule -q init && for mod in `#{git} submodule status | awk '{ print $2 }'`; do #{git} config -f .git/config submodule.${mod}.url `#{git} config -f .gitmodules --get submodule.${mod}.url` && echo Synced $mod; done && #{git} submodule -q sync && #{git} submodule -q update --init --recursive && #{git} clean -q -d -x -f", @source.sync(rev, dest)
+    assert_equal "cd #{dest} && #{git} fetch -q origin && #{git} fetch --tags -q origin && #{git} reset -q --hard #{rev} && #{git} submodule -q init && for mod in `#{git} submodule status | awk '{ print $2 }'`; do #{git} config -f .git/config submodule.${mod}.url `#{git} config -f .gitmodules --get submodule.${mod}.url` && echo Synced $mod; done && #{git} submodule -q sync && export GIT_RECURSIVE=$([ ! \"`#{git} --version`\" \\< \"git version 1.6.5\" ] && echo --recursive) && #{git} submodule -q update --init $GIT_RECURSIVE && #{git} clean -q -d -x -f", @source.sync(rev, dest)
   end
 
   def test_sync_with_remote
@@ -155,7 +155,7 @@ class DeploySCMGitTest < Test::Unit::TestCase
     @config[:git_enable_submodules] = true
     dest = "/var/www"
     rev = 'c2d9e79'
-    assert_equal "git clone -q -o username git@somehost.com:project.git /var/www && cd /var/www && git checkout -q -b deploy #{rev} && git submodule -q init && git submodule -q sync && git submodule -q update --init --recursive", @source.checkout(rev, dest)
+    assert_equal "git clone -q -o username git@somehost.com:project.git /var/www && cd /var/www && git checkout -q -b deploy #{rev} && git submodule -q init && git submodule -q sync && export GIT_RECURSIVE=$([ ! \"`git --version`\" \\< \"git version 1.6.5\" ] && echo --recursive) && git submodule -q update --init $GIT_RECURSIVE", @source.checkout(rev, dest)
   end
 
   # Tests from base_test.rb, makin' sure we didn't break anything up there!


### PR DESCRIPTION
git submodule x --recursive is only supported after git 1.6.5.
See https://github.com/git/git/blob/master/Documentation/RelNotes/1.6.5.txt#L147

Users with older versions of git on the deploy target using remote-cache or similar deploy methods would see this error when deploying:

```
 ** [10.0.0.1 :: err] Usage: git submodule [--quiet] [--cached] [add [-b branch] <repo> <path>]|[status|init|update [-i|--init] [-N|--no-fetch]|summary [-n|--summary-limit <n>] [<commit>]] [--] [<path>...]|[foreach <command>]|[sync [--] [<path>...]]
    command finished in 27929ms
*** [deploy:update_code] rolling back
```

This fix was tested on an OSX 10.6 (git 1.7.4.1) and Ubuntu Linux 9.10 (git 1.6.3.3) deploy targets, and against both GNU bash and BSD dash (sh).
