### PR TITLE
Remove duplicate require for sshkit, dsl does it on its own.

### DIFF
--- a/lib/capistrano/all.rb
+++ b/lib/capistrano/all.rb
@@ -1,5 +1,4 @@
 require 'rake'
-require 'sshkit'
 require 'sshkit/dsl'
 
 Rake.application.options.trace = true


### PR DESCRIPTION
This removes warnings like:

/usr/local/lib/ruby/gems/2.0.0/gems/sshkit-1.3.0/lib/sshkit.rb:3: warning: already initialized constant SSHKit::StandardError
/usr/local/Cellar/ruby/2.0.0-p247/lib/ruby/gems/2.0.0/gems/sshkit-1.3.0/lib/sshkit.rb:3: warning: previous definition of StandardError was here
