### PR TITLE
Add UnsharedRemoteCache (copied from eycap gem)

### DIFF
--- a/lib/capistrano/recipes/deploy/strategy/unshared_remote_cache.rb
+++ b/lib/capistrano/recipes/deploy/strategy/unshared_remote_cache.rb
@@ -1,0 +1,21 @@
+require 'capistrano/recipes/deploy/strategy/remote_cache'
+
+module Capistrano
+  module Deploy
+    module Strategy
+      class UnsharedRemoteCache < RemoteCache
+        def check!
+          super.check do |d|
+            d.remote.writable(repository_cache)
+          end
+        end
+
+        private
+
+        def repository_cache
+          configuration[:repository_cache]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
It's identical to `RemoteCache`, except the `:repository_cache` config variable is the _full_ cache path, rather than just the fragment appended to `shared_path`.
