### PR TITLE
Added -h flag to tar command for copy strategy

### DIFF
--- a/lib/capistrano/recipes/deploy/strategy/copy.rb
+++ b/lib/capistrano/recipes/deploy/strategy/copy.rb
@@ -299,7 +299,7 @@ module Capistrano
 
             type = configuration[:copy_compression] || :gzip
             case type
-            when :gzip, :gz   then Compression.new("tar.gz",  [local_tar, 'czf'], [remote_tar, 'xzf'])
+            when :gzip, :gz   then Compression.new("tar.gz",  [local_tar, 'czfh'], [remote_tar, 'xzf'])
             when :bzip2, :bz2 then Compression.new("tar.bz2", [local_tar, 'cjf'], [remote_tar, 'xjf'])
             when :zip         then Compression.new("zip",     %w(zip -qyr), %w(unzip -q))
             else raise ArgumentError, "invalid compression type #{type.inspect}"


### PR DESCRIPTION
The -h flag will force tar to follow symbolic links as if they were
normal files. This behavior is useful when sharing code between
projects.
