### PR TITLE
Add Code Climate badge to README

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -1,7 +1,7 @@
 ## Capistrano
 
 [![Build
-Status](https://secure.travis-ci.org/capistrano/capistrano.png)](http://travis-ci.org/capistrano/capistrano)
+Status](https://secure.travis-ci.org/capistrano/capistrano.png)](http://travis-ci.org/capistrano/capistrano) [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/capistrano/capistrano)
 
 
 Capistrano is a utility and framework for executing commands in parallel on


### PR DESCRIPTION
Hello,

I'm a big fan of Capistrano and so I thought I'd drop you a quick note to let you know that Capistrano has been added to Code Climate. Code Climate is my service that provides quality metrics for Ruby code, and like GitHub it's free for OSS. You can view the reports for Capistrano here:

https://codeclimate.com/github/capistrano/capistrano

This is a small pull request that adds a Code Climate badge to the README (similar to Travis CI) in case you want this information to be available to contributors, like RSpec does:

https://github.com/rspec/rspec-rails#readme

Hope you like find it useful. Let me any know if you have any feedback or questions.

Cheers,

-Bryan
