### PR TITLE
fix for deploy from git branch that is not master

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/git.rb
+++ b/lib/capistrano/recipes/deploy/scm/git.rb
@@ -135,6 +135,7 @@ module Capistrano
 
           args = []
           args << "-o #{remote}" unless remote == 'origin'
+          args << "-b #{head}" unless head == 'HEAD'
           if depth = variable(:git_shallow_clone)
             args << "--depth #{depth}"
           end


### PR DESCRIPTION
When I tried to deploy from branch "foo" (branch can be set in file, result is the same):
`cap staging deploy -s branch=foo`
I got message:
`fatal: reference is not a tree: fd420dda4b994853b9a287c5d3e8df80ed184ac6`

This happened because in "deploy.rb" file I had "set :git_shallow_clone, 1". Without that setting deploy works.
Script successes to get last commit id from remote selected branch "foo", then makes "git clone" from origin without selecting branch that I need. As a result there is a clone of "master" and it know nothing about last commit on branch "foo" which id was fetched previously and fails.

This fix adds "-b <branch>" parameter to "git clone" command if branch is set.
