### PR TITLE
Allow overwrite or enhance scm tasks

### DIFF
--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -5,7 +5,7 @@ namespace :deploy do
   end
 
   task :updating => :new_release_path do
-    invoke "#{scm}:create_release"
+    invoke 'deploy:create_release'
     invoke 'deploy:symlink:shared'
   end
 
@@ -31,7 +31,7 @@ namespace :deploy do
 
   desc 'Check required files and directories exist'
   task :check do
-    invoke "#{scm}:check"
+    invoke 'deploy:check:scm'
     invoke 'deploy:check:directories'
     invoke 'deploy:check:linked_dirs'
     invoke 'deploy:check:make_linked_dirs'
@@ -73,6 +73,11 @@ namespace :deploy do
           end
         end
       end
+    end
+
+    desc 'Check that the repository is reachable'
+    task :scm do
+      invoke "#{scm}:check"
     end
   end
 
@@ -163,6 +168,11 @@ namespace :deploy do
         debug 'Last release is the current release, skip cleanup_rollback.'
       end
     end
+  end
+
+  desc 'Copy data to releases'
+  task :create_release do
+    invoke "#{scm}:create_release"
   end
 
   desc 'Log details of the deploy'


### PR DESCRIPTION
This patch is to allow overwrite scm tasks.

Thanks to this changes we can do something like that:

``` ruby
Rake::Task["deploy:check:scm"].clear
Rake::Task["deploy:create_release"].clear
Rake::Task.define_task("deploy:create_release") do
# do something
end
```

Without those changes we can't overwrite scm tasks as they are loaded dynamically with `load "capistrano/#{fetch(:scm)}.rb"` https://github.com/capistrano/capistrano/blob/master/lib/capistrano/setup.rb#L16

so with something like that

``` ruby
Rake::Task["#{scm}:check"].clear
Rake::Task["#{scm}:create_release"].clear
Rake::Task.define_task("#{scm}:create_release") do
# do something
end
```

We get error:

``` sh
cap aborted!
Don't know how to build task 'git:check'
```
