### PR TITLE
Use the :git_environmental_variables settings when updating from remote ...

### DIFF
--- a/lib/capistrano/tasks/git.rake
+++ b/lib/capistrano/tasks/git.rake
@@ -50,7 +50,9 @@ namespace :git do
     on release_roles :all do
       within repo_path do
         capturing_revisions do
-          strategy.update
+          with fetch(:git_environmental_variables) do
+            strategy.update
+          end
         end
       end
     end


### PR DESCRIPTION
...origin.

I ran into a small problem during our upgrade to 3.0 that happens on the 'git:update' task. I noticed that this task omits a block with :git_environmental_variables set, unlike all the other git commands.
