### PR TITLE
Fix deploy:assets:symlink to use assets_prefix

### DIFF
--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -42,7 +42,7 @@ namespace :deploy do
     task :symlink, :roles => lambda { assets_role }, :except => { :no_release => true } do
       run <<-CMD.compact
         rm -rf #{latest_release}/public/#{assets_prefix} &&
-        mkdir -p #{latest_release}/public &&
+        mkdir -p #{latest_release}/public/#{assets_prefix} &&
         mkdir -p #{shared_path}/#{shared_assets_prefix} &&
         ln -s #{shared_path}/#{shared_assets_prefix} #{latest_release}/public/#{assets_prefix}
       CMD


### PR DESCRIPTION
This commit updates deploy:assets:symlink to use assets_prefix when
making the new directory, otherwise it was failing when it tried to create the new symlink
