### PR TITLE
Allow roles to be fetched with an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Reverse Chronological Order:
   * Add command line option to control role filtering (@andytinycat)
   * Make use of recent changes in Rake to over-ride the application name (@shime)
   * Readme corrections (@nathanstitt)
+  * Allow roles to be fetched with a variable containing an array (@seenmyfate)
 
 ## `3.0.1`
 

--- a/lib/capistrano/dsl/env.rb
+++ b/lib/capistrano/dsl/env.rb
@@ -40,7 +40,7 @@ module Capistrano
       end
 
       def roles(*names)
-        env.roles_for(names)
+        env.roles_for(names.flatten)
       end
 
       def release_roles(*names)

--- a/spec/integration/dsl_spec.rb
+++ b/spec/integration/dsl_spec.rb
@@ -60,6 +60,14 @@ describe Capistrano::DSL do
         end
       end
 
+      describe 'fetching servers by an array of roles' do
+        subject { dsl.roles([:app]) }
+
+        it 'returns the servers' do
+          expect(subject.map(&:hostname)).to eq %w{example3.com example4.com}
+        end
+      end
+
       describe 'fetching filtered servers by role' do
         subject { dsl.roles(:app, filter: :active) }
 
@@ -142,6 +150,14 @@ describe Capistrano::DSL do
 
       describe 'fetching servers by role' do
         subject { dsl.roles(:app) }
+
+        it 'returns the servers' do
+          expect(subject.map(&:hostname)).to eq %w{example3.com example4.com}
+        end
+      end
+
+      describe 'fetching servers by an array of roles' do
+        subject { dsl.roles([:app]) }
 
         it 'returns the servers' do
           expect(subject.map(&:hostname)).to eq %w{example3.com example4.com}


### PR DESCRIPTION
For the case where the array may be stored in a variable, for example:

```
set :my_roles, [:app, :web]

on roles fetch(:my_roles) do
  #
end
```

This will allow https://github.com/capistrano/rails/pull/30 to be
refactored
