### PR TITLE
Added ability to add args to callbacks `after` and `before`.

### DIFF
--- a/lib/capistrano/dsl/task_enhancements.rb
+++ b/lib/capistrano/dsl/task_enhancements.rb
@@ -2,14 +2,16 @@ module Capistrano
   module TaskEnhancements
     def before(task, prerequisite, *args, &block)
       prerequisite = Rake::Task.define_task(prerequisite, *args, &block) if block_given?
-      Rake::Task[task].enhance [prerequisite]
+      Rake::Task[task].enhance do
+        Rake::Task[prerequisite].invoke(*args)
+      end
     end
 
     def after(task, post_task, *args, &block)
       Rake::Task.define_task(post_task, *args, &block) if block_given?
       post_task = Rake::Task[post_task]
       Rake::Task[task].enhance do
-        post_task.invoke
+        post_task.invoke(args)
       end
     end
 


### PR DESCRIPTION
Commet from @michamilz: http://www.jetthoughts.com/tech/2013/09/26/capistrano-3-passing-parameters-to-your-task.html#comment-1233054544

Added ability to provide args to callbacks. Example we have task with args:

``` ruby
desc 'Example of task with args'
task :uname, :opt do |task, args|
  on roles(:app) do
    execute :uname, args[:opt]
  end
end
```

To provide args for callbacks in current version:

``` ruby
before :started, "uname_a" do
  Rake::Task[:uname].invoke('-a')
end
```

Added a new implementation:

``` ruby
before :started, :uname, '-a'
```
