### PR TITLE
Run uniq on linked_dir_parents.

### DIFF
--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -95,7 +95,7 @@ namespace :deploy do
     task :linked_dirs do
       next unless any? :linked_dirs
       on release_roles :all do
-        execute :mkdir, '-pv', linked_dir_parents(release_path)
+        execute :mkdir, '-pv', linked_dir_parents(release_path).uniq
 
         fetch(:linked_dirs).each do |dir|
           target = release_path.join(dir)


### PR DESCRIPTION
Without uniq it will try to create multiple of the same folder if several have the same parent.  This makes it so that it only creates folders that are unique.
