### PR TITLE
updating mapped commands to remove symlink deprecation warning 

### DIFF
--- a/lib/capistrano/configuration/callbacks.rb
+++ b/lib/capistrano/configuration/callbacks.rb
@@ -90,7 +90,7 @@ module Capistrano
       # Usage:
       #
       #  on :before, "some:hook", "another:hook", :only => "deploy:update"
-      #  on :after, "some:hook", :except => "deploy:symlink"
+      #  on :after, "some:hook", :except => "deploy:create_symlink"
       #  on :before, "global:hook"
       #  on :after, :only => :deploy do
       #    puts "after deploy here"

--- a/lib/capistrano/recipes/compat.rb
+++ b/lib/capistrano/recipes/compat.rb
@@ -7,7 +7,7 @@ load 'deploy'
 map = { "diff_from_last_deploy"  => "deploy:pending:diff",
         "update"                 => "deploy:update",
         "update_code"            => "deploy:update_code",
-        "symlink"                => "deploy:symlink",
+        "symlink"                => "deploy:create_symlink",
         "restart"                => "deploy:restart",
         "rollback"               => "deploy:rollback",
         "cleanup"                => "deploy:cleanup",


### PR DESCRIPTION
" \* executing `deploy:create_symlink'
- executing `deploy:symlink'
  [Deprecation Warning] This API has changed, please hook`deploy:create_symlink`instead of`deploy:symlink`."
