### PR TITLE
(v3) Use :default_env variable consistently in templates and codes

### DIFF
--- a/lib/capistrano/defaults.rb
+++ b/lib/capistrano/defaults.rb
@@ -2,7 +2,7 @@ set :scm, :git
 set :branch, :master
 set :deploy_to, "/var/www/#{fetch(:application)}"
 
-set :default_environment, {}
+set :default_env, {}
 set :keep_releases, 5
 
 set :format, :pretty

--- a/lib/capistrano/templates/deploy.rb.erb
+++ b/lib/capistrano/templates/deploy.rb.erb
@@ -13,5 +13,5 @@ ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }
 # set :linked_files, %w{config/database.yml}
 # set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
 
-# set :default_environment, { path: "/opt/ruby/bin:$PATH" }
+# set :default_env, { path: "/opt/ruby/bin:$PATH" }
 # set :keep_releases, 5

--- a/lib/capistrano/templates/stage.rb.erb
+++ b/lib/capistrano/templates/stage.rb.erb
@@ -39,4 +39,4 @@ server 'example.com', user: 'deploy', roles: %w{web app}, my_property: :my_value
 #   }
 # setting per server overrides global ssh_options
 
-# set :rails_env, :<%= stage %>
+# fetch(:default_env).merge!(:rails_env, :<%= stage %>)


### PR DESCRIPTION
The `:default_env` variable is used when instantiate SSHKit, but this variable is not set in anywhere else.

This patch replaces `:default_environment` that appears in templates and codes with `:default_env`, I assume they mean the same thing. 

It also updated stage template to add `:rails_env` into `:default_env`.
