### PR TITLE
Add a task to load defaults

### DIFF
--- a/lib/capistrano/setup.rb
+++ b/lib/capistrano/setup.rb
@@ -1,10 +1,15 @@
 include Capistrano::DSL
 
-load 'capistrano/defaults.rb'
+namespace :load do
+  task :defaults do
+    load 'capistrano/defaults.rb'
+    load 'config/deploy.rb'
+  end
+end
 
 stages.each do |stage|
   Rake::Task.define_task(stage) do
-    load "config/deploy.rb"
+    invoke 'load:defaults'
     load "config/deploy/#{stage}.rb"
     load "capistrano/#{fetch(:scm)}.rb"
     set(:stage, stage.to_sym)
@@ -12,6 +17,5 @@ stages.each do |stage|
     configure_backend
   end
 end
-
 
 require 'capistrano/dotfile'


### PR DESCRIPTION
Now gems can implement a 'load:defaults' task in order to set any
defaults that may rely on other varibles set in stage configuration.

```
namespace :load do
  task :defaults do
    set :my_file, release_path.join('my_file')
  end
end
```
