### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ bundle --binstubs
 ```
 
 Capify:
-
+*make sure there's no "Capfile" or "capfile" present* 
 ``` shell
 $ cap install
 ```


### PR DESCRIPTION
When there is a `Capfile` or `capfile` present (which is empty) it will throw errors such as "Don't know how to build task 'install'" which is confusing and unhelpful.  Since v3 wants to create its own Capfile it would be helpful to know not to have one if you're upgrading from 2.x.
