### PR TITLE
Stage environment

### DIFF
--- a/lib/capistrano/ext/multistage.rb
+++ b/lib/capistrano/ext/multistage.rb
@@ -15,6 +15,7 @@ Capistrano::Configuration.instance.load do
     desc "Set the target stage to `#{name}'."
     task(name) do
       set :stage, name.to_sym
+      set :rails_env, name
       load "#{location}/#{stage}"
     end
   end


### PR DESCRIPTION
Using convention over configuration, it seems that the rails environment should default to the name of the stage... I cant imagine a situation where two different stages would want to use the same rails environment.
