### PR TITLE
Fixed #346 by using ln and then mv.

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -313,13 +313,13 @@ namespace :deploy do
   task :create_symlink, :except => { :no_release => true } do
     on_rollback do
       if previous_release
-        run "rm -f #{current_path}; ln -s #{previous_release} #{current_path}; true"
+        run "ln -s #{previous_release} #{current_path}_tmp; mv -fT #{current_path}_tmp #{current_path}"
       else
         logger.important "no previous release to rollback to, rollback of symlink skipped"
       end
     end
 
-    run "rm -f #{current_path} && ln -s #{latest_release} #{current_path}"
+    run "ln -s #{latest_release} #{current_path}_tmp && mv -fT #{current_path}_tmp #{current_path}"
   end
 
   desc <<-DESC


### PR DESCRIPTION
After reading several articles it seems that the `mv` UNIX operation is atomic, but creating a symbolic link is not. The current operation in `deploy:create_symlink` is definitely not atomic. We've been discussing in #346 several different methods of getting to an atomic operation. 

Now this obviously doesn't take into account if we are spanning across file systems, but that itself should be highly unlikely. 

There are several places where this seems the best approach:
http://stackoverflow.com/questions/1385244/replace-important-symbolic-link-safely
http://rcrowley.org/2010/01/06/things-unix-can-do-atomically.html
http://superuser.com/questions/101676/is-there-some-difference-between-mv-and-cp-rm-the-old-file-on-unix
