### PR TITLE
Avoid git warning when cloning repo and specifying a git hash code in branch variable

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/git.rb
+++ b/lib/capistrano/recipes/deploy/scm/git.rb
@@ -136,7 +136,7 @@ module Capistrano
           args = []
 
           # Add an option for the branch name so :git_shallow_clone works with branches
-          args << "-b #{variable(:branch)}" unless variable(:branch).nil?
+          args << "-b #{variable(:branch)}" unless variable(:branch).nil? || variable(:branch) == revision
           args << "-o #{remote}" unless remote == 'origin'
           if depth = variable(:git_shallow_clone)
             args << "--depth #{depth}"

--- a/test/deploy/scm/git_test.rb
+++ b/test/deploy/scm/git_test.rb
@@ -43,6 +43,21 @@ class DeploySCMGitTest < Test::Unit::TestCase
     assert_equal "#{git} clone -q git@somehost.com:project.git /var/www && cd /var/www && #{git} checkout -q -b deploy #{rev} && #{git} submodule -q init && #{git} submodule -q sync && export GIT_RECURSIVE=$([ ! \"`#{git} --version`\" \\< \"git version 1.6.5\" ] && echo --recursive) && #{git} submodule -q update --init $GIT_RECURSIVE", @source.checkout(rev, dest).gsub(/\s+/, ' ')
   end
 
+  def test_checkout_branching
+    @config[:repository] = "git@somehost.com:project.git"
+    dest = "/var/www"
+    rev = 'c2d9e79'
+    assert_equal "git clone -q git@somehost.com:project.git /var/www && cd /var/www && git checkout -q -b deploy c2d9e79", @source.checkout(rev, dest)
+
+    # with :branch
+    @config[:branch] = "master"
+    assert_equal "git clone -q -b master git@somehost.com:project.git /var/www && cd /var/www && git checkout -q -b deploy c2d9e79", @source.checkout(rev, dest)
+
+    # with :branch with hash code
+    @config[:branch] = "c2d9e79"
+    assert_equal "git clone -q git@somehost.com:project.git /var/www && cd /var/www && git checkout -q -b deploy c2d9e79", @source.checkout(rev, dest)
+  end
+
   def test_checkout_submodules_without_recursive
     @config[:repository] = "git@somehost.com:project.git"
     dest = "/var/www"


### PR DESCRIPTION
Warning is :
warning: Remote branch 417b9918f9bbecf07a2311a04ea72faa937b17c9 not found in upstream origin, using HEAD instead
