### PR TITLE
Fixed default capfile

### DIFF
--- a/lib/capistrano/templates/Capfile
+++ b/lib/capistrano/templates/Capfile
@@ -36,7 +36,7 @@ namespace :deploy do
   after :restart, :clear_cache do
     on roles(:web), in: :groups, limit: 3, wait: 10 do
       # Here we can do anything such as:
-      # within latest_release_path do
+      # within release_path do
       #   execute :rake, 'cache:clear'
       # end
     end


### PR DESCRIPTION
`latest_release_path` helper doesn't exist, but default `Capfile` contains it.
