### PR TITLE
Set stage before requiring config/deploy.rb

### DIFF
--- a/lib/capistrano/setup.rb
+++ b/lib/capistrano/setup.rb
@@ -8,11 +8,12 @@ end
 
 stages.each do |stage|
   Rake::Task.define_task(stage) do
+    set(:stage, stage.to_sym)
+    
     invoke 'load:defaults'
     load 'config/deploy.rb'
     load "config/deploy/#{stage}.rb"
     load "capistrano/#{fetch(:scm)}.rb"
-    set(:stage, stage.to_sym)
     I18n.locale = fetch(:locale, :en)
     configure_backend
   end


### PR DESCRIPTION
Now we're not able to access stage name from `config/deploy.rb`, which may be useful in some cases.
