### PR TITLE
cap shell dies when Thread.abort_on_exception=true

### DIFF
--- a/test/shell_test.rb
+++ b/test/shell_test.rb
@@ -79,9 +79,6 @@ class ShellTest < Test::Unit::TestCase
     end
   end
   
-  def test_can_access_its_sessions
-    assert_nothing_raised(Exception) { @shell.process_iteration }
-  end
   
   private
   


### PR DESCRIPTION
Try this deploy.rb to reproduce: https://gist.github.com/2837590

Patch fixes it by moving the sessions method where processable expects it
