### PR TITLE
Disable :normalize_asset_timestamps when the asset pipeline is enabled

### DIFF
--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -3,6 +3,8 @@ load 'deploy' unless defined?(_cset)
 _cset :asset_env, "RAILS_GROUPS=assets"
 _cset :assets_prefix, "assets"
 
+_cset :normalize_asset_timestamps, false
+
 before 'deploy:finalize_update', 'deploy:assets:symlink'
 after 'deploy:update_code', 'deploy:assets:precompile'
 


### PR DESCRIPTION
I suggest to default the `:normalize_asset_timestamps` to false (normally is true) when the asset pipeline is enabled. Otherwise, `capistrano` will continue to run the following command

``` ruby
if fetch(:normalize_asset_timestamps, true)
  stamp = Time.now.utc.strftime("%Y%m%d%H%M.%S")
  asset_paths = fetch(:public_children, %w(images stylesheets javascripts)).map { |p| "#{latest_release}/public/#{p}" }.join(" ")
  run "find #{asset_paths} -exec touch -t #{stamp} {} ';'; true", :env => { "TZ" => "UTC" }
end
```

This command is useless in Rails 3.1. It also generates an error because the public folders are no longer there.

```

 * executing "find /path/to/application/releases/20111026112344/public/images /path/to/application/releases/20111026112344/public/stylesheets /path/to/application/releases/20111026112344/public/javascripts -exec touch -t 201110261123.47 {} ';'; true"
   servers: ["octopus"]
   [octopus] executing command
** [out :: octopus] find: `/path/to/application/releases/20111026112344/public/images': No such file or directory
** [out :: octopus] 
** [out :: octopus] find: `/path/to/application/releases/20111026112344/public/stylesheets'
** [out :: octopus] : No such file or directory
** [out :: octopus] find: `/path/to/application/releases/20111026112344/public/javascripts'
** [out :: octopus] : No such file or directory
** [out :: octopus] 
   command finished in 668ms
```
