### PR TITLE
Replace a dead link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ tasks.
 * Push to your branch - `git push origin my_branch`
 * Create a Pull Request from your branch, include as much documentation
   as you can in the commit message/pull request, following these
-[guidelines on writing a good commit message](http://spheredev.org/wiki/Git_for_the_lazy#Writing_good_commit_messages)
+[guidelines on writing a good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
 * That's it!
 
 


### PR DESCRIPTION
Replace a dead link in the README about how to write good
git commit messages with a link to the canonical article on 
the subject by Tim Pope (@tpope).
