### PR TITLE
Fix "undefined method shellescape for nil:NilClass (NoMethodError)"

### DIFF
--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -46,7 +46,7 @@ namespace :deploy do
       run <<-CMD.compact
         cd -- #{latest_release} &&
         #{rake} RAILS_ENV=#{rails_env.to_s.shellescape} #{asset_env} assets:precompile &&
-        cp -- #{shared_path.shellescape}/assets/manifest.yml #{current_release.shellescape}/assets_manifest.yml
+        cp -- #{shared_path.shellescape}/assets/manifest.yml #{current_release.to_s.shellescape}/assets_manifest.yml
       CMD
     end
 


### PR DESCRIPTION
If `deploy:assets:precompile` is executed while no servers match and `current_release` is not yet evaluated, the task try to call `shellescape` on nil.

This prevents this case by just silent error during the build of the command line.
