### PR TITLE
Fix missing spacing in subversion deploy recipe.

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/subversion.rb
+++ b/lib/capistrano/recipes/deploy/scm/subversion.rb
@@ -97,8 +97,8 @@ module Capistrano
           def authentication
             username = variable(:scm_username)
             return "" unless username
-            result = %(--username "#{variable(:scm_username)}")
-            result << %(--password "#{variable(:scm_password)}") unless variable(:scm_auth_cache) || variable(:scm_prefer_prompt)
+            result = %(--username "#{variable(:scm_username)}" )
+            result << %(--password "#{variable(:scm_password)}" ) unless variable(:scm_auth_cache) || variable(:scm_prefer_prompt)
             result << "--no-auth-cache " unless variable(:scm_auth_cache)
             result
           end

--- a/test/deploy/scm/subversion_test.rb
+++ b/test/deploy/scm/subversion_test.rb
@@ -44,6 +44,21 @@ Last Changed Date: 2009-03-11 11:04:25 -0700 (Wed, 11 Mar 2009)
     assert_equal %("opensesame"\n), @source.handle_data(mock_state, :test_stream, text)
   end
 
+  def test_authentication
+    require 'capistrano/logger'
+    @config[:scm_username] = 'user_name'
+    @config[:scm_password] = 'opensesame'
+    assert_equal '--username "user_name" --password "opensesame" --no-auth-cache ', @source.send(:authentication)
+  end
+
+  def test_authentication_cache_if_set
+    require 'capistrano/logger'
+    @config[:scm_username] = 'user_name'
+    @config[:scm_password] = 'opensesame'
+    @config[:scm_auth_cache] = 'yes'
+    assert_equal '--username "user_name" ', @source.send(:authentication)
+  end
+
   def test_prompt_password
     require 'capistrano/logger'
     require 'capistrano/cli'


### PR DESCRIPTION
A recent change removed the white space between the scm_username and scm_password string returned from the private authentication method. This was causing the method to return an invalid username string consisting of the valid username concatenated with the string '--password'.
