### PR TITLE
make run_locally work with --dry-run

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -127,6 +127,9 @@ end
 # logs the command then executes it locally.
 # returns the command output as a string
 def run_locally(cmd)
+  if dry_run
+    return logger.debug "executing locally: #{cmd.inspect}"
+  end
   logger.trace "executing locally: #{cmd.inspect}" if logger
   output_on_stdout = nil
   elapsed = Benchmark.realtime do


### PR DESCRIPTION
Hi all,

This pull request just make the `run_locally` function work with the `--dry-run` flag.
