### PR TITLE
Split creation of linked files dirs from testing the files

### DIFF
--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -35,6 +35,7 @@ namespace :deploy do
     invoke "#{scm}:check"
     invoke 'deploy:check:directories'
     invoke 'deploy:check:linked_dirs'
+    invoke 'deploy:check:make_linked_dirs'
     invoke 'deploy:check:linked_files'
   end
 
@@ -53,12 +54,19 @@ namespace :deploy do
         execute :mkdir, '-pv', linked_dirs(shared_path)
       end
     end
+    
+    desc 'Check directories of files to be linked exist in shared'
+    task :make_linked_dirs do
+      next unless any? :linked_files
+      on roles :app do |host|
+        execute :mkdir, '-pv', linked_file_dirs(shared_path)
+      end
+    end
 
     desc 'Check files to be linked exist in shared'
     task :linked_files do
       next unless any? :linked_files
       on roles :app do |host|
-        execute :mkdir, '-pv', linked_file_dirs(shared_path)
         linked_files(shared_path).each do |file|
           unless test "[ -f #{file} ]"
             error t(:linked_file_does_not_exist, file: file, host: host)


### PR DESCRIPTION
Now we can add hooks to after create a folder of linked files and testing files, because if just created a folder, so the file would not be exists anyway.

Example when we do the first deploy, there are no shared directory and config for `database.yml`. Lets put it to `shared_path/config/database.yml` and we would have the error, that the file is not exists.

So default soultion to create the `databse.yml` https://gist.github.com/miry/6700162 would not work. Because before `deploy:check:linked_files` the folder `shared_path/config` is not exists.
