### PR TITLE
remove default deploy_to option

### DIFF
--- a/lib/capistrano/defaults.rb
+++ b/lib/capistrano/defaults.rb
@@ -1,6 +1,5 @@
 set :scm, :git
 set :branch, :master
-set :deploy_to, "/var/www/#{fetch(:application)}"
 set :tmp_dir, "/tmp"
 
 set :default_env, {}

--- a/lib/capistrano/templates/deploy.rb.erb
+++ b/lib/capistrano/templates/deploy.rb.erb
@@ -3,7 +3,7 @@ set :repo_url, 'git@example.com:me/my_repo.git'
 
 # ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }
 
-# set :deploy_to, '/var/www/my_app'
+set :deploy_to, '/var/www/my_app'
 # set :scm, :git
 
 # set :format, :pretty


### PR DESCRIPTION
Since defaults are loaded before the user options, the `deploy_to` is misconfigured. Because it depends on 'application' option, which is configured by the user.

See #824
