### PR TITLE
Ticket 193 alias task show wrong name when it is not override

### DIFF
--- a/lib/capistrano/configuration/alias_task.rb
+++ b/lib/capistrano/configuration/alias_task.rb
@@ -15,7 +15,8 @@ module Capistrano
           raise ArgumentError, "expected a valid task name"
         end
 
-        task = find_task(old_name) or raise NoSuchTaskError, "the task `#{old_name}' does not exist"
+        original_task = find_task(old_name) or raise NoSuchTaskError, "the task `#{old_name}' does not exist"
+        task = original_task.dup # Dup. task to avoid modify original task
         task.name = new_name
 
         define_task(task)

--- a/test/configuration/alias_task_test.rb
+++ b/test/configuration/alias_task_test.rb
@@ -30,6 +30,14 @@ class AliasTaskTest < Test::Unit::TestCase
     assert @config.tasks.key?(:new_foo)
   end
 
+  def test_original_task_remain_with_same_name
+    @config.task(:foo) { 42 }
+    @config.alias_task 'new_foo', 'foo'
+
+    assert_equal :foo, @config.tasks[:foo].name
+    assert_equal :new_foo, @config.tasks[:new_foo].name
+  end
+
   def test_aliased_task_do_the_same
     @config.task(:foo) { 42 }
     @config.alias_task 'new_foo', 'foo'


### PR DESCRIPTION
_alias_task_ works as expected, technically, but tasks list(cap -T) shows wrong
task name if you don't override the original task. I found it writing documentation :)

This commit fix it.
