### PR TITLE
To support a new changes from sshkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Add this line to your application's Gemfile:
 
 ``` ruby
 gem 'capistrano', github: 'capistrano/capistrano', branch: 'v3'
+gem 'sshkit', github: 'leehambley/sshkit'
 ```
 
 And then execute:


### PR DESCRIPTION
Now we could not to use latest commits from `sshkit` by gem. Example: to use `cap --dry-run deploy` would raise exception.

And we need this fix: https://github.com/leehambley/sshkit/commit/0e13c969da6a0e717b606cc67014dfd11c60a137
