### PR TITLE
Fix bug for "problems with deploy:migrate - Syntax error: end of file unexpected"

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -29,7 +29,7 @@ _cset(:deploy_to) { "/u/apps/#{application}" }
 _cset(:revision)  { source.head }
 
 _cset :rails_env, "production"
-_cset :rake, "rake"
+_cset :rake_bin, "rake"
 
 _cset :maintenance_basename, "maintenance"
 
@@ -384,7 +384,7 @@ namespace :deploy do
       else raise ArgumentError, "unknown migration target #{migrate_target.inspect}"
       end
 
-    run "cd #{directory} && #{rake} RAILS_ENV=#{rails_env} #{migrate_env} db:migrate"
+    run "cd #{directory} && #{rake_bin} RAILS_ENV=#{rails_env} #{migrate_env} db:migrate"
   end
 
   desc <<-DESC

--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -36,7 +36,7 @@ namespace :deploy do
         set :asset_env, "RAILS_GROUPS=assets"
     DESC
     task :precompile, :roles => :web, :except => { :no_release => true } do
-      run "cd #{latest_release} && #{rake} RAILS_ENV=#{rails_env} #{asset_env} assets:precompile"
+      run "cd #{latest_release} && #{rake_bin} RAILS_ENV=#{rails_env} #{asset_env} assets:precompile"
     end
 
     desc <<-DESC
@@ -51,7 +51,7 @@ namespace :deploy do
         set :asset_env, "RAILS_GROUPS=assets"
     DESC
     task :clean, :roles => :web, :except => { :no_release => true } do
-      run "cd #{latest_release} && #{rake} RAILS_ENV=#{rails_env} #{asset_env} assets:clean"
+      run "cd #{latest_release} && #{rake_bin} RAILS_ENV=#{rails_env} #{asset_env} assets:clean"
     end
   end
 end


### PR DESCRIPTION
Fix bug for "run command can't not use rake variable".

environments: 
ruby 1.8.7
rails 3.0.10

```
modified:   lib/capistrano/recipes/deploy.rb

modified:   lib/capistrano/recipes/deploy/assets.rb
```
