### PR TITLE
Add deprecation warning if someone uses old deploy:symlink syntax on callbacks

### DIFF
--- a/lib/capistrano/configuration/callbacks.rb
+++ b/lib/capistrano/configuration/callbacks.rb
@@ -107,6 +107,18 @@ module Capistrano
           callbacks[event] << ProcCallback.new(block, options)
         else
           args.each do |name|
+            [:only, :except].each do |key|
+              if options[key] == 'deploy:symlink'
+                warn "[Deprecation Warning] This API has changed, please hook `deploy:create_symlink` instead of `deploy:symlink`."
+                options[key] = 'deploy:create_symlink'
+              elsif options[key].is_a?(Array) && options[key].include?('deploy:symlink')
+                warn "[Deprecation Warning] This API has changed, please hook `deploy:create_symlink` instead of `deploy:symlink`."
+                options[key] = options[key].collect do |task|
+                  task == 'deploy:symlink' ? 'deploy:create_symlink' : task
+                end
+              end
+            end
+            
             callbacks[event] << TaskCallback.new(self, name, options)
           end
         end

--- a/test/configuration/callbacks_test.rb
+++ b/test/configuration/callbacks_test.rb
@@ -39,9 +39,29 @@ class ConfigurationCallbacksTest < Test::Unit::TestCase
     @config.before :bar, :foo, "bing:blang", :zip => :zing
   end
 
+  def test_before_should_map_before_deploy_symlink
+    @config.before "deploy:symlink", "bing:blang"
+    assert_equal ["deploy:create_symlink"], @config.callbacks[:before].last.only
+  end
+
+  def test_before_should_map_before_deploy_symlink_array
+    @config.before ["deploy:symlink", "bingo:blast"], "bing:blang"
+    assert_equal ["deploy:create_symlink", "bingo:blast"], @config.callbacks[:before].last.only
+  end
+
   def test_after_should_delegate_to_on
     @config.expects(:on).with(:after, :foo, "bing:blang", {:only => :bar, :zip => :zing})
     @config.after :bar, :foo, "bing:blang", :zip => :zing
+  end
+
+  def test_after_should_map_before_deploy_symlink
+    @config.after "deploy:symlink", "bing:blang"
+    assert_equal ["deploy:create_symlink"], @config.callbacks[:after].last.only
+  end
+
+  def test_after_should_map_before_deploy_symlink_array
+    @config.after ["deploy:symlink", 'bingo:blast'], "bing:blang"
+    assert_equal ["deploy:create_symlink", 'bingo:blast'], @config.callbacks[:after].last.only
   end
 
   def test_on_with_single_reference_should_add_task_callback


### PR DESCRIPTION
This adds a deprecation warning when the following commands are called:

```
before "deploy:symlink", "pizza:friendship"
after "deploy:symlink", "omg:kittens"
```

```
[Deprecation Warning] This API has changed, please hook `deploy:create_symlink` instead of `deploy:symlink`.
```

and the code effectively treats it as rewritten to the following

```
before "deploy:create_symlink", "pizza:friendship"
after "deploy:create_symlink", "omg:kittens"
```

Let me know if you see any problems, or want me to make any changes.
