### PR TITLE
Fix typo in loading default taks in Capfile template

### DIFF
--- a/bin/capify
+++ b/bin/capify
@@ -38,7 +38,7 @@ end
 files = {
   "Capfile" => unindent(<<-FILE),
 
-    require 'deploy'
+    load 'deploy'
 
     # Uncomment if you are using Rails' asset pipeline
     # load 'deploy/assets'


### PR DESCRIPTION
It's broken now
