### PR TITLE
Allow excluding directories from clean during git sync

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/git.rb
+++ b/lib/capistrano/recipes/deploy/scm/git.rb
@@ -201,7 +201,14 @@ module Capistrano
 
           # Make sure there's nothing else lying around in the repository (for
           # example, a submodule that has subsequently been removed).
-          execute << "#{git} clean #{verbose} -d -x -f"
+          if variable(:git_clean_exclude)
+            clean_exclusions = [variable(:git_clean_exclude)].flatten
+            clean_exclusions = "-e " + clean_exclusions.join(" -e ")
+
+            execute << "#{git} clean #{verbose} -d -x -f #{clean_exclusions}"
+          else
+            execute << "#{git} clean #{verbose} -d -x -f"
+          end
 
           execute.join(" && ")
         end

--- a/test/deploy/scm/git_test.rb
+++ b/test/deploy/scm/git_test.rb
@@ -125,9 +125,13 @@ class DeploySCMGitTest < Test::Unit::TestCase
     @config[:scm_command] = git
     assert_equal "cd #{dest} && #{git} fetch -q origin && #{git} fetch --tags -q origin && #{git} reset -q --hard #{rev} && #{git} clean -q -d -x -f", @source.sync(rev, dest)
 
+    # With :git_clean_exclude
+    @config[:git_clean_exclude] = ["build/output", "cache/package"]
+    assert_equal "cd #{dest} && #{git} fetch -q origin && #{git} fetch --tags -q origin && #{git} reset -q --hard #{rev} && #{git} clean -q -d -x -f -e build/output -e cache/package", @source.sync(rev, dest)
+
     # with submodules
     @config[:git_enable_submodules] = true
-    assert_equal "cd #{dest} && #{git} fetch -q origin && #{git} fetch --tags -q origin && #{git} reset -q --hard #{rev} && #{git} submodule -q init && #{git} submodule -q sync && export GIT_RECURSIVE=$([ ! \"`#{git} --version`\" \\< \"git version 1.6.5\" ] && echo --recursive) && #{git} submodule -q update --init $GIT_RECURSIVE && #{git} clean -q -d -x -f", @source.sync(rev, dest)
+    assert_equal "cd #{dest} && #{git} fetch -q origin && #{git} fetch --tags -q origin && #{git} reset -q --hard #{rev} && #{git} submodule -q init && #{git} submodule -q sync && export GIT_RECURSIVE=$([ ! \"`#{git} --version`\" \\< \"git version 1.6.5\" ] && echo --recursive) && #{git} submodule -q update --init $GIT_RECURSIVE && #{git} clean -q -d -x -f -e build/output -e cache/package", @source.sync(rev, dest)
   end
 
   def test_sync_with_remote


### PR DESCRIPTION
The git SCM module's sync method runs git-clean to ensure there are no
stray files in the working directory. It includes the -x option, which
causes git-clean to remove files normally ignored by git.

This commit causes the sync method to check the :git_clean_exclude
setting for a list of files or directories to exempt from being
cleaned. This is useful, e.g. if you set a :build_script that produces
files that would normally be ignored and thus cleaned, but could
otherwise be reused.
