### PR TITLE
Set default to :git from :subversion

### DIFF
--- a/bin/capify
+++ b/bin/capify
@@ -51,7 +51,7 @@ files = {
   "config/deploy.rb" => 'set :application, "set your application name here"
 set :repository,  "set your repository location here"
 
-set :scm, :subversion
+set :scm, :git
 # Or: `accurev`, `bzr`, `cvs`, `darcs`, `git`, `mercurial`, `perforce`, `subversion` or `none`
 
 role :web, "your web-server here"                          # Your HTTP server, Apache/etc

--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -22,7 +22,7 @@ _cset(:repository)  { abort "Please specify the repository that houses your appl
 # are not sufficient.
 # =========================================================================
 
-_cset :scm, :subversion
+_cset :scm, :git
 _cset :deploy_via, :checkout
 
 _cset(:deploy_to) { "/u/apps/#{application}" }
@@ -213,7 +213,7 @@ namespace :deploy do
     task (if you want to perform the `restart' task separately).
 
     You will need to make sure you set the :scm variable to the source \
-    control software you are using (it defaults to :subversion), and the \
+    control software you are using (it defaults to :git), and the \
     :deploy_via variable to the strategy you want to use to deploy (it \
     defaults to :checkout).
   DESC


### PR DESCRIPTION
Changes default SCM from Subversion to git. This also seems to jive with the documentation on the wiki with respect to [configuration variables](https://github.com/capistrano/capistrano/wiki/2.x-Significant-Configuration-Variables).
