### PR TITLE
Don't attempt to connect to nil/empty :gateway

### DIFF
--- a/lib/capistrano/configuration/connections.rb
+++ b/lib/capistrano/configuration/connections.rb
@@ -106,7 +106,7 @@ module Capistrano
       # establish connections to servers defined via ServerDefinition objects.
       def connection_factory
         @connection_factory ||= begin
-          if exists?(:gateway)
+          if exists?(:gateway) && !fetch(:gateway).nil? && !fetch(:gateway).empty?
             logger.debug "establishing connection to gateway `#{fetch(:gateway).inspect}'"
             GatewayConnectionFactory.new(fetch(:gateway), self)
           else


### PR DESCRIPTION
The current code creates a new `GatewayConnectionFactory` if `:gateway` exists, rather than if it has a value. This is a minor change to amend the `connection_factory` method to only initiate a gateway connection if `:gateway` exists, is not nil and is not empty.

For my particular use case this then allows me to define `:gateway` as a block which can respond to different environments or configuration tasks - returning `nil` if no gateway is required.
