### PR TITLE
Use proper logger in deploy strategy 

### DIFF
--- a/lib/capistrano/recipes/deploy/strategy/base.rb
+++ b/lib/capistrano/recipes/deploy/strategy/base.rb
@@ -73,7 +73,7 @@ module Capistrano
         private
 
           def logger
-            @logger ||= configuration[:logger] || Capistrano::Logger.new(:output => STDOUT)
+            @logger ||= configuration.logger || Capistrano::Logger.new(:output => STDOUT)
           end
 
           # The revision to deploy. Must return a real revision identifier,

--- a/test/deploy/strategy/copy_test.rb
+++ b/test/deploy/strategy/copy_test.rb
@@ -6,10 +6,11 @@ require 'stringio'
 class DeployStrategyCopyTest < Test::Unit::TestCase
   def setup
     @config = { :application => "captest",
-                :logger => Capistrano::Logger.new(:output => StringIO.new),
                 :releases_path => "/u/apps/test/releases",
                 :release_path => "/u/apps/test/releases/1234567890",
                 :real_revision => "154" }
+    @config.stubs(:logger).returns(stub_everything)
+
     @source = mock("source")
     @config.stubs(:source).returns(@source)
     @strategy = Capistrano::Deploy::Strategy::Copy.new(@config)


### PR DESCRIPTION
There is no :logger configuration variable, logger is accessed via instance variable.
Because of that all deploy strategies creates new logger to STDOUT.
