### PR TITLE
Extend remote_file method in different approach to #767

### DIFF
--- a/lib/capistrano/dsl/task_enhancements.rb
+++ b/lib/capistrano/dsl/task_enhancements.rb
@@ -15,13 +15,14 @@ module Capistrano
 
     def remote_file(task)
       target_roles = task.delete(:roles) { :all }
-      define_remote_file_task(task, target_roles)
+      remote_path = task.delete(:within) { shared_path }
+      define_remote_file_task(task, target_roles, remote_path)
     end
 
-    def define_remote_file_task(task, target_roles)
+    def define_remote_file_task(task, target_roles, remote_path = shared_path)
       Rake::Task.define_task(task) do |t|
         prerequisite_file = t.prerequisites.first
-        file = shared_path.join(t.name)
+        file = remote_path.join(t.name)
 
         on roles(target_roles) do
           unless test "[ -f #{file} ]"


### PR DESCRIPTION
Hash key :within is added to the argument of remote_file.
This is I think simpler solution for #762 .
Default value of remote_path of define_remote_file_task is for compatibility
