### PR TITLE
Add multistage note

### DIFF
--- a/lib/capistrano/recipes/deploy/strategy/base.rb
+++ b/lib/capistrano/recipes/deploy/strategy/base.rb
@@ -29,7 +29,7 @@ module Capistrano
         # is setup such that a deploy could succeed.
         def check!
           Dependencies.new(configuration) do |d|
-            if (exists?(:stage)
+            if exists?(:stage)
               d.remote.directory(configuration[:releases_path]).or("`#{configuration[:releases_path]}' does not exist. Please run `cap #{configuration[:stage]} deploy:setup'.")
             else
               d.remote.directory(configuration[:releases_path]).or("`#{configuration[:releases_path]}' does not exist. Please run `cap deploy:setup'.")


### PR DESCRIPTION
Just a quick improvement.

If you you're using the multistage extension with Capistrano, and you do a deploy check, the command it asks you to run won't give you the stage you need to run it on.

This PR checks if a stage exists and shows that in the output text if given. It also works for when no stage is given and default_stage is used.
