### PR TITLE
Set Shell Environment before command

### DIFF
--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -60,8 +60,8 @@ namespace :deploy do
     DESC
     task :precompile, :roles => lambda { assets_role }, :except => { :no_release => true } do
       run <<-CMD.compact
-        cd -- #{latest_release} &&
-        #{rake} RAILS_ENV=#{rails_env.to_s.shellescape} #{asset_env} assets:precompile
+        cd -- #{latest_release} && 
+        RAILS_ENV=#{rails_env.to_s.shellescape} #{asset_env} #{rake} assets:precompile
       CMD
 
       if capture("ls -1 #{shared_path.shellescape}/#{shared_assets_prefix}/manifest* | wc -l").to_i > 1


### PR DESCRIPTION
In my understanding of unix shell conventions - the environment variables should be before the shell command. I noticed that a rake task that was scoped to be in ENV development or test was getting loaded in a completely different environment.

Pls Review so I can take my catchall hack out of my local rake task :D

thank you!
