### PR TITLE
Fix capture by listening for method definition on Kernel and undefine on Namespace

### DIFF
--- a/lib/capistrano/configuration/namespaces.rb
+++ b/lib/capistrano/configuration/namespaces.rb
@@ -214,3 +214,23 @@ module Capistrano
     end
   end
 end
+
+module Kernel
+  class << self
+    alias_method :method_added_without_capistrano, :method_added
+
+    # Detect method additions to Kernel and remove them in the Namespace class
+    def method_added(name)
+      result = method_added_without_capistrano(name)
+      return result if self != Kernel
+
+      namespace = Capistrano::Configuration::Namespaces::Namespace
+
+      if namespace.method_defined?(name) && namespace.method(name).owner == Kernel
+        namespace.send :undef_method, name
+      end
+
+      result
+    end
+  end
+end

--- a/test/configuration/namespace_dsl_test.rb
+++ b/test/configuration/namespace_dsl_test.rb
@@ -322,8 +322,6 @@ class ConfigurationNamespacesDSLTest < Test::Unit::TestCase
       def some_weird_method() 'kernel' end
     end
     
-    @config.namespace(:clash2) {}
-    namespace = @config.namespaces[:clash2]
     assert_equal 'config', namespace.some_weird_method
     
     Kernel.send :remove_method, :some_weird_method


### PR DESCRIPTION
Fixes capture method issues when ActiveSupport Kernel extensions are loaded after a namespace is defined (code added before fixes when AS is loaded before the namespace is defined). Given the new use of capture in the deploy:clean task, AS would have to be loaded before the deploy recipe to work with the existing code.

It's ugly but it seems to work to fix capture even if loaded after a namespace is defined. It's based on similar strategies for recreating BasicObject in Ruby 1.8.

Fixes #175 #168 #170 #239 #169
