### PR TITLE
move the git ssh helper to application path

### DIFF
--- a/lib/capistrano/tasks/git.rake
+++ b/lib/capistrano/tasks/git.rake
@@ -1,8 +1,10 @@
 namespace :git do
 
-  git_environmental_variables = {
-    git_askpass: "/bin/echo",
-    git_ssh:     "#{fetch(:tmp_dir)}/#{fetch(:application)}/git-ssh.sh"
+  set :git_environmental_variables, ->() {
+    {
+      git_askpass: "/bin/echo",
+      git_ssh:     "#{fetch(:tmp_dir)}/#{fetch(:application)}/git-ssh.sh"
+    }
   }
 
   desc 'Upload the git wrapper script, this script guarantees that we can script git without getting an interactive prompt'
@@ -18,7 +20,7 @@ namespace :git do
   task check: :'git:wrapper' do
     fetch(:branch)
     on roles :all do
-      with git_environmental_variables do
+      with fetch(:git_environmental_variables) do
         exit 1 unless test :git, :'ls-remote', repo_url
       end
     end
@@ -31,7 +33,7 @@ namespace :git do
         info t(:mirror_exists, at: repo_path)
       else
         within deploy_path do
-          with git_environmental_variables do
+          with fetch(:git_environmental_variables) do
             execute :git, :clone, '--mirror', repo_url, repo_path
           end
         end
@@ -51,7 +53,7 @@ namespace :git do
   desc 'Copy repo to releases'
   task create_release: :'git:update' do
     on roles :all do
-      with git_environmental_variables do
+      with fetch(:git_environmental_variables) do
         within repo_path do
           execute :mkdir, '-p', release_path
           execute :git, :archive, fetch(:branch), '| tar -x -C', release_path


### PR DESCRIPTION
when the git-ssh helper is only in /tmp then deployment done by two
different users will make this file not writable for the second user,
to avoid that problem I have added extra `fetch :application`.
