### PR TITLE
deploy:update_code rolling back is not sudo aware and fails

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -249,7 +249,7 @@ namespace :deploy do
     defaults to :checkout).
   DESC
   task :update_code, :except => { :no_release => true } do
-    on_rollback { run "rm -rf #{release_path}; true" }
+    on_rollback { run "#{try_sudo} rm -rf #{release_path}; true" }
     strategy.deploy!
     finalize_update
   end


### PR DESCRIPTION
When an error appears in the deploy:update_code task, the rollback fails if permissions & ownership on the directories/files is different due to set permissions with sudo in previous tasks.
