### PR TITLE
fixed deploy asset precompile recipe 

### DIFF
--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -45,7 +45,7 @@ namespace :deploy do
     task :precompile, :roles => assets_role, :except => { :no_release => true } do
       run <<-CMD.compact
         cd -- #{latest_release} &&
-        #{rake} RAILS_ENV=#{rails_env.to_s.shellescape} #{asset_env} assets:precompile &&
+        #{rake} RAILS_ENV=#{rails_env.to_s.shellescape} assets:precompile &&
         cp -- #{shared_path.shellescape}/assets/manifest.yml #{current_release.shellescape}/assets_manifest.yml
       CMD
     end


### PR DESCRIPTION
bundle exec rake RAILS_ENV=production production assets:precompile was being executed, causing Capistrano to return: Don't know how to build task 'production'. Removing #{assets_env} from command fixes it on rake (10.0.4)
