### PR TITLE
ArgumentError: wrong number of arguments(1 for 0) on to_s(true)

### DIFF
--- a/lib/capistrano/configuration/actions/invocation.rb
+++ b/lib/capistrano/configuration/actions/invocation.rb
@@ -163,7 +163,7 @@ module Capistrano
 
           if tree.branches.any? || tree.fallback
             _, servers = filter_servers(options)
-            branches = branches_for_servers(tree,servers)
+            branches = servers.map{|server| tree.branches_for(server)}.flatten.compact
             case branches.size
             when 0
               branches = tree.branches.dup + [tree.fallback]


### PR DESCRIPTION
Hi there,

I'm facing this where the `to_s(true)` [here](https://github.com/capistrano/capistrano/blob/master/lib/capistrano/configuration/actions/invocation.rb#L182) is called in a regular array instead of a [`Branch`](https://github.com/capistrano/capistrano/blob/a5b50fd1888bfa2019ef48dd3d408339e6b2ac4e/lib/capistrano/command.rb#L19) resulting in this error:

```
ArgumentError: wrong number of arguments(1 for 0)
```

It seems it all started here https://github.com/capistrano/capistrano/commit/a5b50fd1888bfa2019ef48dd3d408339e6b2ac4e#L1R174.

Sorry for not providing a patch, I'm not sufficiently familiarized with capistrano internals for that. Although, with some guidance I'd be glad to help.

Thanks in advance.

/cc @mpapis
