### PR TITLE
Ensure `release_path` returns the correct value

### DIFF
--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -20,6 +20,10 @@ module Capistrano
       config[key] = value
     end
 
+    def delete(key)
+      config.delete(key)
+    end
+
     def fetch(key, default=nil, &block)
       value = fetch_for(key, default, &block)
       if value.respond_to?(:call)

--- a/lib/capistrano/dsl.rb
+++ b/lib/capistrano/dsl.rb
@@ -32,7 +32,7 @@ module Capistrano
     end
 
     def rollback_log_message
-      t(:rollback_log_message, user: local_user, release: release_timestamp)
+      t(:rollback_log_message, user: local_user, release: fetch(:rollback_timestamp))
     end
 
     def local_user

--- a/lib/capistrano/dsl/env.rb
+++ b/lib/capistrano/dsl/env.rb
@@ -23,6 +23,10 @@ module Capistrano
         env.set(key, value)
       end
 
+      def delete(key)
+        env.delete(key)
+      end
+
       def ask(key, value)
         env.ask(key, value)
       end

--- a/lib/capistrano/dsl/paths.rb
+++ b/lib/capistrano/dsl/paths.rb
@@ -20,7 +20,11 @@ module Capistrano
       end
 
       def release_path
-        releases_path.join(release_timestamp)
+        fetch(:release_path, current_path)
+      end
+
+      def set_release_path(timestamp=now)
+        set(:release_path, releases_path.join(timestamp))
       end
 
       def repo_url
@@ -52,9 +56,8 @@ module Capistrano
         deploy_path.join('revisions.log')
       end
 
-      def release_timestamp
-        fetch(:rollback_release_timestamp,
-              env.timestamp.strftime("%Y%m%d%H%M%S"))
+      def now
+        env.timestamp.strftime("%Y%m%d%H%M%S")
       end
 
       def asset_timestamp

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -4,7 +4,7 @@ namespace :deploy do
     invoke 'deploy:check'
   end
 
-  task :updating do
+  task :updating => :new_release_path do
     invoke "#{scm}:create_release"
     invoke 'deploy:symlink:shared'
   end
@@ -162,12 +162,28 @@ namespace :deploy do
   end
 
   desc 'Revert to previous release timestamp'
-  task :revert_release do
+  task :revert_release => :rollback_release_path do
+    on roles(:all) do
+      set(:revision_log_message, rollback_log_message)
+    end
+  end
+
+  task :new_release_path do
+    set_release_path
+  end
+
+  task :last_release_path do
     on roles(:all) do
       last_release = capture(:ls, '-xr', releases_path).split[1]
-      set(:rollback_release_timestamp, last_release)
-      set(:branch, last_release)
-      set(:revision_log_message, rollback_log_message)
+      set_release_path(last_release)
+    end
+  end
+
+  task :rollback_release_path do
+    on roles(:all) do
+      last_release = capture(:ls, '-xr', releases_path).split[1]
+      set_release_path(last_release)
+      set(:rollback_timestamp, last_release)
     end
   end
 

--- a/spec/integration/deploy_finished_spec.rb
+++ b/spec/integration/deploy_finished_spec.rb
@@ -15,6 +15,7 @@ describe 'cap deploy:finished', slow: true do
         server 'localhost', roles: %w{web app}, user: '#{current_user}'
         set :linked_files, %w{config/database.yml}
         set :linked_dirs, %w{bin log public/system vendor/bundle}
+        set :release_path, '#{deploy_to}/releases/1234'
         }
     }
 
@@ -23,12 +24,13 @@ describe 'cap deploy:finished', slow: true do
         cap 'deploy:started'
         cap 'deploy:updating'
         cap 'deploy:publishing'
+        cap 'deploy:finished'
       end
 
       describe 'release' do
         it 'symlinks the release to `current`' do
           expect(File.symlink?(current_path)).to be_true
-          expect(File.readlink(current_path)).to match /\/tmp\/test_app\/deploy_to\/releases\/\d{14}/
+          expect(File.readlink(current_path)).to eq '/tmp/test_app/deploy_to/releases/1234'
         end
       end
     end

--- a/spec/integration/deploy_update_spec.rb
+++ b/spec/integration/deploy_update_spec.rb
@@ -20,16 +20,15 @@ describe 'cap deploy:updating', slow: true do
 
     describe 'symlink' do
       before do
-        cap 'deploy:started'
         create_shared_directory('config')
         create_shared_file('config/database.yml')
-        cap 'deploy:symlink:shared'
+        cap 'deploy'
       end
 
       describe 'linked_dirs' do
         it 'symlinks the directories in shared to `current`' do
           %w{bin log public/system vendor/bundle}.each do |dir|
-            expect(release_path.join(dir)).to be_a_symlink_to shared_path.join(dir)
+            expect(current_path.join(dir)).to be_a_symlink_to shared_path.join(dir)
           end
         end
       end
@@ -37,7 +36,7 @@ describe 'cap deploy:updating', slow: true do
       describe 'linked_files' do
         it 'symlinks the files in shared to `current`' do
           file = 'config/database.yml'
-          expect(release_path.join(file)).to be_a_symlink_to shared_path.join(file)
+          expect(current_path.join(file)).to be_a_symlink_to shared_path.join(file)
         end
       end
     end

--- a/spec/integration/dsl_spec.rb
+++ b/spec/integration/dsl_spec.rb
@@ -284,4 +284,61 @@ describe Capistrano::DSL do
 
   end
 
+  describe 'release path' do
+
+    before do
+      dsl.set(:deploy_to, '/var/www')
+    end
+
+    describe 'fetching release path' do
+      subject { dsl.release_path }
+
+      context 'where no release path has been set' do
+        before do
+          dsl.delete(:release_path)
+        end
+
+        it 'returns the `current_path` value' do
+          expect(subject.to_s).to eq '/var/www/current'
+        end
+      end
+
+      context 'where the release path has been set' do
+        before do
+          dsl.set(:release_path, '/var/www/release_path')
+        end
+
+        it 'returns the set `release_path` value' do
+          expect(subject.to_s).to eq '/var/www/release_path'
+        end
+      end
+    end
+
+    describe 'setting release path' do
+      let(:now) { Time.parse("Oct 21 16:29:00 2015") }
+      subject { dsl.release_path }
+
+      context 'without a timestamp' do
+        before do
+          dsl.env.expects(:timestamp).returns(now)
+          dsl.set_release_path
+        end
+
+        it 'returns the release path with the current env timestamp' do
+          expect(subject.to_s).to eq '/var/www/releases/20151021162900'
+        end
+      end
+
+      context 'with a timestamp' do
+        before do
+          dsl.set_release_path('timestamp')
+        end
+
+        it 'returns the release path with the timestamp' do
+          expect(subject.to_s).to eq '/var/www/releases/timestamp'
+        end
+      end
+    end
+
+  end
 end

--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -62,6 +62,17 @@ module Capistrano
       end
     end
 
+    describe 'deleting' do
+      before do
+        config.set(:key, :value)
+      end
+
+      it 'deletes the value' do
+        config.delete(:key)
+        expect(config.fetch(:key)).to be_nil
+      end
+    end
+
     describe 'asking' do
       let(:question) { stub }
 


### PR DESCRIPTION
`release_path` will now return the value of `current_path` by default.

Tasks that create a new release (i.e. `deploy`) now explicitly over-ride this
default with a new release path.  This change allows tasks that run in both
deploy and non-deploy contexts to use `release_path` to target the latest
 release when run in isolation, and the new release (before it is `current`)
when run as part of a deploy.
