### PR TITLE
Commands will be printed only if they are executing on servers

### DIFF
--- a/lib/capistrano/configuration/actions/invocation.rb
+++ b/lib/capistrano/configuration/actions/invocation.rb
@@ -1,4 +1,5 @@
 require 'capistrano/command'
+require 'capistrano/ext/delayed_logger'
 
 module Capistrano
   class Configuration
@@ -59,7 +60,7 @@ module Capistrano
         #
         # The string specified as the first argument to +when+ may be any valid
         # Ruby code. It has access to the following variables and methods:
-        # 
+        #
         # * +in?(role)+ returns true if the server participates in the given role
         # * +server+ is the ServerDefinition object for the server. This can be
         #   used to get the host-name, etc.
@@ -121,7 +122,7 @@ module Capistrano
         #   to run, then the hosts will be run in groups of max_hosts. The default is nil,
         #   which indicates that there is no maximum host limit. Please note this does not
         #   limit the number of SSH channels that can be open, only the number of hosts upon
-        #   which this will be called. 
+        #   which this will be called.
         # * :shell - says which shell should be used to invoke commands. This
         #   defaults to "sh". Setting this to false causes Capistrano to invoke
         #   the commands directly, without wrapping them in a shell invocation.
@@ -152,18 +153,22 @@ module Capistrano
         # use, but should instead be called indirectly, via #run or #parallel,
         # or #invoke_command.
         def run_tree(tree, options={}) #:nodoc:
+          delayed_logger = Capistrano::DelayedLogger.new(logger)
           if tree.branches.empty? && tree.fallback
-            logger.debug "executing #{tree.fallback}"
+            delayed_logger.debug "executing #{tree.fallback}"
           elsif tree.branches.any?
-            logger.debug "executing multiple commands in parallel"
+            delayed_logger.debug "executing multiple commands in parallel"
             tree.each do |branch|
-              logger.trace "-> #{branch}"
+              delayed_logger.trace "-> #{branch}"
             end
           else
             raise ArgumentError, "attempt to execute without specifying a command"
           end
 
-          return if dry_run || (debug && continue_execution(tree) == false)
+          if dry_run || (debug && continue_execution(tree) == false)
+            delayed_logger.flush!
+            return
+          end
 
           options = add_default_command_options(options)
 
@@ -174,6 +179,7 @@ module Capistrano
           end
 
           execute_on_servers(options) do |servers|
+            delayed_logger.flush!
             targets = servers.map { |s| sessions[s] }
             Command.process(tree, targets, options.merge(:logger => logger))
           end
@@ -272,7 +278,7 @@ module Capistrano
         def sudo_prompt
           fetch(:sudo_prompt, "sudo password: ")
         end
-        
+
         def continue_execution(tree)
           if tree.branches.length == 1
             continue_execution_for_branch(tree.branches.first)

--- a/lib/capistrano/ext/delayed_logger.rb
+++ b/lib/capistrano/ext/delayed_logger.rb
@@ -1,0 +1,19 @@
+module Capistrano
+  class DelayedLogger
+    def initialize(logger)
+      @logger = logger
+      @buffer = []
+    end
+
+    def flush!
+      @buffer.each do |name, args, block|
+        @logger.send(name, *args, block)
+      end
+      @buffer = []
+    end
+
+    def method_missing(name, *args, &block)
+      @buffer << [name, args, block]
+    end
+  end
+end


### PR DESCRIPTION
Capistrano prints all teams even if they really won't be executed, example:

```
  == Currently executing `deploy:assets:symlink'
  executing "rm -rf /u/apps/appname/releases/20120528203209/public/assets &&\\\n        mkdir -p /u/apps/appname/releases/20120528203209/public &&\\\n        mkdir -p /u/apps/appname/shared/assets &&\\\n        ln -s /u/apps/appname/shared/assets /u/apps/appname/releases/20120528203209/public/assets"
  skipping `deploy:assets:symlink' because no servers matched
```

after patch:

```
  == Currently executing `deploy:assets:symlink'
  skipping `deploy:assets:symlink' because no servers matched
```
