### PR TITLE
fix repo_url in deploy.rb template (v3)

### DIFF
--- a/lib/capistrano/templates/deploy.rb.erb
+++ b/lib/capistrano/templates/deploy.rb.erb
@@ -1,5 +1,5 @@
 set :application, 'my app name'
-set :repo, 'git@example.com:me/my_repo.git'
+set :repo_url, 'git@example.com:me/my_repo.git'
 
 ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }
 

--- a/spec/integration/deploy_finalize_spec.rb
+++ b/spec/integration/deploy_finalize_spec.rb
@@ -10,7 +10,7 @@ describe 'cap deploy:finished', slow: true do
       %{
         set :stage, :#{stage}
         set :deploy_to, '#{deploy_to}'
-        set :repo, 'git://github.com/capistrano/capistrano.git'
+        set :repo_url, 'git://github.com/capistrano/capistrano.git'
         set :branch, 'v3'
         server 'localhost', roles: %w{web app}, user: '#{current_user}'
         set :linked_files, %w{config/database.yml}

--- a/spec/integration/deploy_finished_spec.rb
+++ b/spec/integration/deploy_finished_spec.rb
@@ -10,7 +10,7 @@ describe 'cap deploy:finished', slow: true do
       %{
         set :stage, :#{stage}
         set :deploy_to, '#{deploy_to}'
-        set :repo, 'git://github.com/capistrano/capistrano.git'
+        set :repo_url, 'git://github.com/capistrano/capistrano.git'
         set :branch, 'v3'
         server 'localhost', roles: %w{web app}, user: '#{current_user}'
         set :linked_files, %w{config/database.yml}

--- a/spec/integration/deploy_started_spec.rb
+++ b/spec/integration/deploy_started_spec.rb
@@ -10,7 +10,7 @@ describe 'cap deploy:started', slow: true do
       %{
         set :stage, :#{stage}
         set :deploy_to, '#{deploy_to}'
-        set :repo, 'git://github.com/capistrano/capistrano.git'
+        set :repo_url, 'git://github.com/capistrano/capistrano.git'
         set :branch, 'v3'
         server 'localhost', roles: %w{web app}, user: '#{current_user}'
         set :linked_files, %w{config/database.yml}

--- a/spec/integration/deploy_update_spec.rb
+++ b/spec/integration/deploy_update_spec.rb
@@ -10,7 +10,7 @@ describe 'cap deploy:update', slow: true do
       %{
         set :stage, :#{stage}
         set :deploy_to, '#{deploy_to}'
-        set :repo, 'git://github.com/capistrano/capistrano.git'
+        set :repo_url, 'git://github.com/capistrano/capistrano.git'
         set :branch, 'v3'
         server 'localhost', roles: %w{web app}, user: '#{current_user}'
         set :linked_files, %w{config/database.yml}


### PR DESCRIPTION
Hi, just to confirm the correct variable to use is `:repo_url`, rather than `:repo` ?
