### PR TITLE
Fix for incorrect symlink creation

### DIFF
--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -94,7 +94,7 @@ namespace :deploy do
           target = release_path.join(dir)
           source = shared_path.join(dir)
           unless test "[ -L #{target} ]"
-            if test "[ -f #{target} ]"
+            if test "[ -d #{target} ]"
               execute :rm, '-rf', target
             end
             execute :ln, '-s', source, target


### PR DESCRIPTION
The symlink for the log directory was being incorrectly created under the existing log folder under the current release path, instead of replacing that directory with the symlink.  This was because the test to see if the folder exists was done with the -f flag, which incorrectly returns false if the target is a directory.  

From the bash man page:

```
   -d file
          True if file exists and is a directory.
   -f file
          True if file exists and is a regular file.
```

The fix changes the test to -d to correctly check if the directory exists.
