### PR TITLE
lib/capistrano/processable.rb: log output if nothing happens for a while

### DIFF
--- a/lib/capistrano/processable.rb
+++ b/lib/capistrano/processable.rb
@@ -22,11 +22,11 @@ module Capistrano
       writers = readers.select { |io| io.respond_to?(:pending_write?) && io.pending_write? }
 
       io_timeout = 10
-      loop do
-        if readers.any? || writers.any?
+      if readers.any? || writers.any?
+        loop do
           rs, ws, = IO.select(readers, writers, nil, io_timeout)
           if rs.nil? && ws.nil?
-            logger.info("Waiting for #{@channels.select{ |ch| !ch[:closed] }.map { |ch| ch[:server] }.join(',')}")
+            logger.info("Still waiting on #{@channels.select{ |ch| !ch[:closed] }.map { |ch| ch[:server] }.join(',')}")
           else
             readers = rs
             writers = ws


### PR DESCRIPTION
Currently, cap can hang indefinitely waiting for output from a server.
This adds a 10 second timeout to the IO.select command and prints the
names of the servers to which we still have open channels.  This allows
us to easily see which servers are taking a long time or hanging.
