### PR TITLE
Friendly "command finished in" times

### DIFF
--- a/lib/capistrano/command.rb
+++ b/lib/capistrano/command.rb
@@ -166,7 +166,22 @@ module Capistrano
         end
       end
 
-      logger.trace "command finished in #{(elapsed * 1000).round}ms" if logger
+      if logger
+        milliseconds = (elapsed * 1000).round.to_i
+
+        time_string = "(unknown time)"
+        if milliseconds < 1000
+          time_string = "#{milliseconds}ms"
+        else
+          hours = (milliseconds / (1000*60*60)).to_i
+          minutes = ((milliseconds % (1000*60*60)) / (1000*60)).to_i
+          seconds = (((milliseconds % (1000*60*60)) % (1000*60)) / 1000)
+          time_string = "#{seconds}s"
+          time_string = "#{minutes}m #{time_string}" if minutes > 0 or hours > 0
+          time_string = "#{hours}h #{time_string}" if hours > 0
+        end
+        logger.trace "command finished in #{time_string}"
+      end
 
       if (failed = @channels.select { |ch| ch[:status] != 0 }).any?
         commands = failed.inject({}) { |map, ch| (map[ch[:command]] ||= []) << ch[:server]; map }


### PR DESCRIPTION
This is trivial, but it might be nice to convert milliseconds to seconds or minutes when appropriate so the log is easier to read; "2m 17s" would be more interesting than "136908ms" (line 169 of `capistrano/lib/capistrano/command.rb`).

If I get some time, I may submit a pull request, but I thought I'd at least share the idea in the meantime...
