### PR TITLE
Added `the precompile_only_if_changed` option (Rails 3.1+)

### DIFF
--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -5,6 +5,7 @@ _cset :assets_prefix, "assets"
 _cset :assets_role, [:web]
 
 _cset :normalize_asset_timestamps, false
+_cset :precompile_only_if_changed, false
 
 before 'deploy:finalize_update', 'deploy:assets:symlink'
 after 'deploy:update_code', 'deploy:assets:precompile'
@@ -32,14 +33,27 @@ namespace :deploy do
       Run the asset precompilation rake task. You can specify the full path \
       to the rake executable by setting the rake variable. You can also \
       specify additional environment variables to pass to rake via the \
-      asset_env variable. The defaults are:
+      asset_env variable. If you set the precompile_only_if_changed option \
+      as true it will precompile assets only if there are any changes since \
+      the last release. The defaults are:
 
         set :rake,      "rake"
         set :rails_env, "production"
         set :asset_env, "RAILS_GROUPS=assets"
+        set :precompile_only_if_changed, false
     DESC
     task :precompile, :roles => assets_role, :except => { :no_release => true } do
-      run "cd #{latest_release} && #{rake} RAILS_ENV=#{rails_env} #{asset_env} assets:precompile"
+      precompile_command = "cd #{latest_release} && #{rake} RAILS_ENV=#{rails_env} #{asset_env} assets:precompile"
+
+      if precompile_only_if_changed
+        if capture("cd #{latest_release} && #{source.local.log(previous_revision)} lib/assets vendor/assets/ app/assets/ config/ | wc -l").to_i
+          run precompile_command
+        else
+          logger.info "Skipping assets precompilation because there were no asset changes"
+        end
+      else
+        run precompile_command
+      end
     end
 
     desc <<-DESC


### PR DESCRIPTION
If you set the `precompile_only_if_changed` option as true it will precompile Rails assets only if there are any changes since the last release. This option is disabled by default.
