### PR TITLE
remove rails_env from stage template

### DIFF
--- a/lib/capistrano/templates/stage.rb.erb
+++ b/lib/capistrano/templates/stage.rb.erb
@@ -37,5 +37,3 @@ server 'example.com', user: 'deploy', roles: %w{web app}, my_property: :my_value
 #     # password: 'please use keys'
 #   }
 # setting per server overrides global ssh_options
-
-# fetch(:default_env).merge!(rails_env: :<%= stage %>)


### PR DESCRIPTION
The removed line has nothing to do with Capistrano itself.
capistrano-rails handles the `RAILS_ENV` definition and management.
And it confuses people to do strange things.
