### PR TITLE
Default stage template cleanup

### DIFF
--- a/lib/capistrano/templates/stage.rb.erb
+++ b/lib/capistrano/templates/stage.rb.erb
@@ -1,5 +1,3 @@
-set :stage, :<%= stage %>
-
 # Simple Role Syntax
 # ==================
 # Supports bulk-adding hosts to roles, the primary

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -8,7 +8,6 @@ module TestApp
 
   def default_config
     %{
-      set :stage, :#{stage}
       set :deploy_to, '#{deploy_to}'
       set :repo_url, 'git://github.com/capistrano/capistrano.git'
       set :branch, 'v3'


### PR DESCRIPTION
Since `stage` is already set (https://github.com/capistrano/capistrano/pull/712), we don't need to declare it twice here.
