### PR TITLE
Add a line to the Capfile template to load 'config/deploy.rb'.

### DIFF
--- a/lib/capistrano/templates/Capfile
+++ b/lib/capistrano/templates/Capfile
@@ -21,5 +21,8 @@ require 'capistrano/deploy'
 # require 'capistrano/rails/assets'
 # require 'capistrano/rails/migrations'
 
+# Loads custom tasks from the main deploy file
+load 'config/deploy.rb'
+
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.cap').each { |r| import r }


### PR DESCRIPTION
Without this setting custom tasks defined in the deploy file will not show up in the cap -T list, which can be confusing.
