### PR TITLE
avoid asking sudo password in cleanup task.

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -462,7 +462,7 @@ namespace :deploy do
   DESC
   task :cleanup, :except => { :no_release => true } do
     count = fetch(:keep_releases, 5).to_i
-    try_sudo "ls -1dt #{releases_path}/* | tail -n +#{count + 1} | #{try_sudo} xargs rm -rf"
+    try_sudo "rm -rf `ls -1dt #{releases_path}/* | tail -n +#{count + 1}`"
   end
 
   desc <<-DESC


### PR DESCRIPTION
Using backquote instead of using xargs, I avoid asking sudo password in cleanup task.
Without this change, my deploy:cleanup task is broken.
My environment is Debian 6.0.7.
