### PR TITLE
Add error message when repo is not reachable

### DIFF
--- a/lib/capistrano/i18n.rb
+++ b/lib/capistrano/i18n.rb
@@ -27,6 +27,9 @@ en = {
     user: {
       does_not_exist:  'User %{user} does not exists',
       cannot_switch:   'Cannot switch to user %{user}'
+    },
+    repo: {
+      not_reachable: 'The repository is not reachable.',
     }
   }
 }

--- a/lib/capistrano/tasks/git.rake
+++ b/lib/capistrano/tasks/git.rake
@@ -21,7 +21,10 @@ namespace :git do
     fetch(:branch)
     on release_roles :all do
       with fetch(:git_environmental_variables) do
-        exit 1 unless test :git, :'ls-remote', repo_url
+        unless test :git, :'ls-remote', repo_url
+          error t('error.repo.not_reachable')
+          exit 1
+        end
       end
     end
   end


### PR DESCRIPTION
Currently git:check (invoked by deploy:check) does not print anything when `git ls-remote` is failed and **silently** aborted. It would be better to show some error messages when it is aborted.

Output when log level is info (current):

```
 INFO [f20ac338] Running /usr/bin/env mkdir -p /tmp/foobar/ on example.com
 INFO [f20ac338] Finished in 0.225 seconds with exit status 0 (successful).
 INFO Uploading /tmp/foobar/git-ssh.sh 100.0%
 INFO [8f04ecda] Running /usr/bin/env chmod +x /tmp/foobar/git-ssh.sh on example.com
 INFO [8f04ecda] Finished in 0.014 seconds with exit status 0 (successful).
```

Output when log level is debug  (current):

```
 INFO [55aa79d3] Running /usr/bin/env mkdir -p /tmp/foobar/ on example.com
DEBUG [55aa79d3] Command: /usr/bin/env mkdir -p /tmp/foobar/
 INFO [55aa79d3] Finished in 0.208 seconds with exit status 0 (successful).
DEBUG Uploading /tmp/foobar/git-ssh.sh 0.0%
 INFO Uploading /tmp/foobar/git-ssh.sh 100.0%
 INFO [ee1464f1] Running /usr/bin/env chmod +x /tmp/foobar/git-ssh.sh on example.com
DEBUG [ee1464f1] Command: /usr/bin/env chmod +x /tmp/foobar/git-ssh.sh
 INFO [ee1464f1] Finished in 0.008 seconds with exit status 0 (successful).
DEBUG [c6b76799] Running /usr/bin/env git ls-remote git@github.com:foo/foobar.git on example.com
DEBUG [c6b76799] Command: ( GIT_ASKPASS=/bin/echo GIT_SSH=/tmp/foobar/git-ssh.sh /usr/bin/env git ls-remote git@github.com:foo/foobar.git )
DEBUG [c6b76799]    /usr/bin/env:
DEBUG [c6b76799]    git
DEBUG [c6b76799]    : No such file or directory
DEBUG [c6b76799]
DEBUG [c6b76799] Finished in 0.213 seconds with exit status 127 (failed).
```
