### PR TITLE
Added stages= method to allow programmatically setting new stages

### DIFF
--- a/lib/capistrano/dsl/stages.rb
+++ b/lib/capistrano/dsl/stages.rb
@@ -1,9 +1,15 @@
 module Capistrano
   module DSL
     module Stages
+      @@stages = []
 
       def stages
-        Dir[stage_definitions].map { |f| File.basename(f, '.rb') }
+        @@stages | Dir[stage_definitions].map { |f| File.basename(f, '.rb') }
+      end
+
+      def stages=(args=[])
+        @@stages = []
+        @@stages = stages | Array(args)
       end
 
       def infer_stages_from_stage_files

--- a/spec/lib/capistrano/dsl/stages_spec.rb
+++ b/spec/lib/capistrano/dsl/stages_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+module Capistrano
+  module DSL
+
+    class DummyStages
+      include Stages
+      include Paths
+      include Env
+    end
+
+    describe Stages do
+      before(:each) do
+        @stage =  DummyStages.new
+        @stage.stages = []
+      end
+
+      it "should return empty array if no stages are set" do
+        expect(@stage.stages).to eq(Array.new)
+      end
+
+      it "should return empty array if directory is empty" do
+        expect(@stage.stages).to eq(Array.new)
+      end
+
+      it "should return array of stages which were set before" do
+        @stage.stages = "production", "dev", "staging"
+        expect(@stage.stages).to eq(["production", "dev", "staging"])
+      end
+
+      it "should return array of stages which were set before" do
+        @stage.stages = "production"
+        expect(@stage.stages).to eq(["production"])
+      end
+
+      it "should overwrite previously set stages" do
+        @stage.stages = "production", "dev", "staging"
+        expect(@stage.stages).to eq(["production", "dev", "staging"])
+        @stage.stages = "production", "dev", "staging2"
+        expect(@stage.stages).to eq(["production", "dev", "staging2"])
+      end
+
+      describe "stage_definitions" do
+        before(:each) do
+          File.open("/tmp/stage.rb", "w") {}
+          def @stage.stage_definitions
+            "/tmp/*.rb"
+          end
+        end
+
+        it "should return only stages in directory" do
+          expect(@stage.stages).to eq(["stage"])
+        end
+
+        it "should return union of set and directory stages" do
+          @stage.stages = "production", "dev"
+          expect(@stage.stages).to eq(["stage","production", "dev"])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will allow us to set stages by specifying:
stages = "blah", "something"
I decided to keep the functionality of loading stages each time from the file instead of loading it once to allow changes to stages even if the module is already loaded.

Related to: https://github.com/capistrano/capistrano/issues/816
