### PR TITLE
Asset pipeline versioning

### DIFF
--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -21,7 +21,6 @@ namespace :deploy do
     DESC
     task :symlink, :roles => assets_role, :except => { :no_release => true } do
       run <<-CMD
-        rm -rf #{latest_release}/public/#{assets_prefix} &&
         mkdir -p #{latest_release}/public &&
         mkdir -p #{shared_path}/assets/#{release_name} &&
         ln -s #{shared_path}/assets/#{release_name} #{latest_release}/public/#{assets_prefix}


### PR DESCRIPTION
If you attempt to rollback and your assets get mucked up in the bad deployment, the site you roll back to will potentially have asset errors.  Rather than re-precompiling assets on rollback and thereby slowing the rollback down, versioning assets just like releases is favorable (assuming you have the storage space).  This may want to be a configurable option and users will have to put 'after "deploy", "deploy:assets:cleanup' in their deploy files just like 'after "deploy", "deploy:cleanup"'.
