### PR TITLE
capistrano cli: add --mail-to option to support emailing output.

### DIFF
--- a/lib/capistrano/cli/options.rb
+++ b/lib/capistrano/cli/options.rb
@@ -67,7 +67,19 @@ module Capistrano
 															 end
 					end
 
-          opts.on("-n", "--dry-run",
+          opts.on("-m", "--mail-to RECIPIENT",
+            "Mail the log output to the specified address.  May be given more than once."
+          ) do |value|
+            # The only goal of this email validation is to block shell injections in popen, used
+            # by the logger to send mail. It will block email addresses with '%' in them, but those are rare."
+            if !(value =~ /\A[\w\.\+-]+@[\w\.-]+\z/)
+              @logger.important("Invalid email address: #{value}.")
+              exit 1
+            end
+            options[:mail_to] << value
+          end
+
+           opts.on("-n", "--dry-run",
             "Prints out commands without running them."
           ) { |value| options[:dry_run] = true }
 
@@ -142,7 +154,7 @@ module Capistrano
       # line and set up any default options.
       def parse_options! #:nodoc:
         @options = { :recipes => [], :actions => [],
-          :vars => {}, :pre_vars => {},
+          :vars => {}, :pre_vars => {}, :mail_to => [],
           :sysconf => default_sysconf, :dotfile => default_dotfile }
 
         if args.empty?


### PR DESCRIPTION
This change adds the ability to email log output to one or more
recipients.  Cap output is still echoed to $stderr per usual and email
contents are identical to $stderr output, minus the terminal colors.
