### PR TITLE
run deploy:bundle right after deploy:update

### DIFF
--- a/lib/capistrano/tasks/bundler.rake
+++ b/lib/capistrano/tasks/bundler.rake
@@ -9,5 +9,5 @@ namespace :deploy do
     end
   end
 
-  after :update, :bundle
+  after 'deploy:update', 'deploy:bundle'
 end


### PR DESCRIPTION
As discussed in #536, the patch will ensure `deploy:bundle` runs as early as possible. 

It also replaces the arguments in after() with full task name string, because error raised with original arguments syntax i.e. `after(:finalize, :bundle)`. Can someone confirm which one is the valid syntax?
