### PR TITLE
Remove unecessary explicit rubygems access

### DIFF
--- a/lib/capistrano/ssh.rb
+++ b/lib/capistrano/ssh.rb
@@ -1,9 +1,3 @@
-begin
-  require 'rubygems'
-  gem 'net-ssh', ">= 2.0.10"
-rescue LoadError, NameError
-end
-
 require 'net/ssh'
 
 module Capistrano


### PR DESCRIPTION
Since the dependencies are already specified in the .gemspec, there is
no need for this.
