### PR TITLE
spaces around password svn option

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/subversion.rb
+++ b/lib/capistrano/recipes/deploy/scm/subversion.rb
@@ -97,10 +97,11 @@ module Capistrano
           def authentication
             username = variable(:scm_username)
             return "" unless username
-            result = %(--username "#{variable(:scm_username)}")
-            result << %( --password "#{variable(:scm_password)} ") unless variable(:scm_auth_cache) || variable(:scm_prefer_prompt)
+            result = []
+            result << %(--username "#{variable(:scm_username)}")
+            result << %(--password "#{variable(:scm_password)}") unless variable(:scm_auth_cache) || variable(:scm_prefer_prompt)
             result << "--no-auth-cache " unless variable(:scm_auth_cache)
-            result
+            result.join(' ')
           end
 
           # If verbose output is requested, return nil, otherwise return the


### PR DESCRIPTION
There are should be spaces around --password option for subversion. As for now when I use 

set :scm, :subversion
set :scm_username, 'deploy'
set :scm_password, 'password-here'

(I know its not very secure etc, but that's how the things are for the time being)
capistrano tries to execute something like

svn info svn://<repo.url> --username \"deploy\"--password \"password-here\"--no-auth-cache  -rHEAD

Of course it fails and then svn asks me for password for 'deploy--password' user.
Addings spaces around the password option fixes this behavior.
