### PR TITLE
(v3) add a rollback hook to run rollback-only tasks

### DIFF
--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -132,6 +132,10 @@ namespace :deploy do
     end
   end
 
+  desc 'Rollback hook'
+  task :finalize_rollback do
+  end
+
   desc 'Rollback to the last release'
   task :rollback do
     on primary :app do
@@ -142,7 +146,8 @@ namespace :deploy do
     end
 
     on roles :app do
-      %w{check finalize restart finishing finished}.each do |task|
+      %w{finalize_rollback
+         check finalize restart finishing finished}.each do |task|
         invoke "deploy:#{task}"
       end
     end


### PR DESCRIPTION
In order to run custom rollback-only tasks e.g. rollback assets during  `deploy:rollback`, we need at least one rollback-only hook.

This patch is based on a suggestion from @leehambley during a short offline discussion.
