### PR TITLE
Specify mocha version.  

### DIFF
--- a/capistrano.gemspec
+++ b/capistrano.gemspec
@@ -28,14 +28,14 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<net-sftp>, [">= 2.0.0"])
       s.add_runtime_dependency(%q<net-scp>, [">= 1.0.0"])
       s.add_runtime_dependency(%q<net-ssh-gateway>, [">= 1.1.0"])
-      s.add_development_dependency(%q<mocha>, [">= 0"])
+      s.add_development_dependency(%q<mocha>, ["0.9.12"])
     else
       s.add_dependency(%q<net-ssh>, [">= 2.0.14"])
       s.add_dependency(%q<net-sftp>, [">= 2.0.0"])
       s.add_dependency(%q<net-scp>, [">= 1.0.0"])
       s.add_dependency(%q<net-ssh-gateway>, [">= 1.1.0"])
       s.add_dependency(%q<highline>, [">= 0"])
-      s.add_dependency(%q<mocha>, [">= 0"])
+      s.add_dependency(%q<mocha>, ["0.9.12"])
     end
   else
     s.add_dependency(%q<net-ssh>, [">= 2.0.14"])
@@ -43,6 +43,6 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<net-scp>, [">= 1.0.0"])
     s.add_dependency(%q<net-ssh-gateway>, [">= 1.1.0"])
     s.add_dependency(%q<highline>, [">= 0"])
-    s.add_dependency(%q<mocha>, [">= 0"])
+    s.add_dependency(%q<mocha>, ["0.9.12"])
   end
 end


### PR DESCRIPTION
This is a pretty crazy bug.

14 hours ago mocha released version 0.11 (before it was 10.5).

In this version mocked objects with function named `process` that are passed blocks, will not get the block passed.  Instead it will seem as if it was nil.  If the function is named anything besides `process` the block goes through fine.  This only happens in ruby 1.8.7 (1.9.3 works fine).

Since the gemspec didn't specify the version, it was pulling in the latest version.

Since 0.11.0 of mocha seems to have bugs, I locked the version of mocha to the last stable version 10.5 in the gemspec.
