### PR TITLE
For deploy:cleanup, use try_sudo with rm command.

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -462,7 +462,7 @@ namespace :deploy do
   DESC
   task :cleanup, :except => { :no_release => true } do
     count = fetch(:keep_releases, 5).to_i
-    try_sudo "ls -1dt #{releases_path}/* | tail -n +#{count + 1} | xargs rm -rf"
+    try_sudo "ls -1dt #{releases_path}/* | tail -n +#{count + 1} | #{try_sudo} xargs rm -rf"
   end
 
   desc <<-DESC


### PR DESCRIPTION
Fix a bug where sudo is not used when removing files with the deploy:cleanup command.

Prior to this fix, "sudo" only applied to the first command (ls) in the pipe sequence.  This changes things so it applies to the "rm" command at the end of the pipe sequence as well, which is the intent.
