### PR TITLE
Allow configuration location to be configurable

### DIFF
--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -1,0 +1,15 @@
+Feature: The path to the configuration can be changed, removing the need to
+  follow Ruby/Rails conventions
+
+  Background:
+    Given a test app with the default configuration
+    And servers with the roles app and web
+
+  Scenario: Deploying with configuration in default location
+    When I run "cap test"
+    Then the task is successful
+
+  Scenario: Deploying with configuration in a custom location
+    But the configuration is in a custom location
+    When I run "cap test"
+    Then the task is successful

--- a/features/step_definitions/assertions.rb
+++ b/features/step_definitions/assertions.rb
@@ -88,3 +88,7 @@ end
 Then(/^it will not recreate the file$/) do
   #
 end
+
+Then(/^the task is successful$/) do
+  expect(@success).to be_true
+end

--- a/features/step_definitions/cap_commands.rb
+++ b/features/step_definitions/cap_commands.rb
@@ -1,8 +1,12 @@
 When(/^I run cap "(.*?)"$/) do |task|
-  TestApp.cap(task)
+  @success = TestApp.cap(task)
 end
 
 When(/^I run cap "(.*?)" as part of a release$/) do |task|
   TestApp.cap("deploy:new_release_path #{task}")
+end
+
+When(/^I run "(.*?)"$/) do |command|
+  @success = TestApp.run(command)
 end
 

--- a/features/step_definitions/setup.rb
+++ b/features/step_definitions/setup.rb
@@ -23,3 +23,6 @@ Given(/^a custom task to generate a file$/) do
   TestApp.copy_task_to_test_app('spec/support/tasks/database.cap')
 end
 
+Given(/^the configuration is in a custom location$/) do
+  TestApp.move_configuration_to_custom_location('app')
+end

--- a/lib/capistrano/dsl/paths.rb
+++ b/lib/capistrano/dsl/paths.rb
@@ -27,6 +27,14 @@ module Capistrano
         set(:release_path, releases_path.join(timestamp))
       end
 
+      def stage_config_path
+        Pathname.new fetch(:stage_config_path, 'config/deploy')
+      end
+
+      def deploy_config_path
+        Pathname.new fetch(:deploy_config_path, 'config/deploy.rb')
+      end
+
       def repo_url
         require 'cgi'
         require 'uri'

--- a/lib/capistrano/dsl/stages.rb
+++ b/lib/capistrano/dsl/stages.rb
@@ -3,7 +3,14 @@ module Capistrano
     module Stages
 
       def stages
-        Dir['config/deploy/*.rb'].map { |f| File.basename(f, '.rb') }
+        Dir[stage_definitions].map { |f| File.basename(f, '.rb') }
+      end
+
+      def infer_stages_from_stage_files
+      end
+
+      def stage_definitions
+        stage_config_path.join('*.rb')
       end
 
       def stage_set?

--- a/lib/capistrano/setup.rb
+++ b/lib/capistrano/setup.rb
@@ -9,8 +9,8 @@ end
 stages.each do |stage|
   Rake::Task.define_task(stage) do
     invoke 'load:defaults'
-    load 'config/deploy.rb'
-    load "config/deploy/#{stage}.rb"
+    load deploy_config_path
+    load stage_config_path.join("#{stage}.rb")
     load "capistrano/#{fetch(:scm)}.rb"
     set(:stage, stage.to_sym)
     I18n.locale = fetch(:locale, :en)

--- a/spec/integration/dsl_spec.rb
+++ b/spec/integration/dsl_spec.rb
@@ -340,5 +340,53 @@ describe Capistrano::DSL do
       end
     end
 
+    describe 'setting deploy configuration path' do
+      subject { dsl.deploy_config_path.to_s }
+
+      context 'where no config path is set' do
+        before do
+          dsl.delete(:deploy_config_path)
+        end
+
+        it 'returns "config/deploy.rb"' do
+          expect(subject).to eq 'config/deploy.rb'
+        end
+      end
+
+      context 'where a custom path is set' do
+        before do
+          dsl.set(:deploy_config_path, 'my/custom/path.rb')
+        end
+
+        it 'returns the custom path' do
+          expect(subject).to eq 'my/custom/path.rb'
+        end
+      end
+    end
+
+    describe 'setting stage configuration path' do
+      subject { dsl.stage_config_path.to_s }
+
+      context 'where no config path is set' do
+
+        before do
+          dsl.delete(:stage_config_path)
+        end
+
+        it 'returns "config/deploy"' do
+          expect(subject).to eq 'config/deploy'
+        end
+      end
+
+      context 'where a custom path is set' do
+        before do
+          dsl.set(:stage_config_path, 'my/custom/path')
+        end
+
+        it 'returns the custom path' do
+          expect(subject).to eq 'my/custom/path'
+        end
+      end
+    end
   end
 end

--- a/spec/lib/capistrano/dsl_spec.rb
+++ b/spec/lib/capistrano/dsl_spec.rb
@@ -20,17 +20,6 @@ module Capistrano
       end
     end
 
-    describe '#stages' do
-      before do
-        Dir.expects(:[]).with('config/deploy/*.rb').
-          returns(['config/deploy/staging.rb', 'config/deploy/production.rb'])
-      end
-
-      it 'returns a list of defined stages' do
-        expect(dsl.stages).to eq %w{staging production}
-      end
-    end
-
     describe '#stage_set?' do
       subject { dsl.stage_set? }
 


### PR DESCRIPTION
This change allows both the `deploy_config_path` and `stage_config_path`
to be moved from the default locations of `config/deploy.rb` and
`config/deploy` respectively.  These values **must** be set in the
`Capfile` prior to `capistrano/setup` being called, for example:

```
set :deploy_config_path, 'app/config/deploy.rb'
set :stage_config_path, 'app/config/deploy'

# Load DSL and Setup Up Stages
require 'capistrano/setup'
```

Fixes #610
