### PR TITLE
Suggest users to require 'capistrano/rails'

### DIFF
--- a/lib/capistrano/templates/Capfile
+++ b/lib/capistrano/templates/Capfile
@@ -19,8 +19,7 @@ require 'capistrano/deploy'
 # require 'capistrano/rbenv'
 # require 'capistrano/chruby'
 # require 'capistrano/bundler'
-# require 'capistrano/rails/assets'
-# require 'capistrano/rails/migrations'
+# require 'capistrano/rails'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.cap').each { |r| import r }


### PR DESCRIPTION
Instead of `require 'capistrano/rails/assets'` and `require 'capistrano/rails/migrations'` to fix bug when `rails_env` was not set in [capistrano/rails/lib/capistrano/tasks/rails.rake](https://github.com/capistrano/rails/blob/master/lib/capistrano/tasks/rails.rake#L2)
