### PR TITLE
Add _cset to be a proper configuration DSL.

### DIFF
--- a/lib/capistrano/configuration/variables.rb
+++ b/lib/capistrano/configuration/variables.rb
@@ -37,6 +37,15 @@ module Capistrano
 
       alias :[]= :set
 
+      # Conditionally set a variable if it is not already set.
+      def cset(name, *args, &block)
+        unless exists?(name)
+          set(name, *args, &block)
+        end
+      end
+      
+      alias :_cset :cset
+
       # Removes any trace of the given variable.
       def unset(variable)
         sym = variable.to_sym

--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -5,12 +5,6 @@ require "yaml"
 require "capistrano/recipes/deploy/scm"
 require "capistrano/recipes/deploy/strategy"
 
-def _cset(name, *args, &block)
-  unless exists?(name)
-    set(name, *args, &block)
-  end
-end
-
 # =========================================================================
 # These variables MUST be set in the client capfiles. If they are not set,
 # the deploy will fail with an error.


### PR DESCRIPTION
This is an extremely useful property in the deploy recipe. I have run into several problems where, to not have to re-implement it several times, I just loaded the `deploy` recipe without it actually being necessary.
