### PR TITLE
Compare servers by user, hostname and port

### DIFF
--- a/lib/capistrano/configuration/server.rb
+++ b/lib/capistrano/configuration/server.rb
@@ -51,7 +51,7 @@ module Capistrano
       end
 
       def matches?(other)
-        hostname == other.hostname && port == other.port
+        user == other.user && hostname == other.hostname && port == other.port
       end
 
       private

--- a/spec/integration/dsl_spec.rb
+++ b/spec/integration/dsl_spec.rb
@@ -201,16 +201,18 @@ describe Capistrano::DSL do
     describe 'when defining a host using a combination of the `server` and `role` syntax' do
 
       before do
-        dsl.server 'example1.com:1234', roles: %w{web}, active: true
+        dsl.server 'db@example1.com:1234', roles: %w{db}, active: true
+        dsl.server 'root@example1.com:1234', roles: %w{web}, active: true
         dsl.server 'example1.com:5678', roles: %w{web}, active: true
+        dsl.role :app, %w{deployer@example1.com:1234}
         dsl.role :app, %w{example1.com:5678}
       end
 
       describe 'fetching all servers' do
-        subject { dsl.roles(:all).map { |server| "#{server.hostname}:#{server.port}" } }
+        subject { dsl.roles(:all).map { |server| "#{server.user}@#{server.hostname}:#{server.port}" } }
 
-        it 'creates a server instance for each unique host:port combination' do
-          expect(subject).to eq %w{example1.com:1234 example1.com:5678}
+        it 'creates a server instance for each unique user@host:port combination' do
+          expect(subject).to eq %w{db@example1.com:1234 root@example1.com:1234 @example1.com:5678 deployer@example1.com:1234}
         end
       end
 
@@ -220,7 +222,7 @@ describe Capistrano::DSL do
         end
 
         it 'roles defined using the `role` syntax are included' do
-          expect(dsl.roles(:app)).to have(1).items
+          expect(dsl.roles(:app)).to have(2).items
         end
       end
 

--- a/spec/lib/capistrano/configuration/server_spec.rb
+++ b/spec/lib/capistrano/configuration/server_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Capistrano
   class Configuration
     describe Server do
-      let(:server) { Server.new('hostname:1234') }
+      let(:server) { Server.new('root@hostname:1234') }
 
       describe 'adding a role' do
         subject { server.add_role(:test) }
@@ -35,23 +35,23 @@ module Capistrano
       describe 'comparing identity' do
         subject { server.matches? Server[hostname] }
 
-        context 'with the same hostname' do
-          let(:hostname) { 'hostname:1234' }
+        context 'with the same user, hostname and port' do
+          let(:hostname) { 'root@hostname:1234' }
           it { should be_true }
         end
 
-        context 'with the same hostname and a user' do
-          let(:hostname) { 'user@hostname:1234' }
-          it { should be_true }
+        context 'with a different user' do
+          let(:hostname) { 'deployer@hostname:1234' }
+          it { should be_false }
         end
 
-        context 'with the same hostname but different port' do
-          let(:hostname) { 'hostname:5678' }
+        context 'with a different port' do
+          let(:hostname) { 'root@hostname:5678' }
           it { should be_false }
         end
 
         context 'with a different hostname' do
-          let(:hostname) { 'otherserver' }
+          let(:hostname) { 'root@otherserver:1234' }
           it { should be_false }
         end
       end

--- a/spec/lib/capistrano/configuration/servers_spec.rb
+++ b/spec/lib/capistrano/configuration/servers_spec.rb
@@ -106,10 +106,15 @@ module Capistrano
           expect(servers.roles_for([:all]).first.properties.test).to eq :value
         end
 
-        it 'can accept multiple servers with the same hostname but different ports' do
-          servers.add_host('2', roles: [:app, 'web'], test: :value, port: 12)
-          servers.add_host('2', roles: [:app, 'web'], test: :value, port: 34)
-          expect(servers.count { |server| server.hostname == '2' }).to eq 2
+        it 'can accept multiple servers with the same hostname but different ports or users' do
+          servers.add_host('1', roles: [:app, 'web'], test: :value, port: 12)
+          servers.add_host('1', roles: [:app, 'web'], test: :value, port: 34)
+          servers.add_host('1', roles: [:app, 'web'], test: :value, user: 'root')
+          servers.add_host('1', roles: [:app, 'web'], test: :value, user: 'deployer')
+          servers.add_host('1', roles: [:app, 'web'], test: :value, user: 'root', port: 34)
+          servers.add_host('1', roles: [:app, 'web'], test: :value, user: 'deployer', port: 34)
+          servers.add_host('1', roles: [:app, 'web'], test: :value, user: 'deployer', port: 56)
+          servers.should have(8).items
         end
       end
 


### PR DESCRIPTION
To check if servers match compare them by
user, hostname and port.

When servers match is checked just by hostname and port
there is no way to access to the same server with different users
to execute special actions allowed for specific users.

There are workarounds to do it. But I think it should be done in standard way
through matching/comparing servers by 'user@hostname:port'.

I have found previous merged pull request with similar problem (about port):
https://github.com/capistrano/capistrano/pull/801
and solved my issue in similar way.
