### PR TITLE
Use `sudo` for initial creation of shared/releases

### DIFF
--- a/lib/capistrano/dsl.rb
+++ b/lib/capistrano/dsl.rb
@@ -43,6 +43,18 @@ module Capistrano
       VersionValidator.new(locked_version).verify
     end
 
+    def user
+      fetch(:user) { fail t(:user_not_set) }
+    end
+
+    def group
+      fetch(:group) { fail t(:group_not_set) }
+    end
+
+    def user_group
+      [user, group].join(':')
+    end
+
   end
 end
 self.extend Capistrano::DSL

--- a/lib/capistrano/i18n.rb
+++ b/lib/capistrano/i18n.rb
@@ -11,6 +11,8 @@ en = {
   finishing:                   'Finishing',
   finished:                    'Finished',
   stage_not_set:               'Stage not set, please call something such as `cap production deploy`, where production is a stage you have defined.',
+  user_not_set:                'User not set, please add `set :user, "username" to your configuration',
+  group_not_set:               'Group not set, please add `set :group, "group_name" to your configuration',
   written_file:                'create %{file}',
   question:                    'Please enter %{key}: |%{default_value}|',
   keeping_releases:            'Keeping %{keep_releases} of %{releases} deployed releases on %{host}',

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -42,7 +42,8 @@ namespace :deploy do
     desc 'Check shared and release directories exist'
     task :directories do
       on roles :all do
-        execute :mkdir, '-pv', shared_path, releases_path
+        sudo :mkdir, '-pv', shared_path, releases_path
+        sudo :chown, user_group, shared_path, releases_path
       end
     end
 

--- a/spec/lib/capistrano/dsl_spec.rb
+++ b/spec/lib/capistrano/dsl_spec.rb
@@ -59,5 +59,25 @@ module Capistrano
         dsl.sudo(:my, :command)
       end
     end
+
+    describe '#user' do
+      subject { dsl.user }
+
+      context 'user does not exist' do
+        it 'fails' do
+          expect { subject }. to raise_error
+        end
+      end
+    end
+
+    describe '#group' do
+      subject { dsl.group }
+
+      context 'group does not exist' do
+        it 'fails' do
+          expect { subject }. to raise_error
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
First pass at resolving #447. This change creates shared and release directories using `sudo`, then
sets the permissions for the defined user and group. Fails with an error
message if user or group are not set.
