### PR TITLE
update stage template to merge in a hash

### DIFF
--- a/lib/capistrano/templates/stage.rb.erb
+++ b/lib/capistrano/templates/stage.rb.erb
@@ -39,4 +39,4 @@ server 'example.com', user: 'deploy', roles: %w{web app}, my_property: :my_value
 #   }
 # setting per server overrides global ssh_options
 
-# fetch(:default_env).merge!(:rails_env, :<%= stage %>)
+# fetch(:default_env).merge!(rails_env: :<%= stage %>)


### PR DESCRIPTION
I updated the merge at the bottom of the stage template.
when merging the stage and rails_env together was trying to merge more then 2 arg and was getting an error.
I turned it into a hash which does not cause an error and I believe that is the original intent. 
