### PR TITLE
Fix current_release for after rollback case

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -57,7 +57,7 @@ _cset(:current_path)      { File.join(deploy_to, current_dir) }
 _cset(:release_path)      { File.join(releases_path, release_name) }
 
 _cset(:releases)          { capture("ls -x #{releases_path}", :except => { :no_release => true }).split.sort }
-_cset(:current_release)   { releases.length > 0 ? File.join(releases_path, releases.last) : nil }
+_cset(:current_release)   { File.exists?(current_path) ? File.realpath(current_path) : release_path }
 _cset(:previous_release)  { releases.length > 1 ? File.join(releases_path, releases[-2]) : nil }
 
 _cset(:current_revision)  { capture("cat #{current_path}/REVISION",     :except => { :no_release => true }).chomp }


### PR DESCRIPTION
Fixes capistrano/capistrano#154 such that instead of getting the newest
release directory it will follow the `current_path` symlink and read the
path of the linked to path. Even if a failed deploy release directory is
not cleaned up afterwards, the `current_release` variable should point to
the correct path still and avoids using the failed deploy release on
subsequent Capistrano runs until the next successful deploy.

Should still work when `current_dir` symlink doesn't exist as well as it
falls back to `release_path` if `current_path` does not exist to read its
link path.
