### PR TITLE
Deploy via branchless bundle failing.

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/git.rb
+++ b/lib/capistrano/recipes/deploy/scm/git.rb
@@ -136,7 +136,7 @@ module Capistrano
           args = []
 
           # Add an option for the branch name so :git_shallow_clone works with branches
-          args << "-b #{variable(:branch)}" unless variable(:branch).nil? || variable(:branch) == revision
+          args << "-b #{variable(:branch)}" unless variable(:branch).nil? || variable(:branch) == revision || variable(:git_bundle)
           args << "-o #{remote}" unless remote == 'origin'
           if depth = variable(:git_shallow_clone)
             args << "--depth #{depth}"


### PR DESCRIPTION
We deploy via a bundle that does not have any tags or branches.  The issue is the addition of the "-b <branch>", shown in the outputs of each operation for two revisions below: 

v2.15.4 (does not work):

```
git clone -b <branch> --depth 1 <bundle file> <destination>
```

v.2.14.2 (works)

```
git clone --depth 1 <bundle file> <destination>  
```

I traced the problem for us to 6f84111.  

If we are deploying the master branch from a repo, v2.15.4 will attempt to clone branch master from the bundle, which does not work since the bundle is only a collection of refs.
