### PR TITLE
Adding a log method to Capistrano::Deploy::SCM::None

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/none.rb
+++ b/lib/capistrano/recipes/deploy/scm/none.rb
@@ -37,6 +37,13 @@ module Capistrano
         def query_revision(revision)
           revision
         end
+        
+        # log: There's no log, so it just echos from and to.
+        
+        def log(from="", to="")
+          "No SCM: #{from} - #{to}"
+        end
+        
       end
 
     end


### PR DESCRIPTION
We do a lot of test deploys using :scm: none, which causes problems with NewRelic because there's no log method.  This method just echoes what's passed in with the "from" and "to" arguments so there's some feedback when NewRelic reports the deploy and to maintain some consistency with the other SCM classes.
