### PR TITLE
Extend remote_file DSL method  - closes #762

### DIFF
--- a/lib/capistrano/dsl/task_enhancements.rb
+++ b/lib/capistrano/dsl/task_enhancements.rb
@@ -1,3 +1,6 @@
+require 'tmpdir'
+require 'pathname'
+
 module Capistrano
   module TaskEnhancements
     def before(task, prerequisite, *args, &block)
@@ -21,7 +24,16 @@ module Capistrano
     def define_remote_file_task(task, target_roles)
       Rake::Task.define_task(task) do |t|
         prerequisite_file = t.prerequisites.first
-        file = shared_path.join(t.name)
+
+        # Extract the task name; ignore any
+        # scope a user may have accidentally
+        # attached that could be in `t.name`
+        task_name = task.keys.first
+        if Pathname.new(task_name).absolute?
+          file = task_name
+        else
+          file = File.join((fetch(:shared_path) || Dir.tmpdir), task_name)
+        end
 
         on roles(target_roles) do
           unless test "[ -f #{file} ]"


### PR DESCRIPTION
Extends remote_file to support a task with a full path for a name. When
the name is not a full path, remote_file now degrades gracefully via use
of Dir.tmpdir

It's unclear to me at this time if capistrano v3/sshkit support windows,
but it would appear that pathname.absolute? may not, based on some brief
research (though I don't have a Windows box to test this with).

It is also unclear to me how safe/trustworthy the method
`task.keys.first` is for returning the unscoped task name, but splitting
on ':' would  _certainly_ break windows paths, so it was avoided in case
that was a concern. The intent of that block is so that if a
`remote_file` is declared in a namespace, the path could be retrieved
from `define_remote_file_task`
