### PR TITLE
Fixed unexpected variable escaping in svn

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/subversion.rb
+++ b/lib/capistrano/recipes/deploy/scm/subversion.rb
@@ -97,9 +97,9 @@ module Capistrano
           def authentication
             username = variable(:scm_username)
             return "" unless username
-            result = %(--username "#{variable(:scm_username)}")
-            result << %(--password "#{variable(:scm_password)}") unless variable(:scm_auth_cache) || variable(:scm_prefer_prompt)
-            result << "--no-auth-cache " unless variable(:scm_auth_cache)
+            result = %( --username '#{variable(:scm_username)}')
+            result << %( --password '#{variable(:scm_password)}') unless variable(:scm_auth_cache) || variable(:scm_prefer_prompt)
+            result << " --no-auth-cache " unless variable(:scm_auth_cache)
             result
           end
 


### PR DESCRIPTION
I was unable to deploy via SVN, because doublequotes around 'username' and 'password' variables were escaped with backslash, plus there was no space after last doublequote, so generated command was incorrect
`executing locally: "svn info https://mysvnserver.com/trunk --username \"myusername\"--password \"mypassword\"--no-auth-cache  -rHEAD"`

After this fix command ran properly.
`executing locally: "svn info https://mysvnserver.com/trunk  --username 'myusername' --password 'mypassword' --no-auth-cache  -rHEAD"
`

I haven't tested it on anything else but my computer. 

Windows 7 x64
ruby 1.9.3p448 (2013-06-27) [i386-cygwin]
Capistrano v2.15.5

I know this fix is little nasty, but since I don't know ruby, I was unable to dig deeper.
