### PR TITLE
Fix NilClass error when flattening required roles.

### DIFF
--- a/lib/capistrano/configuration/servers/role_filter.rb
+++ b/lib/capistrano/configuration/servers/role_filter.rb
@@ -22,6 +22,7 @@ module Capistrano
         private
 
         def required
+          return [] unless (@required.select { |req| req.nil? }).empty?
           Array(@required).flat_map(&:to_sym)
         end
 


### PR DESCRIPTION
When I remotely `bundle install`, I get the following error:

```
cap aborted!
undefined method `to_sym' for nil:NilClass
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/gems/capistrano-3.0.0/lib/capistrano/configuration/servers/role_filter.rb:32:in `each'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/gems/capistrano-3.0.0/lib/capistrano/configuration/servers/role_filter.rb:32:in `flat_map'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/gems/capistrano-3.0.0/lib/capistrano/configuration/servers/role_filter.rb:32:in `required'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/gems/capistrano-3.0.0/lib/capistrano/configuration/servers/role_filter.rb:15:in `roles'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/gems/capistrano-3.0.0/lib/capistrano/configuration/servers/role_filter.rb:11:in `for'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/gems/capistrano-3.0.0/lib/capistrano/configuration/servers.rb:45:in `fetch_roles'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/gems/capistrano-3.0.0/lib/capistrano/configuration/servers.rb:18:in `roles_for'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/gems/capistrano-3.0.0/lib/capistrano/configuration.rb:45:in `roles_for'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/gems/capistrano-3.0.0/lib/capistrano/dsl/env.rb:43:in `roles'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/gems/capistrano-bundler-1.0.0/lib/capistrano/tasks/bundler.cap:18:in `block (2 levels) in <top (required)>'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/gems/capistrano-3.0.0/lib/capistrano/dsl.rb:14:in `invoke'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/gems/capistrano-3.0.0/lib/capistrano/tasks/framework.rake:64:in `block (2 levels) in <top (required)>'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/gems/capistrano-3.0.0/lib/capistrano/tasks/framework.rake:63:in `each'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/gems/capistrano-3.0.0/lib/capistrano/tasks/framework.rake:63:in `block in <top (required)>'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/gems/capistrano-3.0.0/lib/capistrano/application.rb:12:in `run'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/gems/capistrano-3.0.0/bin/cap:3:in `<top (required)>'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/bin/cap:23:in `load'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/bin/cap:23:in `<main>'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/bin/ruby_noexec_wrapper:14:in `eval'
/Users/dsherk/.rvm/gems/ruby-2.0.0-p247/bin/ruby_noexec_wrapper:14:in `<main>'
Tasks: TOP => deploy:updated => bundler:install
(See full trace by running task with --trace)
```

This pull request fixes this issue. I'm not sure if this is the optimal method or not.
