### PR TITLE
Warn developers that :all is a meta role

### DIFF
--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -34,6 +34,10 @@ module Capistrano
     end
 
     def role(name, hosts, options={})
+      if name == :all
+        raise ArgumentError.new("#{name} reserved name for role. Please choose another name")
+      end
+
       servers.add_role(name, hosts, options)
     end
 

--- a/lib/capistrano/templates/stage.rb.erb
+++ b/lib/capistrano/templates/stage.rb.erb
@@ -5,6 +5,7 @@ set :stage, :<%= stage %>
 # Supports bulk-adding hosts to roles, the primary
 # server in each group is considered to be the first
 # unless any hosts have the primary property set.
+# Don't declare `role :all`, it's a meta role
 role :app, %w{deploy@example.com}
 role :web, %w{deploy@example.com}
 role :db,  %w{deploy@example.com}

--- a/spec/integration/dsl_spec.rb
+++ b/spec/integration/dsl_spec.rb
@@ -70,6 +70,14 @@ describe Capistrano::DSL do
 
     end
 
+    describe 'when defining role with reserved name' do
+      it 'fails with ArgumentError' do
+        expect {
+          dsl.role :all, %w{example1.com}
+        }.to raise_error(ArgumentError, "all reserved name for role. Please choose another name")
+      end
+    end
+
     describe 'when defining hosts using the `role` syntax' do
       before do
         dsl.role :web, %w{example1.com example2.com example3.com}


### PR DESCRIPTION
We already had few reported issues (like #705) from developers who used role `:all`. This patch can prevent such cases.
