### PR TITLE
linked_dirs and linked_files on :all role

### DIFF
--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -50,7 +50,7 @@ namespace :deploy do
     desc 'Check directories to be linked exist in shared'
     task :linked_dirs do
       next unless any? :linked_dirs
-      on roles :app do
+      on roles :all do
         execute :mkdir, '-pv', linked_dirs(shared_path)
       end
     end
@@ -58,7 +58,7 @@ namespace :deploy do
     desc 'Check directories of files to be linked exist in shared'
     task :make_linked_dirs do
       next unless any? :linked_files
-      on roles :app do |host|
+      on roles :all do |host|
         execute :mkdir, '-pv', linked_file_dirs(shared_path)
       end
     end
@@ -66,7 +66,7 @@ namespace :deploy do
     desc 'Check files to be linked exist in shared'
     task :linked_files do
       next unless any? :linked_files
-      on roles :app do |host|
+      on roles :all do |host|
         linked_files(shared_path).each do |file|
           unless test "[ -f #{file} ]"
             error t(:linked_file_does_not_exist, file: file, host: host)
@@ -95,7 +95,7 @@ namespace :deploy do
     desc 'Symlink linked directories'
     task :linked_dirs do
       next unless any? :linked_dirs
-      on roles :app do
+      on roles :all do
         execute :mkdir, '-pv', linked_dir_parents(release_path)
 
         fetch(:linked_dirs).each do |dir|
@@ -114,7 +114,7 @@ namespace :deploy do
     desc 'Symlink linked files'
     task :linked_files do
       next unless any? :linked_files
-      on roles :app do
+      on roles :all do
         execute :mkdir, '-pv', linked_file_dirs(release_path)
 
         fetch(:linked_files).each do |file|


### PR DESCRIPTION
run check:linked_dirs, check:linked_files, symlink:linked_dirs and symlink:linked_files on :all role

otherwise it fails to run deploy:migrate on db server.
