### PR TITLE
Fix ask example in readme per issues #768 and #747

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ This method is widely used.
 ``` ruby
 desc "Ask about breakfast"
 task :breakfast do
-  breakfast = ask(:breakfast, "What would you like your colleagues to bring you for breakfast?")
+  ask(:breakfast, "What would you like your colleagues to bring you for breakfast?")
   on roles(:all) do |h|
-    execute "echo \"$(whoami) wants #{breakfast} for breakfast!\" | wall"
+    execute "echo \"$(whoami) wants #{fetch(:breakfast)} for breakfast!\""
   end
 end
 ```


### PR DESCRIPTION
The example in the README appears to be broken.

See:
- `ask` never asks for user input - https://github.com/capistrano/capistrano/issues/768
- [Bug] :ask not working - https://github.com/capistrano/capistrano/issues/747
