### PR TITLE
Makes :git_shallow_clone work with branches

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/git.rb
+++ b/lib/capistrano/recipes/deploy/scm/git.rb
@@ -133,7 +133,10 @@ module Capistrano
           git    = command
           remote = origin
 
-          args = []
+          args = [] 
+
+          # Add an option for the branch name so :git_shallow_clone works with branches
+          args << "-b #{variable(:branch)}" unless variable(:branch).nil?
           args << "-o #{remote}" unless remote == 'origin'
           if depth = variable(:git_shallow_clone)
             args << "--depth #{depth}"

--- a/test/deploy/scm/git_test.rb
+++ b/test/deploy/scm/git_test.rb
@@ -145,9 +145,19 @@ class DeploySCMGitTest < Test::Unit::TestCase
   def test_shallow_clone
     @config[:repository] = "git@somehost.com:project.git"
     @config[:git_shallow_clone] = 1
+    @config[:branch] = nil
     dest = "/var/www"
     rev = 'c2d9e79'
     assert_equal "git clone -q --depth 1 git@somehost.com:project.git /var/www && cd /var/www && git checkout -q -b deploy #{rev}", @source.checkout(rev, dest)
+  end
+
+  def test_shallow_clone_with_branch
+    @config[:repository] = "git@somehost.com:project.git"
+    @config[:git_shallow_clone] = 1
+    @config[:branch] = 'foobar'
+    dest = "/var/www"
+    rev = 'c2d9e79'
+    assert_equal "git clone -q -b foobar --depth 1 git@somehost.com:project.git /var/www && cd /var/www && git checkout -q -b deploy #{rev}", @source.checkout(rev, dest)
   end
 
   def test_remote_clone


### PR DESCRIPTION
Hey guys, I added the `-b` option to the initial clone command (for deploy via copy) so that if you have the `:git_shallow_clone` variable set it will work with named branches (currently it only works for the tip of master):

```
# Before:
executing locally: git clone -q --depth 1 git@github.com:cannikin/my_repo.git /var/folders/5l/5wv_5qqx36bcf8vhh2n0qx6h0000gn/T/20121214220840 && cd /var/folders/5l/5wv_5qqx36bcf8vhh2n0qx6h0000gn/T/20121214220840 && git checkout -q -b deploy cec5221eaac5b661b75478117758f8b3e2d257b1
fatal: reference is not a tree: cec5221eaac5b661b75478117758f8b3e2d257b1

# After:
executing locally: git clone -q -b qa --depth 1 git@github.com:cannikin/my_repo.git /var/folders/5l/5wv_5qqx36bcf8vhh2n0qx6h0000gn/T/20121214222735 && cd /var/folders/5l/5wv_5qqx36bcf8vhh2n0qx6h0000gn/T/20121214222735 && git checkout -q -b deploy cec5221eaac5b661b75478117758f8b3e2d257b1
command finished in 5293ms
```

Granted I am not a git expert so I'm not sure if the `-b` flag is valid in all `git clone` scenarios...hopefully someone else knows?
