### PR TITLE
Report if command got killed by a signal

### DIFF
--- a/lib/capistrano/command.rb
+++ b/lib/capistrano/command.rb
@@ -243,6 +243,13 @@ module Capistrano
                 ch[:status] = data.read_long
               end
 
+              channel.on_request("exit-signal") do |ch, data|
+                if logger
+                  exit_signal = data.read_string
+                  logger.important "command received signal #{exit_signal}", ch[:server]
+                end
+              end
+
               channel.on_close do |ch|
                 ch[:closed] = true
               end

--- a/test/command_test.rb
+++ b/test/command_test.rb
@@ -154,6 +154,16 @@ class CommandTest < Test::Unit::TestCase
     assert_equal 5, channel[:status]
   end
 
+  def test_on_request_should_log_exit_signal_if_logger_present
+    data = mock(:read_string => "TERM")
+    logger = stub_everything
+
+    session = setup_for_extracting_channel_action([:on_request, "exit-signal"], data)
+    logger.expects(:important).with("command received signal TERM", server("capistrano"))
+
+    Capistrano::Command.new("puppet", [session], :logger => logger)
+  end
+
   def test_on_close_should_set_channel_closed
     channel = nil
     session = setup_for_extracting_channel_action(:on_close) { |ch| channel = ch }
@@ -236,7 +246,7 @@ class CommandTest < Test::Unit::TestCase
   class MockConfig
     include Capistrano::Configuration::Roles
   end
-  
+
   def test_hostroles_substitution
     @config = MockConfig.new
     @config.server "capistrano", :db, :worker


### PR DESCRIPTION
Spent one hour another day investigating why a Puppet run via Capistrano on some servers failed. In the end found out the command got killed by a left over hourly cron job that used to kill existing Puppet processes.

Before the pull request if the invoked command gets killed by a signal there's no report in the output:

``` shell
$> ROLES=jobs USER=root cap qa COMMAND="sleep 60" invoke
    triggering load callbacks
  * 2013-01-20 16:37:06 executing `qa'
    triggering start callbacks for `invoke'
  * 2013-01-20 16:37:06 executing `multistage:ensure'
  * 2013-01-20 16:37:06 executing `invoke'
  * executing "sleep 60"
    servers: ["vm100-017"]
    [vm100-017] executing command
    command finished in 8958ms
failed: "sh -c 'sleep 60'" on vm100-017
```

After the pull request:

``` shell
$> ROLES=jobs USER=root cap qa COMMAND="sleep 60" invoke
    triggering load callbacks
  * 2013-01-20 16:40:18 executing `qa'
    triggering start callbacks for `invoke'
  * 2013-01-20 16:40:18 executing `multistage:ensure'
  * 2013-01-20 16:40:18 executing `invoke'
  * executing "sleep 60"
    servers: ["vm100-017"]
    [vm100-017] executing command
*** [vm100-017] command received signal TERM
    command finished in 8421ms
failed: "sh -c 'sleep 60'" on vm100-017
```

This will, at least, give some idea to the user on why the command failed.
