### PR TITLE
increase readability of fallback in parallel

### DIFF
--- a/lib/capistrano/command.rb
+++ b/lib/capistrano/command.rb
@@ -95,6 +95,12 @@ module Capistrano
         end
       end
 
+      class ElseBranch < Branch
+        def to_s
+          "\"else\" :: #{command.inspect}"
+        end
+      end
+
       def initialize(config)
         @configuration = config
         @branches = []
@@ -106,7 +112,7 @@ module Capistrano
       end
 
       def else(command, &block)
-        @fallback = Branch.new(command, {}, block)
+        @fallback = ElseBranch.new(command, {}, block)
       end
 
       def branches_for(server)


### PR DESCRIPTION
It increases readability of deployment:

``` bash
  * executing multiple commands in parallel
    -> "in?(:rvm)" :: "rvm_path=$HOME/.rvm/ $HOME/.rvm/bin/rvm-shell 'ruby-1.9.3-p385@ad' -c 'ls -x /home/ad/app/releases'"
    -> "else" :: "sh -c 'ls -x /home/ad/app/releases'"
```
