### PR TITLE
Fixed scm_username, scm_password variables not correctly passed subversion command

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/subversion.rb
+++ b/lib/capistrano/recipes/deploy/scm/subversion.rb
@@ -97,8 +97,8 @@ module Capistrano
           def authentication
             username = variable(:scm_username)
             return "" unless username
-            result = %(--username "#{variable(:scm_username)}")
-            result << %(--password "#{variable(:scm_password)}") unless variable(:scm_auth_cache) || variable(:scm_prefer_prompt)
+            result = %(--username "#{variable(:scm_username)}" )
+            result << %(--password "#{variable(:scm_password)}" ) unless variable(:scm_auth_cache) || variable(:scm_prefer_prompt)
             result << "--no-auth-cache " unless variable(:scm_auth_cache)
             result
           end


### PR DESCRIPTION
After upgrading to 2.15.5 our build scripts stopped to work: deploy:update_code started asking for password to subversion. It turns out to be a problem with missing spaces for rendering svn command options.
