### PR TITLE
Add capdrupal in the 3rd party extension

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,6 +118,8 @@
                   <li>
                   <a href="https://github.com/forward/resque_utils">resque_utils</a> Helper tasks for remote Resque deployments (requeue &amp; remove failed jobs)</li>
                   <li>
+                  <a href="http://antistatique.github.io/capdrupal">capdrupal</a> For deploying Drupal apps with support for features revert and files push/pull</li>
+                  <li>
                   <a href="https://github.com/augustash/capistrano-ash">capistrano-ash</a> For deploying Magento, Drupal, WordPress, and Zend/Doctrine apps</li>
                   <li>
                   <a href="http://www.playframework.org/modules/capistrano">play-capistrano</a> For deploying/controlling remote Play Framework apps</li>


### PR DESCRIPTION
At antistatique we really trying to have one "official" drupal recipe as their is none for now. I hop adding this to the website will bring attention. The extension was tested on a number of server on different project. We also put some effort in the documentation.
