### PR TITLE
Add host information to some logging operations

### DIFF
--- a/lib/capistrano/command.rb
+++ b/lib/capistrano/command.rb
@@ -218,7 +218,7 @@ module Capistrano
 
                   command_line = [environment, shell, cmd].compact.join(" ")
                   ch[:command] = command_line
-
+                  logger.trace command_line, ch[:server] if logger
                   ch.exec(command_line)
                   ch.send_data(options[:data]) if options[:data]
                 else

--- a/lib/capistrano/configuration/actions/invocation.rb
+++ b/lib/capistrano/configuration/actions/invocation.rb
@@ -12,7 +12,7 @@ module Capistrano
 
           base.default_io_proc = Proc.new do |ch, stream, out|
             level = stream == :err ? :important : :info
-            ch[:options][:logger].send(level, out, "#{stream} :: #{ch[:server]}")
+            ch[:options][:logger].send(level, out, ch[:server])
           end
         end
 
@@ -231,7 +231,7 @@ module Capistrano
             if out =~ /^Sorry, try again/
               if prompt_host.nil? || prompt_host == ch[:server]
                 prompt_host = ch[:server]
-                logger.important out, "#{stream} :: #{ch[:server]}"
+                logger.important out, ch[:server]
                 reset! :password
               end
             end

--- a/lib/capistrano/transfer.rb
+++ b/lib/capistrano/transfer.rb
@@ -117,7 +117,7 @@ module Capistrano
 
       def prepare_scp_transfer(from, to, session)
         real_callback = callback || Proc.new do |channel, name, sent, total|
-          logger.trace "[#{channel[:host]}] #{name}" if logger && sent == 0
+          logger.trace "#{transport} #{operation} #{from} -> #{to}", channel[:host] if logger && sent == 0
         end
 
         channel = case direction
@@ -167,9 +167,9 @@ module Capistrano
             if callback
               callback.call(event, op, *args)
             elsif event == :open
-              logger.trace "[#{op[:host]}] #{args[0].remote}"
+              logger.trace "#{transport} #{operation} #{from} -> #{to}", op[:host]
             elsif event == :finish
-              logger.trace "[#{op[:host]}] done"
+              logger.trace "#{transport} #{operation} #{from} -> #{to} done", op[:host]
             end
           end
 


### PR DESCRIPTION
Capistrano outputs all logs into a single place which makes it rather difficult
to figure out what has happened on a single host machine, especially when you are
running parallel. By adding host information to the log as possible as it can will
enable tools such as splunk to easily filter out host specific log information, which
is helpful during the later auditing process.
