### PR TITLE
This patch enables to sort local releases properly with capistrano_rsync...

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -456,7 +456,7 @@ namespace :deploy do
   DESC
   task :cleanup, :except => { :no_release => true } do
     count = fetch(:keep_releases, 5).to_i
-    local_releases = capture("ls -xt #{releases_path}").split.reverse
+    local_releases = Dir::entries(releases_path).select{|x| x =~ /[0-9]+/}.sort
     if count >= local_releases.length
       logger.important "no old releases to clean up"
     else


### PR DESCRIPTION
..._with_remote_cache rubygem.

Hi Tim,

Recently, I started to use the rubygem capistrano_rsync_with_remote_cache(2.4.0) with capistrano(2.12.0). In this environment, I found that the latest release directory was inadvertently removed when deploy:cleanup invokes because each release directory has the same creation date running rsync command like `rsync -az --delete'. Could you check my patch to fix this problem, please? I think it enables to sort local releases properly for both methods, copy and rsync. Thanks. 

Regards,
Kazuo Yagi 
###### 
# Error message when running cap deploy
###### 

deploy-server> cap prod deploy
(… snip …)
**\* [err :: 10.81.88.211] Warning: DocumentRoot [/mnt/myapp/current/game/public] does not exist
**\* [err :: localhost] Warning: DocumentRoot [/mnt/myapp/current/game/admin/public] does not exist
(… snip …)
###### 
# Test case for deploy-via-copy
###### 

one-of-web-servers-deploy-via-copy$ ls -l /mnt/myapp/releases/
total 20
drwxr-xr-x 9 kyagi root 4096 Oct  1 22:25 20121002022554
drwxr-xr-x 9 kyagi root 4096 Oct  2 23:24 20121003032448
drwxr-xr-x 9 kyagi root 4096 Oct  2 23:38 20121003033757
drwxr-xr-x 9 kyagi root 4096 Oct  3 02:53 20121003065300
drwxr-xr-x 9 kyagi root 4096 Oct  6 07:33 20121006113340

one-of-web-servers-deploy-via-copy$ ruby -e 'local_releases = `ls -xt /mnt/myapp/releases`.split.reverse; p local_releases;'
["20121002022554", "20121003032448", "20121003033757", "20121003065300", "20121006113340"]

one-of-web-servers-deploy-via-copy$ ruby -e 'local_releases = Dir::entries("/mnt/myapp/releases").select{|x| x =~ /[0-9]+/}.sort ; p local_releases;'
["20121002022554", "20121003032448", "20121003033757", "20121003065300", "20121006113340"]
###### 
# Test case for deploy-via-rsync_with_remote_cache
###### 

one-of-web-servers-deploy-via-rsync_with_remote_cache$ ls -l /mnt/ayapp/releases/
total 20
drwxr-xr-x 10 kyagi users 4096 Oct  8 21:53 20121009114038
drwxr-xr-x 10 kyagi users 4096 Oct  8 21:53 20121009114204
drwxr-xr-x 10 kyagi users 4096 Oct  8 21:53 20121009121030
drwxr-xr-x 10 kyagi users 4096 Oct  8 21:53 20121009122040
drwxr-xr-x 10 kyagi users 4096 Oct  8 21:53 20121010022528

one-of-web-servers-deploy-via-rsync_with_remote_cache$ ruby -e 'local_releases = `ls -xt /mnt/myapp/releases`.split.reverse; p local_releases;'
["20121010022528", "20121009122040", "20121009121030", "20121009114204", "20121009114038"]

one-of-web-servers-deploy-via-rsync_with_remote_cache$ ruby -e 'local_releases = Dir::entries("/mnt/myapp/releases").select{|x| x =~ /[0-9]+/}.sort ; p local_releases;'
["20121009114038", "20121009114204", "20121009121030", "20121009122040", "20121010022528"]

EOF
