### PR TITLE
run: don't double-encode newlines

### DIFF
--- a/lib/capistrano/command.rb
+++ b/lib/capistrano/command.rb
@@ -21,7 +21,7 @@ module Capistrano
         attr_reader :options
 
         def initialize(command, options, callback)
-          @command = command.strip.gsub(/\r?\n/, "\\\n")
+          @command = command.strip.gsub(/\r\n/, "\n").gsub(/^\s+/, "")
           @callback = callback || Capistrano::Configuration.default_io_proc
           @options = options
           @skip = false

--- a/test/command_test.rb
+++ b/test/command_test.rb
@@ -10,12 +10,12 @@ class CommandTest < Test::Unit::TestCase
 
   def test_command_with_newlines_should_be_properly_escaped
     cmd = Capistrano::Command.new("ls\necho", [mock_session])
-    assert_equal "ls\\\necho", cmd.tree.fallback.command
+    assert_equal "ls\necho", cmd.tree.fallback.command
   end
 
   def test_command_with_windows_newlines_should_be_properly_escaped
     cmd = Capistrano::Command.new("ls\r\necho", [mock_session])
-    assert_equal "ls\\\necho", cmd.tree.fallback.command
+    assert_equal "ls\necho", cmd.tree.fallback.command
   end
 
   def test_command_with_pty_should_request_pty_and_register_success_callback


### PR DESCRIPTION
Instead of double-ecnoding newlines (`\n` -> `\\\n`), just leave them as is.

Without this change, multiline commands are executed as if they are one line.

An invocation like this:

``` ruby
run <<-CMD
  echo
  hostname
CMD
```

previously echoed "hostname" instead of running the `hostname` command because it's being interpreted like: `echo hostname`  instead of `echo \n hostname`.
