### PR TITLE
removed ui.output_cols limit of 80chars

### DIFF
--- a/lib/capistrano/cli/help.rb
+++ b/lib/capistrano/cli/help.rb
@@ -112,7 +112,7 @@ module Capistrano
 
       def output_columns #:nodoc:
         if ( @output_columns.nil? ) 
-          if ( self.class.ui.output_cols.nil? || self.class.ui.output_cols > 80 )
+          if ( self.class.ui.output_cols.nil? )
             @output_columns = 80 
           else
             @output_columns = self.class.ui.output_cols


### PR DESCRIPTION
This removes the hard coded limit of 80 COLUMNS
This closes  capistrano/capistrano#292
