### PR TITLE
Do not require strategy if strategy constant is already defined.

### DIFF
--- a/lib/capistrano/recipes/deploy/strategy.rb
+++ b/lib/capistrano/recipes/deploy/strategy.rb
@@ -3,9 +3,10 @@ module Capistrano
     module Strategy
       def self.new(strategy, config={})
         strategy_file = "capistrano/recipes/deploy/strategy/#{strategy}"
-        require(strategy_file)
-
         strategy_const = strategy.to_s.capitalize.gsub(/_(.)/) { $1.upcase }
+
+        require(strategy_file) unless const_defined?(strategy_const)
+
         if const_defined?(strategy_const)
           const_get(strategy_const).new(config)
         else


### PR DESCRIPTION
This makes it easier to define one off custom strategies without messing with LOAD_PATH.
