### PR TITLE
allow configuration of which roles assets are precompiled on

### DIFF
--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -2,6 +2,7 @@ load 'deploy' unless defined?(_cset)
 
 _cset :asset_env, "RAILS_GROUPS=assets"
 _cset :assets_prefix, "assets"
+_cset :assets_role, [:web]
 
 _cset :normalize_asset_timestamps, false
 
@@ -18,7 +19,7 @@ namespace :deploy do
       for efficiency. If you cutomize the assets path prefix, override the \
       :assets_prefix variable to match.
     DESC
-    task :symlink, :roles => :web, :except => { :no_release => true } do
+    task :symlink, :roles => assets_role, :except => { :no_release => true } do
       run <<-CMD
         rm -rf #{latest_release}/public/#{assets_prefix} &&
         mkdir -p #{latest_release}/public &&
@@ -37,7 +38,7 @@ namespace :deploy do
         set :rails_env, "production"
         set :asset_env, "RAILS_GROUPS=assets"
     DESC
-    task :precompile, :roles => :web, :except => { :no_release => true } do
+    task :precompile, :roles => assets_role, :except => { :no_release => true } do
       run "cd #{latest_release} && #{rake} RAILS_ENV=#{rails_env} #{asset_env} assets:precompile"
     end
 
@@ -52,7 +53,7 @@ namespace :deploy do
         set :rails_env, "production"
         set :asset_env, "RAILS_GROUPS=assets"
     DESC
-    task :clean, :roles => :web, :except => { :no_release => true } do
+    task :clean, :roles => assets_role, :except => { :no_release => true } do
       run "cd #{latest_release} && #{rake} RAILS_ENV=#{rails_env} #{asset_env} assets:clean"
     end
   end


### PR DESCRIPTION
At the moment it is hardcoded that asset recompilation happens on the web role. This doesn't quite work for us: we have machines that only run delayed job that send emails to our customers. These emails frequently references images from the app's assets and so assets needs to be precompiled on these hosts.

The patch allows one to set which roles asset recompilation should happen on. The default is :web, so this shouldn't change behaviour for existing users
