### PR TITLE
Verbose command execution log should be optional. Set :verbose_command_log to true when you need it. Refs #178.

### DIFF
--- a/lib/capistrano/command.rb
+++ b/lib/capistrano/command.rb
@@ -219,7 +219,7 @@ module Capistrano
                   command_line = [environment, shell, cmd].compact.join(" ")
                   ch[:command] = command_line
 
-                  logger.trace command_line, ch[:server] if logger
+                  logger.trace command_line, ch[:server] if logger && options[:verbose_command_log]
 
                   ch.exec(command_line)
                   ch.send_data(options[:data]) if options[:data]

--- a/lib/capistrano/configuration/actions/invocation.rb
+++ b/lib/capistrano/configuration/actions/invocation.rb
@@ -175,7 +175,11 @@ module Capistrano
 
           execute_on_servers(options) do |servers|
             targets = servers.map { |s| sessions[s] }
-            Command.process(tree, targets, options.merge(:logger => logger))
+            Command.process(tree, targets, options.merge(
+                :logger => logger,
+                :verbose_command_log => fetch(:verbose_command_log, false)
+              )
+            )
           end
         end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -16,7 +16,7 @@ class ConfigurationTest < Test::Unit::TestCase
     process_args = Proc.new do |tree, session, opts|
       tree.fallback.command == "echo 'hello world'" &&
       session == [:session] &&
-      opts == { :logger => @config.logger }
+      opts == { :logger => @config.logger, :verbose_command_log => false }
     end
 
     Capistrano::Command.expects(:process).with(&process_args)


### PR DESCRIPTION
Per our conversation at https://github.com/capistrano/capistrano/issues/178
