### PR TITLE
Teach deploy:web:enable to fail gracefully

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -546,7 +546,7 @@ namespace :deploy do
     DESC
     task :disable, :roles => :web, :except => { :no_release => true } do
       require 'erb'
-      on_rollback { run "rm #{shared_path}/system/#{maintenance_basename}.html" }
+      on_rollback { run "rm -f #{shared_path}/system/#{maintenance_basename}.html" }
 
       warn <<-EOHTACCESS
 
@@ -588,7 +588,7 @@ namespace :deploy do
       web-accessible again.
     DESC
     task :enable, :roles => :web, :except => { :no_release => true } do
-      run "rm #{shared_path}/system/#{maintenance_basename}.html"
+      run "rm -f #{shared_path}/system/#{maintenance_basename}.html"
     end
   end
 end


### PR DESCRIPTION
Don't fail if the maintenance files does not exist. This could happen if
multiple web servers share their #{shared_path}/system folder, the rm
would succeed on the first web box and fail on others in this case.
