### PR TITLE
Don't dereference symlinks when deploying via copy

### DIFF
--- a/lib/capistrano/recipes/deploy/strategy/copy.rb
+++ b/lib/capistrano/recipes/deploy/strategy/copy.rb
@@ -217,9 +217,9 @@ module Capistrano
 
             type = configuration[:copy_compression] || :gzip
             case type
-            when :gzip, :gz   then Compression.new("tar.gz",  [local_tar, 'chzf'], [remote_tar, 'xzf'])
-            when :bzip2, :bz2 then Compression.new("tar.bz2", [local_tar, 'chjf'], [remote_tar, 'xjf'])
-            when :zip         then Compression.new("zip",     %w(zip -qr), %w(unzip -q))
+            when :gzip, :gz   then Compression.new("tar.gz",  [local_tar, 'czf'], [remote_tar, 'xzf'])
+            when :bzip2, :bz2 then Compression.new("tar.bz2", [local_tar, 'cjf'], [remote_tar, 'xjf'])
+            when :zip         then Compression.new("zip",     %w(zip -qyr), %w(unzip -q))
             else raise ArgumentError, "invalid compression type #{type.inspect}"
             end
           end

--- a/test/deploy/strategy/copy_test.rb
+++ b/test/deploy/strategy/copy_test.rb
@@ -23,7 +23,7 @@ class DeployStrategyCopyTest < Test::Unit::TestCase
     @strategy.expects(:system).with(:local_checkout)
 
     Dir.expects(:chdir).with("/temp/dir").yields
-    @strategy.expects(:system).with("tar chzf 1234567890.tar.gz 1234567890")
+    @strategy.expects(:system).with("tar czf 1234567890.tar.gz 1234567890")
     @strategy.expects(:upload).with("/temp/dir/1234567890.tar.gz", "/tmp/1234567890.tar.gz")
     @strategy.expects(:run).with("cd /u/apps/test/releases && gtar xzf /tmp/1234567890.tar.gz && rm /tmp/1234567890.tar.gz")
 
@@ -45,7 +45,7 @@ class DeployStrategyCopyTest < Test::Unit::TestCase
     @strategy.expects(:system).with(:local_checkout)
 
     Dir.expects(:chdir).with("/temp/dir").yields
-    @strategy.expects(:system).with("gtar chzf 1234567890.tar.gz 1234567890")
+    @strategy.expects(:system).with("gtar czf 1234567890.tar.gz 1234567890")
     @strategy.expects(:upload).with("/temp/dir/1234567890.tar.gz", "/tmp/1234567890.tar.gz")
     @strategy.expects(:run).with("cd /u/apps/test/releases && tar xzf /tmp/1234567890.tar.gz && rm /tmp/1234567890.tar.gz")
 
@@ -109,7 +109,7 @@ class DeployStrategyCopyTest < Test::Unit::TestCase
     @source.expects(:checkout).with("154", "/temp/dir/1234567890").returns(:local_checkout)
 
     @strategy.expects(:system).with(:local_checkout)
-    @strategy.expects(:system).with("zip -qr 1234567890.zip 1234567890")
+    @strategy.expects(:system).with("zip -qyr 1234567890.zip 1234567890")
     @strategy.expects(:upload).with("/temp/dir/1234567890.zip", "/tmp/1234567890.zip")
     @strategy.expects(:run).with("cd /u/apps/test/releases && unzip -q /tmp/1234567890.zip && rm /tmp/1234567890.zip")
 
@@ -130,7 +130,7 @@ class DeployStrategyCopyTest < Test::Unit::TestCase
     @source.expects(:checkout).with("154", "/temp/dir/1234567890").returns(:local_checkout)
 
     @strategy.expects(:system).with(:local_checkout)
-    @strategy.expects(:system).with("tar chjf 1234567890.tar.bz2 1234567890")
+    @strategy.expects(:system).with("tar cjf 1234567890.tar.bz2 1234567890")
     @strategy.expects(:upload).with("/temp/dir/1234567890.tar.bz2", "/tmp/1234567890.tar.bz2")
     @strategy.expects(:run).with("cd /u/apps/test/releases && tar xjf /tmp/1234567890.tar.bz2 && rm /tmp/1234567890.tar.bz2")
 
@@ -161,7 +161,7 @@ class DeployStrategyCopyTest < Test::Unit::TestCase
     @source.expects(:checkout).with("154", "/other/path/1234567890").returns(:local_checkout)
 
     @strategy.expects(:system).with(:local_checkout)
-    @strategy.expects(:system).with("tar chzf 1234567890.tar.gz 1234567890")
+    @strategy.expects(:system).with("tar czf 1234567890.tar.gz 1234567890")
     @strategy.expects(:upload).with("/other/path/1234567890.tar.gz", "/tmp/1234567890.tar.gz")
     @strategy.expects(:run).with("cd /u/apps/test/releases && tar xzf /tmp/1234567890.tar.gz && rm /tmp/1234567890.tar.gz")
 
@@ -182,7 +182,7 @@ class DeployStrategyCopyTest < Test::Unit::TestCase
     @source.expects(:checkout).returns(:local_checkout)
 
     @strategy.expects(:system).with(:local_checkout)
-    @strategy.expects(:system).with("tar chzf 1234567890.tar.gz 1234567890")
+    @strategy.expects(:system).with("tar czf 1234567890.tar.gz 1234567890")
     @strategy.expects(:upload).with("/temp/dir/1234567890.tar.gz", "/somewhere/else/1234567890.tar.gz")
     @strategy.expects(:run).with("cd /u/apps/test/releases && tar xzf /somewhere/else/1234567890.tar.gz && rm /somewhere/else/1234567890.tar.gz")
 
@@ -321,7 +321,7 @@ class DeployStrategyCopyTest < Test::Unit::TestCase
 
     def prepare_standard_compress_and_copy!
       Dir.expects(:chdir).with("/temp/dir").yields
-      @strategy.expects(:system).with("tar chzf 1234567890.tar.gz 1234567890")
+      @strategy.expects(:system).with("tar czf 1234567890.tar.gz 1234567890")
       @strategy.expects(:upload).with("/temp/dir/1234567890.tar.gz", "/tmp/1234567890.tar.gz")
       @strategy.expects(:run).with("cd /u/apps/test/releases && tar xzf /tmp/1234567890.tar.gz && rm /tmp/1234567890.tar.gz")
 


### PR DESCRIPTION
Hi,

I noticed that the the behaviour of the copy strategy differs from the remote checkout strategy. 

The remote checkout strategy does not dereference symlinks, and it seems strange to
have a different behaviour between the two strategies.

Maybe this change should be offered as an option to preserve backwards compatibility. I'd be happy to submit another pull request with that available. 

Let me know what you think.

Best wishes

David Heath
