### PR TITLE
redefining password and username way to fetch from subversion

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/subversion.rb
+++ b/lib/capistrano/recipes/deploy/scm/subversion.rb
@@ -100,6 +100,7 @@ module Capistrano
             result = %(--username '#{variable(:scm_username)}' )
             result << %(--password '#{variable(:scm_password)}' ) unless variable(:scm_auth_cache) || variable(:scm_prefer_prompt)
             result << "--no-auth-cache " unless variable(:scm_auth_cache)
+            result << " --trust-server-cert --non-interactive "
             result
           end
 


### PR DESCRIPTION
When I try to deploy using subversion the string that is generated for the command svn info is 

```
svn info https://svn.mydomain.com/my_repo --username \"myusername"\--password \"mypassword\"--no-auth-cache  -rHEAD
```

this causes the command not to work properly. So I changed the double quotes for single quotes and gave some spaces at the code so the string now is

```
svn info https://svn.mydomain.com/my_repo --username 'myusername' --password 'mypassword' --no-auth-cache  -rHEAD
```

This issue happens with versions 2.0.0-p247 and 1.9.3-p448
