### PR TITLE
Add :on_no_matching_servers => :continue to assets tasks

### DIFF
--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -19,7 +19,7 @@ namespace :deploy do
       for efficiency. If you cutomize the assets path prefix, override the \
       :assets_prefix variable to match.
     DESC
-    task :symlink, :roles => assets_role, :except => { :no_release => true } do
+    task :symlink, :roles => assets_role, :on_no_matching_servers => :continue, :except => { :no_release => true } do
       run <<-CMD
         rm -rf #{latest_release}/public/#{assets_prefix} &&
         mkdir -p #{latest_release}/public &&
@@ -38,7 +38,7 @@ namespace :deploy do
         set :rails_env, "production"
         set :asset_env, "RAILS_GROUPS=assets"
     DESC
-    task :precompile, :roles => assets_role, :except => { :no_release => true } do
+    task :precompile, :roles => assets_role, :on_no_matching_servers => :continue, :except => { :no_release => true } do
       run "cd #{latest_release} && #{rake} RAILS_ENV=#{rails_env} #{asset_env} assets:precompile"
     end
 
@@ -53,7 +53,7 @@ namespace :deploy do
         set :rails_env, "production"
         set :asset_env, "RAILS_GROUPS=assets"
     DESC
-    task :clean, :roles => assets_role, :except => { :no_release => true } do
+    task :clean, :roles => assets_role, :on_no_matching_servers => :continue, :except => { :no_release => true } do
       run "cd #{latest_release} && #{rake} RAILS_ENV=#{rails_env} #{asset_env} assets:clean"
     end
   end


### PR DESCRIPTION
I use one capistrano instance to deploy all my applications, when I deploy non rails application, who has only background workers, I see error:

```
  `deploy:assets:symlink' is only run for servers matching ...
```

This patch fixes it.
