### PR TITLE
Don't default to closing the input stream when sudo is being used.

### DIFF
--- a/lib/capistrano/configuration/actions/invocation.rb
+++ b/lib/capistrano/configuration/actions/invocation.rb
@@ -147,7 +147,9 @@ module Capistrano
         # variable, they will apply for all invocations of #run, #invoke_command,
         # and #parallel.
         def run(cmd, options={}, &block)
-          options = options.merge(:eof => !block_given?) if options[:eof].nil?
+          if options[:eof].nil? && !cmd.include?(sudo)
+            options = options.merge(:eof => !block_given?)
+          end
           block ||= self.class.default_io_proc
           tree = Command::Tree.new(self) { |t| t.else(cmd, &block) }
           run_tree(tree, options)

--- a/test/configuration/actions/invocation_test.rb
+++ b/test/configuration/actions/invocation_test.rb
@@ -115,6 +115,11 @@ class ConfigurationActionsInvocationTest < Test::Unit::TestCase
     @config.sudo "ls"
   end
 
+  def test_sudo_should_keep_input_stream_open
+    @config.expects(:execute_on_servers).with(:foo => "bar")
+    @config.sudo "ls", :foo => "bar"
+  end
+
   def test_sudo_should_use_sudo_variable_definition
     @config.expects(:run).with("/opt/local/bin/sudo -p 'sudo password: ' ls", {})
     @config.options[:sudo] = "/opt/local/bin/sudo"


### PR DESCRIPTION
Fixes #253

Makes the same check as in `Capistrano::Configuration::Actions::Invocation#run_tree` to see if sudo is being used, so the input stream will not be closed by default if the `sudo_behaviour_callback` is being used.
