### PR TITLE
Don't hardcode :restart task in deploy cycle

### DIFF
--- a/lib/capistrano/i18n.rb
+++ b/lib/capistrano/i18n.rb
@@ -7,7 +7,6 @@ en = {
   start:                       'Start',
   update:                      'Update',
   finalize:                    'Finalise',
-  restart:                     'Restart',
   finishing:                   'Finishing',
   finished:                    'Finished',
   stage_not_set:               'Stage not set, please call something such as `cap production deploy`, where production is a stage you have defined.',

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -15,7 +15,6 @@ namespace :deploy do
 
   task :publishing do
     invoke 'deploy:symlink:release'
-    invoke 'deploy:restart'
   end
 
   task :finishing do

--- a/lib/capistrano/templates/deploy.rb.erb
+++ b/lib/capistrano/templates/deploy.rb.erb
@@ -17,6 +17,7 @@ set :repo_url, 'git@example.com:me/my_repo.git'
 # set :keep_releases, 5
 
 namespace :deploy do
+  after :publishing, :restart
 
   desc 'Restart application'
   task :restart do


### PR DESCRIPTION
Moving :restart into confing/deploy.rb example
Fixed #692

I suppose that we can't break 3.0 with removing `:restart` task and it's better to push it into 3.1.
