### PR TITLE
Cleanup task

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -454,7 +454,7 @@ namespace :deploy do
   DESC
   task :cleanup, :except => { :no_release => true } do
     count = fetch(:keep_releases, 5).to_i
-    local_releases = releases.reverse
+    local_releases = releases
     if count >= local_releases.length
       logger.important "no old releases to clean up"
     else


### PR DESCRIPTION
I've added an option to 'ls' command in cleanup task to get only the right directories in releases path

for example with current 'ls' command the returned directories are '20121115143513' and  'client_side_validations-rails_2'
with the fix,  instead, the 'ls' command return just '20121115143513' directory
