### PR TITLE
Enable to return the correctly sorted array for deploy:cleanup if each r...

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -456,7 +456,7 @@ namespace :deploy do
   DESC
   task :cleanup, :except => { :no_release => true } do
     count = fetch(:keep_releases, 5).to_i
-    local_releases = capture("ls -xt #{releases_path}").split.reverse
+    local_releases = capture("ls #{releases_path} | sort -dnr | xargs").split.reverse
     if count >= local_releases.length
       logger.important "no old releases to clean up"
     else


### PR DESCRIPTION
...elease directory has the same timestamp. 

This request is from https://github.com/capistrano/capistrano/pull/290
