### PR TITLE
Fix for shallow clone of non-master branch under git.

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/git.rb
+++ b/lib/capistrano/recipes/deploy/scm/git.rb
@@ -137,6 +137,13 @@ module Capistrano
           args << "-o #{remote}" unless remote == 'origin'
           if depth = variable(:git_shallow_clone)
             args << "--depth #{depth}"
+
+            # For a shallow clone you should provide a real branch name to be cloned,
+            # tags or revisions result mostly in error anyway
+            if branch = variable(:branch)
+              args << "-b #{branch}"
+            end
+
           end
 
           execute = []

--- a/test/deploy/scm/git_test.rb
+++ b/test/deploy/scm/git_test.rb
@@ -150,6 +150,18 @@ class DeploySCMGitTest < Test::Unit::TestCase
     assert_equal "git clone -q --depth 1 git@somehost.com:project.git /var/www && cd /var/www && git checkout -q -b deploy #{rev}", @source.checkout(rev, dest)
   end
 
+  def test_shallow_clone_single_branch
+    dest = "/var/www"
+    rev = 'c2d9e79'
+    branch = "single_branch"
+
+    @config[:git_shallow_clone] = 1
+    @config[:repository] = "git@somehost.com:project.git"
+    @config[:branch] = branch
+
+    assert_equal "git clone -q --depth 1 -b #{branch} git@somehost.com:project.git /var/www && cd /var/www && git checkout -q -b deploy #{rev}", @source.checkout(rev, dest)
+  end
+
   def test_remote_clone
     @config[:repository] = "git@somehost.com:project.git"
     @config[:remote] = "username"


### PR DESCRIPTION
If you do the shallow clone strategy under git, you must provide a real remote branch name in the :branch setting. Before the fix was provided, only the master branch was cloned as a shallow clone by default. Any other revisions couldn't be checked out. The fix forces the branch in the :branch setting to be cloned out specifically in a shallow way, so that it can be checked out in the next command. Unfortunately, if you set :branch to a sha1 or tag, the clone of the repo fails. But shallow clones of tags and sha1 revisions are not possible anyway, so prevent that.

Summary: If you do shallow clone with git, provide a real remote branch name in the :branch setting.
