### PR TITLE
Fix split command argument leading to error raised and incorrect path returned

### DIFF
--- a/lib/capistrano/i18n.rb
+++ b/lib/capistrano/i18n.rb
@@ -15,6 +15,7 @@ en = {
   keeping_releases:            'Keeping %{keep_releases} of %{releases} deployed releases on %{host}',
   no_old_releases:             'No old releases (keeping newest %{keep_releases}) on %{host}',
   linked_file_does_not_exist:  'linked file %{file} does not exist on %{host}',
+  cannot_rollback:             'There are no older releases to rollback to',
   mirror_exists:               "The repository mirror is at %{at}",
   revision_log_message:        'Branch %{branch} (at %{sha}) deployed as release %{release} by %{user}',
   rollback_log_message:        '%{user} rolled back to release %{release}',

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -185,16 +185,14 @@ namespace :deploy do
     set_release_path
   end
 
-  task :last_release_path do
-    on release_roles(:all) do
-      last_release = capture(:ls, '-xr', releases_path).split[1]
-      set_release_path(last_release)
-    end
-  end
-
   task :rollback_release_path do
     on release_roles(:all) do
-      last_release = capture(:ls, '-xr', releases_path).split[1]
+      releases = capture(:ls, '-xr', releases_path).split
+      if releases.count < 2
+        error t(:cannot_rollback)
+        exit 1
+      end
+      last_release = releases[1]
       set_release_path(last_release)
       set(:rollback_timestamp, last_release)
     end


### PR DESCRIPTION
It looks like last_release_path is doing split[1], and that's the same code as in rollback_release_path.  It produces:
1) an error when there is only one release:

```
DEBUG [3ce6105b] Running /usr/bin/env ls -xr /foo/releases on somebox
DEBUG [3ce6105b] Command: ( RAILS_ENV=production /usr/bin/env ls -xr /foo/releases )
DEBUG [3ce6105b] Finished in 1.081 seconds with exit status 0 (successful).
DEBUG [3ce6105b]    20131029143226
DEBUG [3ce6105b] Finished in 1.081 seconds with exit status 0 (successful).
cap aborted!
no implicit conversion of nil into String
/Users/bryan/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/pathname.rb:389:in `initialize'
```

2) the wrong link when running anything else:
given task:

```
namespace :deploy do

  task :foo => :last_release_path do
    on roles(:all) do
      puts release_path      
    end
  end
```

```
$ bin/cap --trace somebox deploy:foo
** Invoke somebox (first_time)
** Execute somebox
** Invoke load:defaults (first_time)
** Execute load:defaults
** Invoke deploy:foo (first_time)
** Invoke deploy:last_release_path (first_time)
** Execute deploy:last_release_path
DEBUG [874effb4] Running /usr/bin/env ls -xr /foo/releases on somebox
DEBUG [874effb4] Command: ( RAILS_ENV=production /usr/bin/env ls -xr /foo/releases )
DEBUG [874effb4] Finished in 1.083 seconds with exit status 0 (successful).
DEBUG [874effb4]    20131101000000  20131029143226
DEBUG [874effb4] Finished in 1.083 seconds with exit status 0 (successful).
** Execute deploy:foo
/foo/releases/20131029143226
```

My proposed patch is so simple, maybe I am missing something? I did want to update specs, but I didn't see anything specific to that task.  I wanted to add some, but it was a bit complicated.  

I guess rollback_release_path should be updated too, in case there are no releases, or only one release -  but not sure what the right cappy way to do that is, raising an error, etc.

I can give specs/cukes it a go if it's useful, and patch rollback_release_path with some advice.

Thanks all for making and updating cap
