### PR TITLE
Add comptability for the ZSH shell on remote host

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/git.rb
+++ b/lib/capistrano/recipes/deploy/scm/git.rb
@@ -195,7 +195,7 @@ module Capistrano
             if false == variable(:git_submodules_recursive)
               execute << "#{git} submodule #{verbose} update --init"
             else
-              execute << %Q(export GIT_RECURSIVE=$([ ! "`#{git} --version`" \\< "git version 1.6.5" ] && echo --recursive))
+              execute << %Q(export GIT_RECURSIVE=$([[ ! "`#{git} --version`" < "git version 1.6.5" ]] && echo --recursive))
               execute << "#{git} submodule #{verbose} update --init $GIT_RECURSIVE"
             end
           end

--- a/test/deploy/scm/git_test.rb
+++ b/test/deploy/scm/git_test.rb
@@ -127,7 +127,7 @@ class DeploySCMGitTest < Test::Unit::TestCase
 
     # with submodules
     @config[:git_enable_submodules] = true
-    assert_equal "cd #{dest} && #{git} fetch -q origin && #{git} fetch --tags -q origin && #{git} reset -q --hard #{rev} && #{git} submodule -q init && for mod in `#{git} submodule status | awk '{ print $2 }'`; do #{git} config -f .git/config submodule.${mod}.url `#{git} config -f .gitmodules --get submodule.${mod}.url` && echo Synced $mod; done && #{git} submodule -q sync && export GIT_RECURSIVE=$([ ! \"`#{git} --version`\" \\< \"git version 1.6.5\" ] && echo --recursive) && #{git} submodule -q update --init $GIT_RECURSIVE && #{git} clean -q -d -x -f", @source.sync(rev, dest)
+    assert_equal "cd #{dest} && #{git} fetch -q origin && #{git} fetch --tags -q origin && #{git} reset -q --hard #{rev} && #{git} submodule -q init && for mod in `#{git} submodule status | awk '{ print $2 }'`; do #{git} config -f .git/config submodule.${mod}.url `#{git} config -f .gitmodules --get submodule.${mod}.url` && echo Synced $mod; done && #{git} submodule -q sync && export GIT_RECURSIVE=$([[ ! \"`#{git} --version`\" < \"git version 1.6.5\" ]] && echo --recursive) && #{git} submodule -q update --init $GIT_RECURSIVE && #{git} clean -q -d -x -f", @source.sync(rev, dest)
   end
 
   def test_sync_with_remote


### PR DESCRIPTION
Changes the use of a single square bracket shell conditional to a double
square bracket shell conditional, which still is still compatible with
bash and also works in other shells such as zsh.

While I'm not sure how to test this within the scope of this project. The
following are examples of how this is not currently working and how this
fixes the issue.

``` sh
# This works
bash -c 'export GIT_RECURSIVE=$([ ! "git version 1.8" \< "git version 1.6.5" ] && echo --recursive); echo $GIT_RECURSIVE'

# This is broken
zsh  -c 'export GIT_RECURSIVE=$([ ! "git version 1.8" \< "git version 1.6.5" ] && echo --recursive); echo $GIT_RECURSIVE'

# Both these work as expected
bash -c 'export GIT_RECURSIVE=$([[ ! "git version 1.8" < "git version 1.6.5" ]] && echo --recursive); echo $GIT_RECURSIVE'
zsh  -c 'export GIT_RECURSIVE=$([[ ! "git version 1.8" < "git version 1.6.5" ]] && echo --recursive); echo $GIT_RECURSIVE'

# As well as these
bash -c 'export GIT_RECURSIVE=$([[ ! "git version 1.8" > "git version 1.6.5" ]] && echo --recursive); echo $GIT_RECURSIVE'
zsh  -c 'export GIT_RECURSIVE=$([[ ! "git version 1.8" > "git version 1.6.5" ]] && echo --recursive); echo $GIT_RECURSIVE'


```
