### PR TITLE
Using quotes around SCMs usernames and password/passphrases

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/cvs.rb
+++ b/lib/capistrano/recipes/deploy/scm/cvs.rb
@@ -84,7 +84,7 @@ module Capistrano
           case text
           when /\bpassword.*:/i
             # prompting for a password
-            "#{variable(:scm_password) || variable(:password)}\n"
+            %("#{variable(:scm_password) || variable(:password)}"\n)
           when %r{\(yes/no\)}
             # let's be agreeable...
             "yes\n"

--- a/lib/capistrano/recipes/deploy/scm/git.rb
+++ b/lib/capistrano/recipes/deploy/scm/git.rb
@@ -263,7 +263,7 @@ module Capistrano
             unless pass = variable(:scm_password)
               pass = Capistrano::CLI.password_prompt
             end
-            "#{pass}\n"
+            %("#{pass}"\n)
           when %r{\(yes/no\)}
             # git is asking whether or not to connect
             "yes\n"
@@ -272,7 +272,7 @@ module Capistrano
             unless pass = variable(:scm_passphrase)
               pass = Capistrano::CLI.password_prompt
             end
-            "#{pass}\n"
+            %("#{pass}"\n)
           when /accept \(t\)emporarily/
             # git is asking whether to accept the certificate
             "t\n"

--- a/lib/capistrano/recipes/deploy/scm/mercurial.rb
+++ b/lib/capistrano/recipes/deploy/scm/mercurial.rb
@@ -73,7 +73,7 @@ module Capistrano
           when /^user:/mi
             # support :scm_user for backwards compatibility of this module
             if user = variable(:scm_username) || variable(:scm_user)
-              "#{user}\n"
+              %("#{user}"\n)
             else
               raise "No variable :scm_username specified and Mercurial asked!\n" +
                 "Prompt was: #{text}"
@@ -84,7 +84,7 @@ module Capistrano
               raise "No variable :scm_password specified and Mercurial asked!\n" +
                 "Prompt was: #{text}"
             end
-            "#{pass}\n"
+            %("#{pass}"\n)
           when /yes\/no/i
             "yes\n"
           end

--- a/lib/capistrano/recipes/deploy/scm/subversion.rb
+++ b/lib/capistrano/recipes/deploy/scm/subversion.rb
@@ -73,13 +73,13 @@ module Capistrano
           case text
           when /\bpassword.*:/i
             # subversion is prompting for a password
-            "#{scm_password_prompt}\n"
+            %("#{scm_password_prompt}"\n)
           when %r{\(yes/no\)}
             # subversion is asking whether or not to connect
             "yes\n"
           when /passphrase/i
             # subversion is asking for the passphrase for the user's key
-            "#{variable(:scm_passphrase)}\n"
+            %("#{variable(:scm_passphrase)}"\n)
           when /The entry \'(.+?)\' is no longer a directory/
             raise Capistrano::Error, "subversion can't update because directory '#{$1}' was replaced. Please add it to svn:ignore."
           when /accept \(t\)emporarily/
@@ -97,8 +97,8 @@ module Capistrano
           def authentication
             username = variable(:scm_username)
             return "" unless username
-            result = "--username #{variable(:scm_username)} "
-            result << "--password #{variable(:scm_password)} " unless variable(:scm_auth_cache) || variable(:scm_prefer_prompt)
+            result = %(--username "#{variable(:scm_username)}")
+            result << %(--password "#{variable(:scm_password)}") unless variable(:scm_auth_cache) || variable(:scm_prefer_prompt)
             result << "--no-auth-cache " unless variable(:scm_auth_cache)
             result
           end

--- a/test/deploy/scm/git_test.rb
+++ b/test/deploy/scm/git_test.rb
@@ -217,5 +217,43 @@ class DeploySCMGitTest < Test::Unit::TestCase
     assert_equal "git", @source.local.command
     assert_equal "/foo/bar/git", @source.command
   end
+
+  def test_sends_password_if_set
+    require 'capistrano/logger'
+    text = "password:"
+    @config[:scm_password] = "opensesame"
+    assert_equal %("opensesame"\n), @source.handle_data(mock_state, :test_stream, text)
+  end
+
+  def test_prompt_password
+    require 'capistrano/logger'
+    require 'capistrano/cli'
+    Capistrano::CLI.stubs(:password_prompt).returns("opensesame")
+
+    text = 'password:'
+    assert_equal %("opensesame"\n), @source.handle_data(mock_state, :test_stream, text)
+  end
+
+  def test_sends_passphrase_if_set
+    require 'capistrano/logger'
+    text = "passphrase:"
+    @config[:scm_passphrase] = "opensesame"
+    assert_equal %("opensesame"\n), @source.handle_data(mock_state, :test_stream, text)
+  end
+
+  def test_prompt_passphrase
+    require 'capistrano/logger'
+    require 'capistrano/cli'
+    Capistrano::CLI.stubs(:password_prompt).returns("opensesame")
+
+    text = 'passphrase:'
+    assert_equal %("opensesame"\n), @source.handle_data(mock_state, :test_stream, text)
+  end
+
+  private
+
+    def mock_state
+      { :channel => { :host => "abc" } }
+    end
 end
 

--- a/test/deploy/scm/mercurial_test.rb
+++ b/test/deploy/scm/mercurial_test.rb
@@ -48,10 +48,10 @@ class DeploySCMMercurialTest < Test::Unit::TestCase
     require 'capistrano/logger'
     @config[:scm_user] = "fred"
     text = "user:"
-    assert_equal "fred\n", @source.handle_data(mock_state, :test_stream, text)
+    assert_equal %("fred"\n), @source.handle_data(mock_state, :test_stream, text)
     # :scm_username takes priority
     @config[:scm_username] = "wilma"
-    assert_equal "wilma\n", @source.handle_data(mock_state, :test_stream, text)
+    assert_equal %("wilma"\n), @source.handle_data(mock_state, :test_stream, text)
   end
 
   def test_sync
@@ -72,7 +72,7 @@ class DeploySCMMercurialTest < Test::Unit::TestCase
     require 'capistrano/logger'
     text = "password:"
     @config[:scm_password] = "opensesame"
-    assert_equal "opensesame\n", @source.handle_data(mock_state, :test_stream, text)
+    assert_equal %("opensesame"\n), @source.handle_data(mock_state, :test_stream, text)
   end
 
   def test_prompts_for_password_if_preferred
@@ -81,7 +81,7 @@ class DeploySCMMercurialTest < Test::Unit::TestCase
     Capistrano::CLI.stubs(:password_prompt).with("hg password: ").returns("opensesame")
     @config[:scm_prefer_prompt] = true
     text = "password:"
-    assert_equal "opensesame\n", @source.handle_data(mock_state, :test_stream, text)
+    assert_equal %("opensesame"\n), @source.handle_data(mock_state, :test_stream, text)
   end
 
 

--- a/test/deploy/scm/subversion_test.rb
+++ b/test/deploy/scm/subversion_test.rb
@@ -37,4 +37,32 @@ Last Changed Date: 2009-03-11 11:04:25 -0700 (Wed, 11 Mar 2009)
     assert_equal "svn switch -q  -r602 http://svn.github.com/capistrano/capistrano.git /var/www", @source.sync(rev, dest)
   end
 
+  def test_sends_password_if_set
+    require 'capistrano/logger'
+    text = "password:"
+    @config[:scm_password] = "opensesame"
+    assert_equal %("opensesame"\n), @source.handle_data(mock_state, :test_stream, text)
+  end
+
+  def test_prompt_password
+    require 'capistrano/logger'
+    require 'capistrano/cli'
+    Capistrano::CLI.stubs(:password_prompt).returns("opensesame")
+
+    text = 'password:'
+    assert_equal %("opensesame"\n), @source.handle_data(mock_state, :test_stream, text)
+  end
+
+  def test_sends_passphrase
+    require 'capistrano/logger'
+    text = 'passphrase:'
+    @config[:scm_passphrase] = "opensesame"
+    assert_equal %("opensesame"\n), @source.handle_data(mock_state, :test_stream, text)
+  end
+
+  private
+
+    def mock_state
+      { :channel => { :host => "abc" } }
+    end
 end


### PR DESCRIPTION
Closes #471

PS: I didn't find the test file of the CVS SCM, maybe it's missing. I opened the issue #479 talking about this.
