### PR TITLE
Fix Multistage : specific stage file should not be mandatory

### DIFF
--- a/lib/capistrano/ext/multistage.rb
+++ b/lib/capistrano/ext/multistage.rb
@@ -15,7 +15,7 @@ Capistrano::Configuration.instance.load do
     desc "Set the target stage to `#{name}'."
     task(name) do
       set :stage, name.to_sym
-      load "#{location}/#{stage}"
+      load "#{location}/#{stage}" if File.exist?(File.join(location, "#{stage}.rb"))
     end
   end
 


### PR DESCRIPTION
For multistage deploy, requiring a file in config/deploy/ (:stage_dir) should not be mandatory
