### PR TITLE
Replace flat_map with map .. flatten to restore 1.8.7 compatibility

### DIFF
--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -110,9 +110,7 @@ namespace :deploy do
         current_assets = Set.new
         manifests.each do |yaml|
           manifest = YAML.load(yaml)
-          current_assets += manifest.to_a.flatten.flat_map do |file|
-            [file, "#{file}.gz"]
-          end
+          current_assets += manifest.to_a.flatten.map {|f| [f, "#{f}.gz"] }.flatten
         end
         current_assets += %w(manifest.yml sources_manifest.yml)
 


### PR DESCRIPTION
Sorry about this. Please merge and release a new version ASAP to fix 1.8.7 compatibility 
