### PR TITLE
Set I18n.enforce_available_locales=true to fix deprecation warning

### DIFF
--- a/lib/capistrano/i18n.rb
+++ b/lib/capistrano/i18n.rb
@@ -32,4 +32,7 @@ en = {
 }
 
 I18n.backend.store_translations(:en, { capistrano: en })
-I18n.enforce_available_locales = true
+
+if I18n.respond_to?(:enforce_available_locales=)
+  I18n.enforce_available_locales = true
+end


### PR DESCRIPTION
This PR fixes the problem where the following deprecation warning is printed to console whenever `cap` is run:

```
[deprecated] I18n.enforce_available_locales will default to true in the future. If you really want to skip validation of your locale you can set I18n.enforce_available_locales = false to avoid this message.
```
