### PR TITLE
Lock config file by default

### DIFF
--- a/lib/capistrano/templates/deploy.rb.erb
+++ b/lib/capistrano/templates/deploy.rb.erb
@@ -1,3 +1,6 @@
+# config valid only for Capistrano 3.1
+lock '<%= Capistrano::VERSION %>'
+
 set :application, 'my_app_name'
 set :repo_url, 'git@example.com:me/my_repo.git'
 


### PR DESCRIPTION
I think it might be useful to generate default `deploy.rb` locked on the current version.
