### PR TITLE
Escape deploy:finalize_update asset_paths separately

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -286,8 +286,10 @@ namespace :deploy do
 
     if fetch(:normalize_asset_timestamps, true)
       stamp = Time.now.utc.strftime("%Y%m%d%H%M.%S")
-      asset_paths = fetch(:public_children, %w(images stylesheets javascripts)).map { |p| "#{escaped_release}/public/#{p}" }
-      run("find #{asset_paths.join(" ")} -exec touch -t #{stamp} -- {} ';'; true",
+      asset_paths = fetch(:public_children, %w(images stylesheets javascripts)).
+        map { |p| "#{latest_release}/public/#{p}" }.
+        map { |p| p.shellescape }.join(" ")
+      run("find #{asset_paths} -exec touch -t #{stamp} -- {} ';'; true",
           :env => { "TZ" => "UTC" }) if asset_paths.any?
     end
   end


### PR DESCRIPTION
Commit 483d2538e6 improved robustness by escaping some arguments in
shell commands.  But it also introduced a bug when there are multiple
public_children configured (the default case), resulting in issue #300.
Commit 6b499f53c6 resolved this issue by reverting the code to escape
arguments.

Escape the arguments separately, rather than as one shell word, to
improve robustness while also avoiding the bug in ticket #300.

Furthermore, I'd like to encourage a new release because the latest 
currently-released gem results in a failure during deploy with a default
configuration.
