### PR TITLE
Also define RACK_ENV for migrate task

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -435,7 +435,7 @@ namespace :deploy do
       else raise ArgumentError, "unknown migration target #{migrate_target.inspect}"
       end
 
-    run "cd #{directory} && #{rake} RAILS_ENV=#{rails_env} #{migrate_env} db:migrate"
+    run "cd #{directory} && #{rake} RAILS_ENV=#{rails_env} RACK_ENV=#{rails_env} #{migrate_env} db:migrate"
   end
 
   desc <<-DESC


### PR DESCRIPTION
When using ActiveRecord outside of Rails with for example https://github.com/janko-m/sinatra-activerecord you need to set `RACK_ENV` since Sinatra does not look at `RACK_ENV`.

This quick fix puts both `RAILS_ENV` and `RACK_ENV` in the command.

Another way might be to define which variable to use (`RAILS_ENV` or `RACK_ENV`) throughout the whole script.
