### PR TITLE
(v3) Renamed task list

### DIFF
--- a/lib/capistrano/tasks/bundler.rake
+++ b/lib/capistrano/tasks/bundler.rake
@@ -9,5 +9,5 @@ namespace :deploy do
     end
   end
 
-  after 'deploy:update', 'deploy:bundle'
+  before 'deploy:updated', 'deploy:bundle'
 end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -1,16 +1,25 @@
 namespace :deploy do
 
-  task :started do
+  task :starting do
     invoke 'deploy:check'
   end
 
-  task :update do
+  task :updating do
     invoke "#{scm}:create_release"
     invoke 'deploy:symlink:shared'
   end
 
-  task :finalize do
+  task :reverting do
+    invoke 'deploy:revert_release'
+  end
+
+  task :publishing do
     invoke 'deploy:symlink:release'
+    invoke 'deploy:restart'
+  end
+
+  task :finishing do
+    invoke 'deploy:cleanup'
   end
 
   task :finished do
@@ -132,19 +141,14 @@ namespace :deploy do
     end
   end
 
-  desc 'Rollback to the last release'
-  task :rollback do
+  desc 'Revert to previous release timestamp'
+  task :revert_release do
     on roles(:all) do
       last_release = capture(:ls, '-xr', releases_path).split[1]
       set(:rollback_release_timestamp, last_release)
       set(:branch, last_release)
       set(:revision_log_message, rollback_log_message)
     end
-
-    on roles :app do
-      %w{check finalize restart finishing finished}.each do |task|
-        invoke "deploy:#{task}"
-      end
-    end
   end
+
 end

--- a/lib/capistrano/tasks/framework.rake
+++ b/lib/capistrano/tasks/framework.rake
@@ -1,6 +1,6 @@
 namespace :deploy do
 
-  desc 'Starting'
+  desc 'Start a deployment, make sure server(s) ready.'
   task :starting do
   end
 
@@ -8,20 +8,36 @@ namespace :deploy do
   task :started do
   end
 
-  desc 'Update'
-  task :update do
+  desc 'Update server(s) by setting up a new release.'
+  task :updating do
   end
 
-  desc 'Finalize'
-  task :finalize do
+  desc 'Updated'
+  task :updated do
   end
 
-  desc 'Restart'
-  task :restart do
+  desc 'Revert server(s) to previous release.'
+  task :reverting do
   end
 
-  desc 'Finishing'
+  desc 'Reverted'
+  task :reverted do
+  end
+
+  desc 'Publish the release.'
+  task :publishing do
+  end
+
+  desc 'Published'
+  task :published do
+  end
+
+  desc 'Finish the deployment, clean up server(s).'
   task :finishing do
+  end
+
+  desc 'Finish the rollback, clean up server(s).'
+  task :finishing_rollback do
   end
 
   desc 'Finished'
@@ -34,11 +50,24 @@ namespace :deploy do
       exit 1
     end
   end
+
+  desc 'Rollback to previous release.'
+  task :rollback do
+    %w{ starting started
+        reverting reverted
+        publishing published
+        finishing_rollback finished }.each do |task|
+      invoke "deploy:#{task}"
+    end
+  end
 end
 
-desc 'Deploy'
+desc 'Deploy a new release.'
 task :deploy do
-  %w{starting started update finalize restart finishing finished}.each do |task|
+  %w{ starting started
+      updating updated
+      publishing published
+      finishing finished }.each do |task|
     invoke "deploy:#{task}"
   end
 end

--- a/spec/integration/deploy_finalize_spec.rb
+++ b/spec/integration/deploy_finalize_spec.rb
@@ -21,8 +21,8 @@ describe 'cap deploy:finished', slow: true do
     describe 'log_revision' do
       before do
         cap 'deploy:started'
-        cap 'deploy:update'
-        cap 'deploy:finalize'
+        cap 'deploy:updating'
+        cap 'deploy:publishing'
         cap 'deploy:finished'
       end
 

--- a/spec/integration/deploy_finished_spec.rb
+++ b/spec/integration/deploy_finished_spec.rb
@@ -21,8 +21,8 @@ describe 'cap deploy:finished', slow: true do
     describe 'symlink' do
       before do
         cap 'deploy:started'
-        cap 'deploy:update'
-        cap 'deploy:finalize'
+        cap 'deploy:updating'
+        cap 'deploy:publishing'
       end
 
       describe 'release' do

--- a/spec/integration/deploy_update_spec.rb
+++ b/spec/integration/deploy_update_spec.rb
@@ -1,6 +1,6 @@
 require 'integration_spec_helper'
 
-describe 'cap deploy:update', slow: true do
+describe 'cap deploy:updating', slow: true do
   before do
     install_test_app_with(config)
   end


### PR DESCRIPTION
This patch is implemented based on the discussion in capistrano/rails#3.

Changes:
- rename tasks with descriptive names (see the new runlist below)
- add new task hooks: updated, reverting, reverted, finishing_rollback
- invoke `deploy:check` in `deploy:starting`
- invoke `deploy:restart` in `deploy:publishing`
- invoke `deploy:revert_release` (set previous release timestamp) in `deploy:reverting`
- move `deploy:rollback` to `framework.rake`

New runlist:

```
deploy
--
starting
started
updating
updated
publishing
published
finishing
finished

rollback

---
starting
started
reverting
reverted
publishing
published
finishing_rollback
finished
```
