### PR TITLE
Update both asset mtime and atime with touch

### DIFF
--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -66,7 +66,7 @@ namespace :deploy do
         put current_assets.map{|a| "#{shared_path}/assets/#{a}" }.join("\n"), "#{deploy_to}/TOUCH_ASSETS"
         run <<-CMD.compact
           cat #{deploy_to.shellescape}/TOUCH_ASSETS | while read asset; do
-            touch -cm -- "$asset";
+            touch -c -- "$asset";
           done &&
           rm -f -- #{deploy_to.shellescape}/TOUCH_ASSETS
         CMD


### PR DESCRIPTION
We use multiple users with common group permissions to deploy. Since touch uses the utime library, a user can't set the mtime of a file even if they have write permissions unless they are the owner of the file. Since many production systems mount the file system with noatime anyways for performance, my suggestion is we update both atime and mtime on assets so that deploying with group write permissions still works.

This issue came to light in 2.14.0 with commit 8412ccfd, because the touch command is no longer run silently. It was silently failing before but is not preventing a successful deployment.

This issue seems to be related: https://github.com/capistrano/capistrano/issues/352
