### PR TITLE
Restore maintenance.rhtml

### DIFF
--- a/lib/capistrano/recipes/templates/maintenance.rhtml
+++ b/lib/capistrano/recipes/templates/maintenance.rhtml
@@ -1,0 +1,53 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+
+<head>
+  <meta http-equiv="content-type" content="text/html;charset=UTF-8" />
+  <title>System down for maintenance</title>
+
+  <style type="text/css">
+    div.outer {
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      width: 500px;
+      height: 300px;
+      margin-left: -260px; 
+      margin-top: -150px;
+    }
+
+    .DialogBody {
+      margin: 0;
+      padding: 10px;
+      text-align: left;
+      border: 1px solid #ccc;
+      border-right: 1px solid #999;
+      border-bottom: 1px solid #999;
+      background-color: #fff;
+    }
+
+    body { background-color: #fff; }
+  </style>
+</head>
+
+<body>
+
+  <div class="outer">
+     <div class="DialogBody" style="text-align: center;">
+       <div style="text-align: center; width: 200px; margin: 0 auto;">
+         <p style="color: red; font-size: 16px; line-height: 20px;">
+           The system is down for <%= reason ? reason : "maintenance" %>
+           as of <%= Time.now.strftime("%H:%M %Z") %>.
+         </p>
+         <p style="color: #666;">
+           It'll be back <%= deadline ? deadline : "shortly" %>.
+         </p>
+       </div>
+     </div>
+  </div>
+
+</body>
+</html>


### PR DESCRIPTION
from 28c484f1f5e6a009d1b8ff07d85e924d6f947d3c^

This is required for web:disable task - only code for variables and tasks are restored :(

If capistrano will keep the maintenance tasks, it would be better to merge code and templates from  https://github.com/tvdeyen/capistrano-maintenance

(cc @tvdeyen)
