### PR TITLE
Symlinks should happen on all roles, not just app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Reverse Chronological Order:
 
 ## `3.1.0` (not released)
 
+  * Tasks that used `linked_dirs` and `linked_files` now run on all roles, not just app roles (@mikespokefire)
   * Tasks `deploy:linked_dirs`, `deploy:make_linked_dirs`, `deploy:linked_files`, `deploy:cleanup_rollback`,
     `deploy:log_revision` and `deploy:revert_release` now use `release_roles()` not `roles()` meaning that they
     will only run on servers where the `no_release` property is not falsy. (@leehambley)

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -49,7 +49,7 @@ namespace :deploy do
     desc 'Check directories to be linked exist in shared'
     task :linked_dirs do
       next unless any? :linked_dirs
-      on release_roles :app do
+      on release_roles :all do
         execute :mkdir, '-pv', linked_dirs(shared_path)
       end
     end
@@ -57,7 +57,7 @@ namespace :deploy do
     desc 'Check directories of files to be linked exist in shared'
     task :make_linked_dirs do
       next unless any? :linked_files
-      on release_roles :app do |host|
+      on release_roles :all do |host|
         execute :mkdir, '-pv', linked_file_dirs(shared_path)
       end
     end
@@ -65,7 +65,7 @@ namespace :deploy do
     desc 'Check files to be linked exist in shared'
     task :linked_files do
       next unless any? :linked_files
-      on release_roles :app do |host|
+      on release_roles :all do |host|
         linked_files(shared_path).each do |file|
           unless test "[ -f #{file} ]"
             error t(:linked_file_does_not_exist, file: file, host: host)
@@ -94,7 +94,7 @@ namespace :deploy do
     desc 'Symlink linked directories'
     task :linked_dirs do
       next unless any? :linked_dirs
-      on release_roles :app do
+      on release_roles :all do
         execute :mkdir, '-pv', linked_dir_parents(release_path)
 
         fetch(:linked_dirs).each do |dir|
@@ -113,7 +113,7 @@ namespace :deploy do
     desc 'Symlink linked files'
     task :linked_files do
       next unless any? :linked_files
-      on release_roles :app do
+      on release_roles :all do
         execute :mkdir, '-pv', linked_file_dirs(release_path)
 
         fetch(:linked_files).each do |file|


### PR DESCRIPTION
When we are precompiling assets on both web and app roles, the symlinks that we require aren't present on the web roles as the symlink tasks only run on app currently.

I can't see a reason why symlinks for linked directories shouldn't happen everywhere, so I've set it to all, but it could easily be changed into a set + fetch combination.
