### PR TITLE
Please check nil on teardown connections.

### DIFF
--- a/lib/capistrano/configuration/connections.rb
+++ b/lib/capistrano/configuration/connections.rb
@@ -139,7 +139,8 @@ module Capistrano
       def teardown_connections_to(servers)
         servers.each do |server|
           begin
-            sessions.delete(server).close
+            session = sessions.delete(server)
+            session.close if session
           rescue IOError
             # the TCP connection is already dead
           end


### PR DESCRIPTION
Invoking `teardown_connections_to` will raise `NoMethodError` if the connections has not been established.
