### PR TITLE
Fix shell bug causing CPU 100%

### DIFF
--- a/lib/capistrano/processable.rb
+++ b/lib/capistrano/processable.rb
@@ -23,6 +23,8 @@ module Capistrano
 
       if readers.any? || writers.any?
         readers, writers, = IO.select(readers, writers, nil, wait)
+      else
+        return false
       end
 
       if readers

--- a/lib/capistrano/shell.rb
+++ b/lib/capistrano/shell.rb
@@ -199,11 +199,13 @@ HELP
       # thread and generally gets things ready for the REPL.
       def setup
         configuration.logger.level = Capistrano::Logger::INFO
+        wait_for = 0.1
 
         @mutex = Mutex.new
         @bgthread = Thread.new do
           loop do
-            @mutex.synchronize { process_iteration(0.1) }
+            ret = @mutex.synchronize { process_iteration(wait_for) }
+            sleep wait_for if !ret
           end
         end
       end


### PR DESCRIPTION
The SSH sessions loop is trying to IO.select and wait for 0.1 seconds,
but the select is often never reached because it only enters if
readers/writers exist. So the loop executes unchecked at 100% when
waiting for commands. Now we will sleep for 0.1 seconds if we have
no waiting IO.
