### PR TITLE
override default rake application name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tmp
 .rspec-local
 .ruby-version
 _site
+.rspec

--- a/lib/capistrano/application.rb
+++ b/lib/capistrano/application.rb
@@ -3,8 +3,11 @@ module Capistrano
 
     def initialize
       super
-      @name = "cap"
       @rakefiles = %w{capfile Capfile capfile.rb Capfile.rb} << capfile
+    end
+
+    def name
+      "cap"
     end
 
     def run
@@ -18,7 +21,6 @@ module Capistrano
     end
 
     def load_rakefile
-      @name = 'cap'
       super
     end
 

--- a/spec/lib/capistrano/application_spec.rb
+++ b/spec/lib/capistrano/application_spec.rb
@@ -7,11 +7,10 @@ describe Capistrano::Application do
   it "provides a --format option which enables the choice of output formatting"
 
   it "identifies itself as cap and not rake" do
-    pending "Waiting for: https://github.com/jimweirich/rake/pull/204"
     out, _ = capture_io do
       flags '--help', '-h'
     end
-    out.should match(/\bcap [ -f capfile ]\b/)
+    out.lines.first.should match(/cap \[-f rakefile\]/)
   end
 
   it "overrides the rake method, but still prints the rake version" do
@@ -37,9 +36,7 @@ describe Capistrano::Application do
     def subject.exit(*args)
       throw(:system_exit, :exit)
     end
-    subject.instance_eval do
-      handle_options
-    end
+    subject.run
     subject.options
   end
 


### PR DESCRIPTION
Since [your pull request was merged](https://github.com/jimweirich/rake/pull/204) into Rake and included in the last version, there's no reason for this spec to remain pending.
