### PR TITLE
made deploy_to a proc so that it can be read after application is set

### DIFF
--- a/lib/capistrano/defaults.rb
+++ b/lib/capistrano/defaults.rb
@@ -1,6 +1,6 @@
 set :scm, :git
 set :branch, :master
-set :deploy_to, "/var/www/#{fetch(:application)}"
+set :deploy_to, -> { "/var/www/#{fetch(:application)}" }
 set :tmp_dir, "/tmp"
 
 set :default_env, {}


### PR DESCRIPTION
This fixes the actual behavior to match what's advertised in [the config/deploy.rb template](https://github.com/capistrano/capistrano/blob/master/lib/capistrano/templates/deploy.rb.erb#L10)
