### PR TITLE
made log_revision log the revision of the configured branch, not master

### DIFF
--- a/lib/capistrano/dsl.rb
+++ b/lib/capistrano/dsl.rb
@@ -56,7 +56,7 @@ module Capistrano
 
     private
     def fetch_revision
-      capture("cd #{repo_path} && git rev-parse --short HEAD")
+      capture("cd #{repo_path} && git rev-parse --short #{fetch(:branch)}")
     end
   end
 end


### PR DESCRIPTION
There are a few factors that made this go unnoticed until now:
1) previous_revision is set but never read
2) current_revision is set but only read when logging the revision to a file on the server that is rarely, if ever, looked at
3) [cap-deploy-tagger](https://github.com/forward3d/cap-deploy-tagger) behaves incorrectly--it really should `fetch(:current_revision)`, but does not.  I've submitted a [PR there](https://github.com/forward3d/cap-deploy-tagger/pull/1) too.
