### PR TITLE
Avoid closing the input stream on capture with sudo in the command.

### DIFF
--- a/lib/capistrano/configuration/actions/inspect.rb
+++ b/lib/capistrano/configuration/actions/inspect.rb
@@ -20,7 +20,7 @@ module Capistrano
         #     stream "tail -f #{shared_path}/log/fastcgi.crash.log"
         #   end
         def stream(command, options={})
-          invoke_command(command, options.merge(:eof => true)) do |ch, stream, out|
+          invoke_command(command, options.merge(:eof => !command.include?(sudo))) do |ch, stream, out|
             puts out if stream == :out
             warn "[err :: #{ch[:server]}] #{out}" if stream == :err
           end
@@ -31,7 +31,7 @@ module Capistrano
         # string. The command is invoked via #invoke_command.
         def capture(command, options={})
           output = ""
-          invoke_command(command, options.merge(:once => true, :eof => true)) do |ch, stream, data|
+          invoke_command(command, options.merge(:once => true, :eof => !command.include?(sudo))) do |ch, stream, data|
             case stream
             when :out then output << data
             when :err then warn "[err :: #{ch[:server]}] #{data}"

--- a/test/configuration/actions/inspect_test.rb
+++ b/test/configuration/actions/inspect_test.rb
@@ -9,11 +9,17 @@ class ConfigurationActionsInspectTest < Test::Unit::TestCase
   def setup
     @config = MockConfig.new
     @config.stubs(:logger).returns(stub_everything)
+    @config.stubs(:sudo).returns('sudo')
   end
 
   def test_stream_should_pass_options_through_to_run
     @config.expects(:invoke_command).with("tail -f foo.log", :once => true, :eof => true)
     @config.stream("tail -f foo.log", :once => true)
+  end
+
+  def test_stream_with_sudo_should_avoid_closing_stdin
+    @config.expects(:invoke_command).with("sudo tail -f foo.log", :once => true, :eof => false)
+    @config.stream("sudo tail -f foo.log", :once => true)
   end
 
   def test_stream_should_emit_stdout_via_puts
@@ -35,6 +41,11 @@ class ConfigurationActionsInspectTest < Test::Unit::TestCase
   def test_capture_should_pass_options_merged_with_once_to_run
     @config.expects(:invoke_command).with("hostname", :foo => "bar", :once => true, :eof => true)
     @config.capture("hostname", :foo => "bar")
+  end
+
+  def test_capture_with_sudo_should_avoid_closing_stdin
+    @config.expects(:invoke_command).with("sudo hostname", :foo => "bar", :once => true, :eof => false)
+    @config.capture("sudo hostname", :foo => "bar")
   end
 
   def test_capture_with_stderr_should_emit_stderr_via_warn


### PR DESCRIPTION
This was another corner case from closing the input stream that was brought up in issue #253.

This should have been done along with pull request #254.
