### PR TITLE
Patch for issue 193 on capistrano/capistrano

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -245,7 +245,11 @@ namespace :deploy do
     # mkdir -p is making sure that the directories are there for some SCM's that don't
     # save empty folders
     shared_children.map do |d|
-      run "rm -rf #{latest_release}/#{d} && mkdir -p #{latest_release}/#{d.split('/').first}"
+  		if (d.rindex('/')) then
+  		  run "rm -rf #{latest_release}/#{d} && mkdir -p #{latest_release}/#{d.slice(0..(d.rindex('/')))}"
+      else
+        run "rm -rf #{latest_release}/#{d}"
+  		end
       run "ln -s #{shared_path}/#{d.split('/').last} #{latest_release}/#{d}"
     end
 


### PR DESCRIPTION
Simplify the finalize_update code by respecting the :shared_children
variable during removal and recreation of the parent.
