### PR TITLE
Shoot at fixing #627.

### DIFF
--- a/lib/capistrano/i18n.rb
+++ b/lib/capistrano/i18n.rb
@@ -14,6 +14,7 @@ en = {
   written_file:                'create %{file}',
   question:                    'Please enter %{key}: |%{default_value}|',
   keeping_releases:            'Keeping %{keep_releases} of %{releases} deployed releases on %{host}',
+  no_old_releases:             'No old releases (keeping newest %{keep_releases}) on %{host}',
   linked_file_does_not_exist:  'linked file %{file} does not exist on %{host}',
   mirror_exists:               "The repository mirror is at %{at}",
   revision_log_message:        'Branch %{branch} deployed as release %{release} by %{user}',

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -129,9 +129,15 @@ namespace :deploy do
       releases = capture(:ls, '-x', releases_path).split
       if releases.count >= fetch(:keep_releases)
         info t(:keeping_releases, host: host.to_s, keep_releases: fetch(:keep_releases), releases: releases.count)
-        directories = (releases - releases.last(fetch(:keep_releases))).map { |release|
-          releases_path.join(release) }.join(" ")
-        execute :rm, '-rf', directories
+        directories = (releases - releases.last(fetch(:keep_releases)))
+        if directories.any?
+          directories_str = directories.map do |release|
+            releases_path.join(release)
+          end.join(" ")
+          execute :rm, '-rf', directories_str
+        else
+          info t(:no_old_releases, host: host.to_s, keep_releases: fetch(:keep_releases))
+        end
       end
     end
   end


### PR DESCRIPTION
This patch checks the list of releas directories first, assuming that
the list returned is an array (i.e responds to `#any?()`). If true then
an `rm` is called after mapping the release names onto the end of the
release path (`#join()`). In case the old release directories list is
empty, then an info message is broadcast through the i18n system
indicating that there is no work to be done.

@seenmyfate one thing is not clear to me here, which is what happens if
two servers have differing release lists, it appears that as we're
inside an `on()`, the `capture()` and all subsequent conditionals should
be host specific, which is important if we concatenate the list of
release directories and expect that one single `rm` command can rule
them all?
