### PR TITLE
Added :p4charset variable for Perforce command line

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/perforce.rb
+++ b/lib/capistrano/recipes/deploy/scm/perforce.rb
@@ -85,7 +85,7 @@ module Capistrano
           def authentication
             [ p4port    && "-p #{p4port}",
               p4user    && "-u #{p4user}",
-              p4passwd  && "-P #{p4passwd}"
+              p4passwd  && "-P #{p4passwd}",
               p4client  && "-c #{p4client}",
               p4charset && "-C #{p4charset}" ].compact.join(" ")
           end


### PR DESCRIPTION
This is my first fork/update/pull_request

Since my perforce admin made the "-C" perforce charset option a requirement, Capistrano fails to work with our perforce server.  

In this patch, the addition of the :p4charset variable works as intended, but I could not figure out how to override the authentication method & add the new p4charset method via deploy.rb or monkey patching environment.rb, so I keep hacking this change directly into Capistrano's perforce.rb file.  Since updating Capistrano kills my changes, submitting a patch seemed the logical path for me to take.  

FYI: I don't know if anyone else using Perforce would need these, but according to my current version of p4 (Rev. P4/DARWIN90U/2011.1/393975 (2011/12/16)) There are 8 other p4 command line options (separate from the p4charset one included in this patch) not included in Capistrano's perforce support.

Thank you,
-=Randy
