### PR TITLE
Fixes a bug that deletes the staging directory before deployment when specifying ".*" in :copy_exclude

### DIFF
--- a/lib/capistrano/recipes/deploy/strategy/copy.rb
+++ b/lib/capistrano/recipes/deploy/strategy/copy.rb
@@ -205,8 +205,8 @@ module Capistrano
 
             copy_exclude.each do |pattern|
               delete_list = Dir.glob(File.join(destination, pattern), File::FNM_DOTMATCH)
-              # avoid the /.. trap that deletes the parent directories
-              delete_list.delete_if { |dir| dir =~ /\/\.\.$/ }
+              # avoid the /.. trap that deletes the parent directories and /. that deletes the current directory
+              delete_list.delete_if { |dir| dir =~ /\/\.{1,2}$/ }
               FileUtils.rm_rf(delete_list.compact)
             end
           end


### PR DESCRIPTION
When using the following config:

```
set :deploy_via, :copy
set :copy_exclude, [".*"]
```

The temp directory used for staging a copy is itself deleted ("."), so the deploy fails.  This commit sanitizes the "._" by removing "." and ".." from the list of deleted folders.  Using "._" is helpful in excludes since it allows you to exclude all locally hidden files using that syntax.  This also brings the exclusion syntax inline with the .gitignore syntax.
