### PR TITLE
Added check for file existance before loading in order to not fail if filie not present

### DIFF
--- a/lib/capistrano/setup.rb
+++ b/lib/capistrano/setup.rb
@@ -11,8 +11,8 @@ stages.each do |stage|
     set(:stage, stage.to_sym)
     
     invoke 'load:defaults'
-    load deploy_config_path
-    load stage_config_path.join("#{stage}.rb")
+    load deploy_config_path if File.exists?(deploy_config_path)
+    load stage_config_path.join("#{stage}.rb") if File.exists?(stage_config_path.join("#{stage}.rb"))
     load "capistrano/#{fetch(:scm)}.rb"
     I18n.locale = fetch(:locale, :en)
     configure_backend


### PR DESCRIPTION
In order to allow capistrano to run without external files, we need to ensure that setup does not fail if file isn't present.
