### PR TITLE
asset_paths should be an Array, is a String

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -294,8 +294,8 @@ namespace :deploy do
       stamp = Time.now.utc.strftime("%Y%m%d%H%M.%S")
       asset_paths = fetch(:public_children, %w(images stylesheets javascripts)).
         map { |p| "#{latest_release}/public/#{p}" }.
-        map { |p| p.shellescape }.join(" ")
-      run("find #{asset_paths} -exec touch -t #{stamp} -- {} ';'; true",
+        map { |p| p.shellescape }
+      run("find #{asset_paths.join(" ")} -exec touch -t #{stamp} -- {} ';'; true",
           :env => { "TZ" => "UTC" }) if asset_paths.any?
     end
   end


### PR DESCRIPTION
any? is called on asset_paths, which is a string due to an early call to
join. asset_paths is joined together and passed to run a find command
on the remote target.

gems/capistrano-2.15.1/lib/capistrano/recipes/deploy.rb:299:in `block (2 levels) in load': undefined method`any?' for #String:0x007f84838a1560 (NoMethodError)
