### PR TITLE
Support JSON manifests and manifests with randomized filenames

### DIFF
--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -177,7 +177,7 @@ namespace :deploy do
         run <<-CMD.compact
           cd -- #{previous_release.shellescape} &&
           cp -f -- #{previous_manifest.shellescape} #{shared_manifest_path.shellescape} &&
-          #{rake} RAILS_ENV=#{rails_env.to_s.shellescape} #{asset_env} assets:precompile:nondigest
+          [ -z "$(#{rake} -P | grep assets:precompile:nondigest)" ] || #{rake} RAILS_ENV=#{rails_env.to_s.shellescape} #{asset_env} assets:precompile:nondigest
         CMD
       end
     end


### PR DESCRIPTION
Rails 4 now writes a JSON asset manifest file with a randomized filename.  This commit expands the `deploy:assets` tasks to support it.  It is completely compatible with YAML manifests as well as manifests that do not have a randomized filename.  

Rollbacks are still broken, though, because there doesn't appear to be an `assets:precompile:nondigest` task or equivalent in Rails 4.  I'll have to look into that further.

Fixes #362
