### PR TITLE
Implement `--dry-run` option

### DIFF
--- a/lib/capistrano/application.rb
+++ b/lib/capistrano/application.rb
@@ -13,7 +13,7 @@ module Capistrano
     end
 
     def sort_options(options)
-      options.push(version)
+      options.push(version,dry_run)
       super
     end
 
@@ -52,6 +52,15 @@ module Capistrano
        lambda { |value|
          puts "Capistrano Version: #{Capistrano::VERSION} (Rake Version: #{RAKEVERSION})"
          exit
+       }
+      ]
+    end
+
+    def dry_run
+      ['--dry-run', '-n',
+       "Do a dry run without executing actions",
+       lambda { |value|
+         Configuration.env.set(:sshkit_backend, SSHKit::Backend::Printer)
        }
       ]
     end

--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -56,6 +56,7 @@ module Capistrano
         sshkit.format           = fetch(:format)
         sshkit.output_verbosity = fetch(:log_level)
         sshkit.default_env      = fetch(:default_env)
+        sshkit.backend          = fetch(:sshkit_backend, SSHKit::Backend::Netssh)
         sshkit.backend.configure do |backend|
           backend.pty                = fetch(:pty)
           backend.connection_timeout = fetch(:connection_timeout)


### PR DESCRIPTION
By passing `--dry-run` or `-n`, Capistrano will configure `SSHKit` to
use the `Printer` backend.

Usage:

```
cap production deploy --dry-run
```

This, in combination with a change to SSHKit, fixes #444
