### PR TITLE
Handle Net::SSH::Disconnected like IOError in teardown_connections_to

### DIFF
--- a/lib/capistrano/configuration/connections.rb
+++ b/lib/capistrano/configuration/connections.rb
@@ -141,7 +141,7 @@ module Capistrano
           begin
             session = sessions.delete(server)
             session.close if session
-          rescue IOError
+          rescue IOError, Net::SSH::Disconnect
             # the TCP connection is already dead
           end
         end


### PR DESCRIPTION
Issue #441, when asked to teardown the connection to a server, if the connection is already dead recent Net::SSH versions will throw Net::SSH::Disconnected so handle that too
