### PR TITLE
Prevent errors on deploy:assets:clean_expired when empty manifests exist on server.

### DIFF
--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -138,7 +138,7 @@ namespace :deploy do
         logger.info "Fetched #{manifests.count} manifests from #{releases_path}/*/assets_manifest.*"
         current_assets = Set.new
         manifests.each do |content|
-          current_assets += parse_manifest(content)
+          current_assets += parse_manifest(content) unless content == ""
         end
         current_assets += [File.basename(shared_manifest_path), "sources_manifest.yml"]
 


### PR DESCRIPTION
When running `deploy:assets:clean_expired` I got an error `capistrano-2.15.4/lib/capistrano/recipes/deploy/assets.rb:28:in `parse_manifest': undefined method `to_a' for false:FalseClass (NoMethodError)`

This occurred because we had some empty manifest files on the server.

This adds a checks that the content of the manifests is not empty before it tries to parse the manifests.
