### PR TITLE
Fix broken links to capistrano/rails repo

### DIFF
--- a/lib/capistrano/templates/Capfile
+++ b/lib/capistrano/templates/Capfile
@@ -12,8 +12,7 @@ require 'capistrano/deploy'
 #   https://github.com/capistrano/rbenv
 #   https://github.com/capistrano/chruby
 #   https://github.com/capistrano/bundler
-#   https://github.com/capistrano/rails/tree/master/assets
-#   https://github.com/capistrano/rails/tree/master/migrations
+#   https://github.com/capistrano/rails
 #
 # require 'capistrano/rvm'
 # require 'capistrano/rbenv'


### PR DESCRIPTION
Links in the generated Capfile were broken. I recommend to just go to the main repo URL (same for capistrano/bundler etc.).
