### PR TITLE
unwrap values during fetch

### DIFF
--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -30,11 +30,10 @@ module Capistrano
 
     def fetch(key, default=nil, &block)
       value = fetch_for(key, default, &block)
-      if value.respond_to?(:call)
-        set(key, value.call)
-      else
-        value
+      while value.respond_to?(:call)
+        value = set(key, value.call)
       end
+      return value
     end
 
     def role(name, hosts, options={})

--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -61,6 +61,41 @@ module Capistrano
         end
       end
 
+      context 'value is a lambda' do
+        subject { config.fetch(:key, lambda { :lambda } ) }
+        it 'calls the lambda' do
+          expect(subject).to eq :lambda
+        end
+      end
+
+      context 'value inside proc inside a proc' do
+        subject { config.fetch(:key, Proc.new { Proc.new { "some value" } } ) }
+        it 'calls all procs and lambdas' do
+          expect(subject).to eq "some value"
+        end
+      end
+
+      context 'value inside lambda inside a lambda' do
+        subject { config.fetch(:key, lambda { lambda { "some value" } } ) }
+        it 'calls all procs and lambdas' do
+          expect(subject).to eq "some value"
+        end
+      end
+
+      context 'value inside lambda inside a proc' do
+        subject { config.fetch(:key, Proc.new { lambda { "some value" } } ) }
+        it 'calls all procs and lambdas' do
+          expect(subject).to eq "some value"
+        end
+      end
+
+      context 'value inside proc inside a lambda' do
+        subject { config.fetch(:key, lambda { Proc.new { "some value" } } ) }
+        it 'calls all procs and lambdas' do
+          expect(subject).to eq "some value"
+        end
+      end
+
       context 'block is passed to fetch' do
         subject { config.fetch(:key, :default) { fail 'we need this!' } }
 


### PR DESCRIPTION
fetching a value with #fetch a proc might be set to the specified key,
in order to unwrap all procs and only return the underlying value,
value.call is performed as long as it does not return any new proc
objects (e.g. it does not repond to :call any more).

fixes #859
