### PR TITLE
Restructure SVN support work.

### DIFF
--- a/lib/capistrano/svn.rb
+++ b/lib/capistrano/svn.rb
@@ -1,0 +1,35 @@
+load File.expand_path("../tasks/svn.rake", __FILE__)
+
+require 'capistrano/scm'
+
+class Capistrano::Svn < Capistrano::SCM
+
+  # execute svn with argument in the context
+  #
+  def svn(*args)
+    args.unshift(:svn)
+    context.execute *args
+  end
+
+  module DefaultStrategy
+    def test
+      return true
+    end
+
+    def check
+      test! :svn, :info, repo_url
+    end
+
+    def clone
+      return true
+    end
+
+    def update
+      return true
+    end
+
+    def release
+      svn :export, "#{repo_url}/#{fetch(:svn_location)}", release_path
+    end
+  end
+end

--- a/lib/capistrano/tasks/svn.rake
+++ b/lib/capistrano/tasks/svn.rake
@@ -1,0 +1,20 @@
+namespace :svn do
+  def strategy
+    @strategy ||= Capistrano::Svn.new(self, fetch(:svn_strategy, Capistrano::Svn::DefaultStrategy))
+  end
+
+  desc 'Check that the repo is reachable'
+  task :check do
+    on release_roles :all do
+      strategy.check
+    end
+  end
+
+  desc 'Copy repo to releases'
+  task :create_release do
+    Capistrano::Configuration.ask(:svn_location, "trunk")
+    on release_roles :all do
+      strategy.release
+    end
+  end
+end

--- a/spec/lib/capistrano/svn_spec.rb
+++ b/spec/lib/capistrano/svn_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+require 'capistrano/svn'
+
+module Capistrano
+  describe Svn do
+    let(:context) { Class.new.new }
+    subject { Capistrano::Svn.new(context, Capistrano::Svn::DefaultStrategy) }
+
+    describe "#svn" do
+      it "should call execute svn in the context, with arguments" do
+        context.expects(:execute).with(:svn, :init)
+        subject.svn(:init)
+      end
+    end
+  end
+
+  describe Svn::DefaultStrategy do
+    let(:context) { Class.new.new }
+    subject { Capistrano::Svn.new(context, Capistrano::Svn::DefaultStrategy) }
+
+    describe "#test" do
+      it "returns true" do
+        expect(subject.test).to be_true
+      end
+    end
+
+    describe "#check" do
+      it "should test the repo url" do
+        context.expects(:repo_url).returns(:url)
+        context.expects(:test).with(:svn, :info, :url).returns(true)
+
+        subject.check
+      end
+    end
+
+    describe "#clone" do
+      it "returns true" do
+        expect(subject.clone).to be_true
+      end
+    end
+
+    describe "#update" do
+      it "returns true" do
+        expect(subject.update).to be_true
+      end
+    end
+
+    describe "#release" do
+      it "should run svn export" do
+        context.expects(:fetch).returns(:svn_location)
+        context.expects(:repo_url).returns(:url)
+        context.expects(:release_path).returns(:path)
+
+        context.expects(:execute).with(:svn, :export, "#{:url}/#{:svn_location}", :path)
+
+        subject.release
+      end
+    end
+  end
+end


### PR DESCRIPTION
An updated version of https://github.com/capistrano/capistrano/pull/838. I don't really see a benefit to checking out a local copy of a project from SVN as it is not used in the deployment process.  As the class Capistrano::SCM class mandates the implementation of the methods test, clone and update, which all relate to a locally maintained repo I have just made these methods return true.
