### PR TITLE
Understandable error when uploading non existing files

### DIFF
--- a/lib/capistrano/transfer.rb
+++ b/lib/capistrano/transfer.rb
@@ -203,6 +203,8 @@ module Capistrano
       end
 
       def handle_error(error)
+        raise error if error.message.include?('expected a file to upload')
+
         transfer = session_map[error.session]
         transfer[:error] = error
         transfer[:failed] = true

--- a/test/transfer_test.rb
+++ b/test/transfer_test.rb
@@ -133,6 +133,14 @@ class TransferTest < Test::Unit::TestCase
     transfer.process!
   end
 
+  def test_uploading_a_non_existing_file_should_raise_an_understandable_error
+    s = session('app1')
+    error = Capistrano::Processable::SessionAssociation.on(ArgumentError.new('expected a file to upload'), s)
+    transfer = Capistrano::Transfer.new(:up, "from", "to", [], :via => :scp)
+    transfer.expects(:process_iteration).raises(error)
+    assert_raise(ArgumentError, 'expected a file to upload') { transfer.process! }
+  end
+
   private
 
     class ExceptionWithSession < ::Exception


### PR DESCRIPTION
The error raised when trying to upload a file which doesn't exist is not the desired one. It's easy to reproduce.

``` ruby
task :failing_upload do
  upload "no_such_file", "will_never_get_here"
end
```

Now net-sftp will actually raise the error `#<ArgumentError: expected a file to upload>` which is easy to understand and correct. But when that error gets side tracked by `Processable::SessionAssociation#ensure_each_session` followed by `Transfer#handle_error` a new (impossible to comprehend) error is created since the `@operation` variable for `SFTPTransferWrapper` was never set.

```
/Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/transfer.rb:156:in `[]=': undefined method `[]=' for nil:NilClass (NoMethodError)
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/transfer.rb:208:in `handle_error'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/transfer.rb:48:in `rescue in block in process!'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/transfer.rb:44:in `block in process!'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/transfer.rb:43:in `loop'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/transfer.rb:43:in `process!'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/transfer.rb:11:in `process'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/configuration/actions/file_transfer.rb:43:in `block in transfer'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/configuration/connections.rb:192:in `block in execute_on_servers'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/configuration/connections.rb:180:in `each'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/configuration/connections.rb:180:in `each_slice'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/configuration/connections.rb:180:in `execute_on_servers'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/configuration/actions/file_transfer.rb:38:in `transfer'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/configuration/actions/file_transfer.rb:26:in `upload'
from ./config/deploy.rb:23:in `block in load'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/configuration/execution.rb:139:in `instance_eval'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/configuration/execution.rb:139:in `invoke_task_directly'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/configuration/callbacks.rb:27:in `invoke_task_directly_with_callbacks'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/configuration/execution.rb:89:in `execute_task'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/configuration/execution.rb:101:in `find_and_execute_task'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/cli/execute.rb:46:in `block in execute_requested_actions'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/cli/execute.rb:45:in `each'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/cli/execute.rb:45:in `execute_requested_actions'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/cli/help.rb:19:in `execute_requested_actions_with_help'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/cli/execute.rb:34:in `execute!'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/lib/capistrano/cli/execute.rb:14:in `execute'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/gems/capistrano-2.6.0/bin/cap:4:in `<top (required)>'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/bin/cap:19:in `load'
from /Users/druiden/.rvm/gems/ruby-1.9.2-p180/bin/cap:19:in `<main>'
```
