### PR TITLE
Update roles.rb to for proper documentation.

### DIFF
--- a/lib/capistrano/configuration/roles.rb
+++ b/lib/capistrano/configuration/roles.rb
@@ -63,6 +63,12 @@ module Capistrano
       # the roles as the remaining parameters:
       #
       #   server "master.example.com", :web, :app
+      #
+      # Also, you can specify additional information
+      # (in the form of a Hash) which can be used to more uniquely specify the
+      # subset of servers specified by this specific definition:
+      #
+      #   server "master.example.com", :db, :primary => true
       def server(host, *roles)
         options = roles.last.is_a?(Hash) ? roles.pop : {}
         raise ArgumentError, "you must associate a server with at least one role" if roles.empty?


### PR DESCRIPTION
The last item in the `roles` argument, if it is a Hash, will actually pass as the options when filtering out the roles. This is extremely useful behavior and should be documented.
