### PR TITLE
added the ability to set config through the enviroment

### DIFF
--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -11,13 +11,17 @@ module Capistrano
       end
     end
 
+    def initialize
+      ENV.each_pair{ |key, value| set(key, value) }
+    end
+
     def ask(key, default=nil)
       question = Question.new(self, key, default)
       set(key, question)
     end
 
     def set(key, value)
-      config[key] = value
+      config[key] = ENV[key.to_s] || value
     end
 
     def delete(key)


### PR DESCRIPTION
This pull request does 2 things.
One on the initialization of the app keys from the environment will be set in the app configuration.
Two when using set you wont set over the environment you gave the app.

so the command
`cap staging deploy branch=master`
will maintain the branch all the way through.
