### PR TITLE
Feature request: copy files between releases

### DIFF
--- a/lib/capistrano/i18n.rb
+++ b/lib/capistrano/i18n.rb
@@ -28,7 +28,8 @@ en = {
       does_not_exist:  'User %{user} does not exists',
       cannot_switch:   'Cannot switch to user %{user}'
     }
-  }
+  },
+  copy_source_does_not_exist:   'Source file %{source} is not a file or directory that can be copied (target: %{target})'
 }
 
 I18n.backend.store_translations(:en, { capistrano: en })


### PR DESCRIPTION
I would like to add an additional feature/setting `copy_paths` to supplement the `linked_files` and `linked_dirs`.

For dependency management a deploy is significantly sped up if the dependencies are copied between releases (specifically talking about npm/composer here). Symlinking dependencies is not sufficient as it can complicate a _rollback_ and a dependency update could break the live release during a deploy.

Things I haven't included/need work
- Namespace, task name and config variable name
- Removing target files if they already exist (as linked files does)
- Tests
- last_release could be added to `dsl/paths.rb`?

I originally opened capistrano/composer#9 - it was suggested this might be better as part of capistrano core. I'm still relatively new to ruby/rake so I don't know if my example is the best.
