### PR TITLE
Set default :pty value to false

### DIFF
--- a/lib/capistrano/defaults.rb
+++ b/lib/capistrano/defaults.rb
@@ -9,5 +9,4 @@ set :keep_releases, 5
 set :format, :pretty
 set :log_level, :debug
 
-set :pty, true
-
+set :pty, false


### PR DESCRIPTION
`:pty` had previously been incorrectly set to default to `true`

Closes issue #652
