### PR TITLE
Fix transfer action to honor dry-run flag

### DIFF
--- a/lib/capistrano/configuration/actions/file_transfer.rb
+++ b/lib/capistrano/configuration/actions/file_transfer.rb
@@ -12,7 +12,7 @@ module Capistrano
           opts = options.dup
           upload(StringIO.new(data), path, opts)
         end
-    
+
         # Get file remote_path from FIRST server targeted by
         # the current task and transfer it to local machine as path.
         #
@@ -35,13 +35,12 @@ module Capistrano
         end
 
         def transfer(direction, from, to, options={}, &block)
+          if dry_run
+            return logger.debug "transfering: #{[direction, from, to] * ', '}"
+          end
           execute_on_servers(options) do |servers|
             targets = servers.map { |s| sessions[s] }
-            if dry_run
-              logger.debug "transfering: #{[direction, from, to, targets, options.merge(:logger => logger).inspect ] * ', '}"
-            else
               Transfer.process(direction, from, to, targets, options.merge(:logger => logger), &block)
-            end
           end
         end
 

--- a/test/configuration/actions/invocation_test.rb
+++ b/test/configuration/actions/invocation_test.rb
@@ -59,7 +59,7 @@ class ConfigurationActionsInvocationTest < Test::Unit::TestCase
     config = make_config
     config.dry_run = true
     config.servers = %w[ foo ]
-    config.expects(:sessions).returns({ 'foo-server' => 'bar' })
+    config.expects(:execute_on_servers).never
     ::Capistrano::Transfer.expects(:process).never
     config.put "foo", "bar", :mode => 0644
   end
@@ -203,7 +203,7 @@ class ConfigurationActionsInvocationTest < Test::Unit::TestCase
     a = mock("channel", :called => true)
     b = mock("stream", :called => true)
     c = mock("data", :called => true)
-  
+
     callback[a, b, c]
   end
 


### PR DESCRIPTION
Currently the transfer action (get,put,download) with enabled dry-run flag
is connecting to the remote servers and behave differently than run action.
This commit fixes this behavior and makes it predictable and correct,
it also updates the test for this case. All other tests passed OK.

It was partly done in #29 by @flori

Related info and issues are #151 #152
