### PR TITLE
Fixed asset:rollback fail when assets_manifest file is not found

### DIFF
--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -173,7 +173,7 @@ namespace :deploy do
       to shared/assets/manifest, and finally recompiling or regenerating nondigest assets.
     DESC
     task :rollback, :roles => lambda { assets_role }, :except => { :no_release => true } do
-      previous_manifest = capture("ls #{previous_release.shellescape}/assets_manifest.*").strip
+      previous_manifest = capture("ls #{previous_release.shellescape}/assets_manifest.* || echo").strip
       if capture("[ -e #{previous_manifest.shellescape} ] && echo true || echo false").strip != 'true'
         puts "#{previous_manifest} is missing! Cannot roll back assets. " <<
              "Please run deploy:assets:precompile to update your assets when the rollback is finished."


### PR DESCRIPTION
When assets_manifest file is not found in previous release folder, capture action (L:176) will fail and abort a whole rollback process. 
There is no problem is allowed to continue, because next step will check the whether file exists or not.
