### PR TITLE
ST: Added :copy_via variable to :copy strategy in order to :scp or :sftp (default) to the remote machines

### DIFF
--- a/lib/capistrano/recipes/deploy/strategy/copy.rb
+++ b/lib/capistrano/recipes/deploy/strategy/copy.rb
@@ -39,6 +39,11 @@ module Capistrano
       # :zip, and which specifies how the source should be compressed for
       # transmission to each host.
       #
+      # By default, files will be transferred across to the remote machines via 'sftp'. If you prefer
+      # to use 'scp' you can set the :copy_via variable to :scp.
+      #
+      #   set :copy_via, :scp
+      #
       # There is a possibility to pass a build command that will get
       # executed if your code needs to be compiled or something needs to be
       # done before the code is ready to run.
@@ -316,7 +321,10 @@ module Capistrano
 
           # Distributes the file to the remote servers
           def distribute!
-            upload(filename, remote_filename)
+            args = [filename, remote_filename]
+            args << { :via => configuration[:copy_via] } if configuration[:copy_via]
+
+            upload(*args)
             decompress_remote_file
           end
       end

--- a/test/deploy/strategy/copy_test.rb
+++ b/test/deploy/strategy/copy_test.rb
@@ -197,6 +197,27 @@ class DeployStrategyCopyTest < Test::Unit::TestCase
     @strategy.deploy!
   end
 
+  def test_deploy_with_copy_via_should_use_the_given_transfer_method
+    @config[:copy_via] = :scp
+    Dir.expects(:tmpdir).returns("/temp/dir")
+    Dir.expects(:chdir).yields
+    @source.expects(:checkout).returns(:local_checkout)
+
+    @strategy.expects(:system).with(:local_checkout)
+    @strategy.expects(:system).with("tar czf 1234567890.tar.gz 1234567890")
+    @strategy.expects(:upload).with("/temp/dir/1234567890.tar.gz", "/tmp/1234567890.tar.gz", {:via => :scp})
+    @strategy.expects(:run).with("cd /u/apps/test/releases && tar xzf /tmp/1234567890.tar.gz && rm /tmp/1234567890.tar.gz")
+
+    mock_file = mock("file")
+    mock_file.expects(:puts).with("154")
+    File.expects(:open).with("/temp/dir/1234567890/REVISION", "w").yields(mock_file)
+
+    FileUtils.expects(:rm).with("/temp/dir/1234567890.tar.gz")
+    FileUtils.expects(:rm_rf).with("/temp/dir/1234567890")
+
+    @strategy.deploy!
+  end
+
   def test_with_copy_cache_should_checkout_to_cache_if_cache_does_not_exist_and_then_copy
     @config[:copy_cache] = true
 


### PR DESCRIPTION
Hi,

I've added the variable :copy_via for the :copy strategy in order to define how to move the tar/zip across to the remote machines. One of my clients does not support :sftp so we're using :scp instead.

Would be nice to have it in the official repo. Many thanks.

Rudi
