### PR TITLE
changed single to double quotes for Windows

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/mercurial.rb
+++ b/lib/capistrano/recipes/deploy/scm/mercurial.rb
@@ -59,7 +59,7 @@ module Capistrano
           cmd = scm :log,
                     verbose,
                     "-r #{changeset}",
-                    "--template '{node|short}'"
+                    '--template "{node|short}"'
                     yield cmd
         end
 

--- a/test/deploy/scm/mercurial_test.rb
+++ b/test/deploy/scm/mercurial_test.rb
@@ -39,7 +39,7 @@ class DeploySCMMercurialTest < Test::Unit::TestCase
   end
 
   def test_query_revision
-    assert_equal "hg log -r 8a8e00b8f11b --template '{node|short}'", @source.query_revision('8a8e00b8f11b') { |o| o }
+    assert_equal "hg log -r 8a8e00b8f11b --template \"{node|short}\"", @source.query_revision('8a8e00b8f11b') { |o| o }
   end
 
   def test_username_should_be_backwards_compatible


### PR DESCRIPTION
When getting the current revision from Mercurial on Windows the
following command:

  "hg log -r tip --template '{node|short}'"

fails due to the single quotes not being escaped. To make this
command run properly on Windows, I modified it to the following:

  "hg log -r tip --template \"{node|short}\""

This change seems to be safe on Windows 7, Mac OS X 10.7.2, and
Ubuntu 11.10.
