### PR TITLE
Update servers.rb to fix documentation.

### DIFF
--- a/lib/capistrano/configuration/servers.rb
+++ b/lib/capistrano/configuration/servers.rb
@@ -14,7 +14,7 @@ module Capistrano
       # an array of host names or ServerDefinition instances), a :roles
       # option (specifying an array of roles), an :only option (specifying
       # a hash of key/value pairs that any matching server must match),
-      # an :exception option (like :only, but the inverse), and a
+      # an :except option (like :only, but the inverse), and a
       # :skip_hostfilter option to ignore the HOSTFILTER environment variable
       # described below.
       #


### PR DESCRIPTION
After reading through the code a bit noticed that the comment at the top of `#find_servers_for_tasks` is referencing the wrong option.
