### PR TITLE
Git remote repository added to the rev-parse command.

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/git.rb
+++ b/lib/capistrano/recipes/deploy/scm/git.rb
@@ -239,7 +239,7 @@ module Capistrano
           return newrev if newrev =~ /^[0-9a-f]{40}$/
 
           # If sha is not found on remote, try expanding from local repository
-          command = scm('rev-parse --revs-only', revision)
+          command = scm('rev-parse --revs-only', origin + '/' + revision)
           newrev = yield(command).to_s.strip
 
           raise "Unable to resolve revision for '#{revision}' on repository '#{repository}'." unless newrev =~ /^[0-9a-f]{40}$/


### PR DESCRIPTION
Hello

In some cases I had some problems with the query_revision method of the Git class. For example if you perform a deploy with a specific revision, a git reset command is executed. If you want to deploy again an older revision, you may encounter a problem due to the state of your local copy.

Doing a rev-parse from the origin is, I think, more consistent.

Regards,
Martial
