### PR TITLE
Use `git archive` to create release

### DIFF
--- a/lib/capistrano/tasks/git.rake
+++ b/lib/capistrano/tasks/git.rake
@@ -52,11 +52,8 @@ namespace :git do
     on roles :all do
       with git_environmental_variables do
         within repo_path do
-          execute :git, :clone, '--branch', fetch(:branch),               \
-            '--depth 1',                                                  \
-            '--recursive',                                                \
-            '--no-hardlinks',                                             \
-            repo_path, release_path
+          execute :mkdir, '-p', release_path
+          execute :git, :archive, fetch(:branch), '| tar -x -C', release_path
         end
       end
     end


### PR DESCRIPTION
This commit replaces `checkout` with `archive`, allowing files and
folder to be excluded by include a `.gitattributes` file in the repo:

```
features/ export-ignore
spec/     export-ignore
```

This provides `copy_exclude` behaviour discussed in #515
