### PR TITLE
Improve console (EOF and empty commands)

### DIFF
--- a/lib/capistrano/tasks/console.rake
+++ b/lib/capistrano/tasks/console.rake
@@ -11,6 +11,8 @@ task :console do
       command = 'exit'
     end
 
+    next if command.empty?
+
     if %w{quit exit q}.include? command
       puts t('console.bye')
       break


### PR DESCRIPTION
Avoid exceptions when sending EOF in console. Don't send execute empty commands on server.

See examples below:
### EOF (`Ctrl+d`)

Before:

```
$ bundle exec cap production console
capistrano console - enter command to execute on production
production> cap aborted!
undefined method `chomp' for nil:NilClass
/Users/jage/Source/capistrano/lib/capistrano/tasks/console.rake:7:in `block (2 levels) in <top (required)>'
/Users/jage/Source/capistrano/lib/capistrano/tasks/console.rake:5:in `loop'
/Users/jage/Source/capistrano/lib/capistrano/tasks/console.rake:5:in `block in <top (required)>'
/Users/jage/Source/capistrano/lib/capistrano/application.rb:12:in `run'
/Users/jage/Source/capistrano/bin/cap:3:in `<top (required)>'
/Users/jage/.gem/ruby/2.0.0/bin/cap:23:in `load'
/Users/jage/.gem/ruby/2.0.0/bin/cap:23:in `<main>'
Tasks: TOP => console
(See full trace by running task with --trace)
```

After:

```
$ bundle exec cap production console
capistrano console - enter command to execute on production
production> bye
```
### Newline (`Enter`)

Before:

```
$ bundle exec cap production console
capistrano console - enter command to execute on production
production>
 INFO [3aea4c1c] Running /usr/bin/env  on XXX
DEBUG [3aea4c1c] Command: /usr/bin/env
...
 INFO [3aea4c1c] Finished in 0.376 seconds with exit status 0 (successful).
production>
```

After:

```
$ bundle exec cap production console
capistrano console - enter command to execute on production
production>
production>
```
