### PR TITLE
Correctly infer namespace in task enhancements

### DIFF
--- a/lib/capistrano/dsl/task_enhancements.rb
+++ b/lib/capistrano/dsl/task_enhancements.rb
@@ -6,9 +6,10 @@ module Capistrano
     end
 
     def after(task, post_task, *args, &block)
-      post_task = Rake::Task.define_task(post_task, *args, &block) if block_given?
+      Rake::Task.define_task(post_task, *args, &block) if block_given?
+      post_task = Rake::Task[post_task]
       Rake::Task[task].enhance do
-        invoke(post_task)
+        post_task.invoke
       end
     end
 

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -200,6 +200,7 @@ namespace :deploy do
     end
   end
 
+  task :restart
   task :failed
 
 end

--- a/lib/capistrano/templates/deploy.rb.erb
+++ b/lib/capistrano/templates/deploy.rb.erb
@@ -17,7 +17,6 @@ set :repo_url, 'git@example.com:me/my_repo.git'
 # set :keep_releases, 5
 
 namespace :deploy do
-  after :publishing, :restart
 
   desc 'Restart application'
   task :restart do
@@ -26,6 +25,8 @@ namespace :deploy do
       # execute :touch, release_path.join('tmp/restart.txt')
     end
   end
+
+  after :publishing, :restart
 
   after :restart, :clear_cache do
     on roles(:web), in: :groups, limit: 3, wait: 10 do


### PR DESCRIPTION
Previously, defining a task using the `after` syntax within a namespace
block ignored the namespace, now the following examples are equivalent:

```
  # within namespace
  namespace :deploy do
    task :my_task do
      #
    end

    after :starting, :my_task
  end

  # outside of namespace
  after 'deploy:starting', 'deploy:my_task'
```

This resolves #541
