### PR TITLE
Expose the release timestamp as a variable.

### DIFF
--- a/lib/capistrano/dsl/paths.rb
+++ b/lib/capistrano/dsl/paths.rb
@@ -24,6 +24,7 @@ module Capistrano
       end
 
       def set_release_path(timestamp=now)
+        set(:release_timestamp, timestamp)
         set(:release_path, releases_path.join(timestamp))
       end
 


### PR DESCRIPTION
Previously the only way to get this value was to extract it from the end of :release_path.

This is something I find useful to be able to use in my deploy tasks. We tag the git SHA with each deploy for instance.

This was the best approach I could figure out and seems pretty innocuous, but if anyone has a better suggestion I'm all ears.
