### PR TITLE
make sure deploying? method is available beofre testing it, fix #915

### DIFF
--- a/lib/capistrano/application.rb
+++ b/lib/capistrano/application.rb
@@ -33,7 +33,7 @@ module Capistrano
     end
 
     def exit_because_of_exception(ex)
-      if deploying?
+      if respond_to?(:deploying?) && deploying?
         exit_deploy_because_of_exception(ex)
       else
         super


### PR DESCRIPTION
any problem in `Capfile` will be to early for the `deploying?` method to be defined, this suppresses the real problem and prints error about missing `deploying?` method, I was able to simulate it by missing to add quote in `Capfile`, a full repository reproducing it => https://github.com/mpapis/broken-capistrano-project

Before the fix:

``` ssh
cap production bundler:install
cap aborted!
/home/mpapis/projects/owned/broken-capistrano-project/Capfile:18: syntax error, unexpected tIDENTIFIER, expecting end-of-input
# require 'capistrano/rvm'
                     ^
/home/mpapis/.rvm/gems/ruby-2.1.0/gems/capistrano-3.1.0/lib/capistrano/application.rb:24:in `load_rakefile'
/home/mpapis/.rvm/gems/ruby-2.1.0/gems/capistrano-3.1.0/lib/capistrano/application.rb:15:in `run'
/home/mpapis/.rvm/gems/ruby-2.1.0/gems/capistrano-3.1.0/bin/cap:3:in `<top (required)>'
/home/mpapis/.rvm/gems/ruby-2.1.0/bin/cap:23:in `load'
/home/mpapis/.rvm/gems/ruby-2.1.0/bin/cap:23:in `<main>'
/home/mpapis/.rvm/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `eval'
/home/mpapis/.rvm/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `<main>'
(See full trace by running task with --trace)
cap aborted!
undefined method `deploying?' for #<Capistrano::Application:0x00000000faea38>
/home/mpapis/.rvm/gems/ruby-2.1.0/gems/capistrano-3.1.0/lib/capistrano/application.rb:36:in `exit_because_of_exception'
/home/mpapis/.rvm/gems/ruby-2.1.0/gems/capistrano-3.1.0/lib/capistrano/application.rb:24:in `load_rakefile'
/home/mpapis/.rvm/gems/ruby-2.1.0/gems/capistrano-3.1.0/lib/capistrano/application.rb:15:in `run'
/home/mpapis/.rvm/gems/ruby-2.1.0/gems/capistrano-3.1.0/bin/cap:3:in `<top (required)>'
/home/mpapis/.rvm/gems/ruby-2.1.0/bin/cap:23:in `load'
/home/mpapis/.rvm/gems/ruby-2.1.0/bin/cap:23:in `<main>'
/home/mpapis/.rvm/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `eval'
/home/mpapis/.rvm/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `<main>'
(See full trace by running task with --trace)
/home/mpapis/.rvm/gems/ruby-2.1.0/gems/capistrano-3.1.0/lib/capistrano/application.rb:36:in `exit_because_of_exception': undefined method `deploying?' for #<Capistrano::Application:0x00000000faea38> (NoMethodError)
        from /home/mpapis/.rvm/gems/ruby-2.1.0/gems/rake-10.1.1/lib/rake/application.rb:175:in `rescue in standard_exception_handling'
        from /home/mpapis/.rvm/gems/ruby-2.1.0/gems/rake-10.1.1/lib/rake/application.rb:165:in `standard_exception_handling'
        from /home/mpapis/.rvm/gems/ruby-2.1.0/gems/rake-10.1.1/lib/rake/application.rb:75:in `run'
        from /home/mpapis/.rvm/gems/ruby-2.1.0/gems/capistrano-3.1.0/lib/capistrano/application.rb:15:in `run'
        from /home/mpapis/.rvm/gems/ruby-2.1.0/gems/capistrano-3.1.0/bin/cap:3:in `<top (required)>'
        from /home/mpapis/.rvm/gems/ruby-2.1.0/bin/cap:23:in `load'
        from /home/mpapis/.rvm/gems/ruby-2.1.0/bin/cap:23:in `<main>'
        from /home/mpapis/.rvm/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `eval'
        from /home/mpapis/.rvm/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `<main>'
```

after the fix:

``` ssh
cap aborted!
/home/mpapis/projects/owned/broken-capistrano-project/Capfile:18: syntax error, unexpected tIDENTIFIER, expecting end-of-input
# require 'capistrano/rvm'
                     ^
/home/mpapis/.rvm/gems/ruby-2.1.0/gems/capistrano-3.1.0/lib/capistrano/application.rb:24:in `load_rakefile'
/home/mpapis/.rvm/gems/ruby-2.1.0/gems/capistrano-3.1.0/lib/capistrano/application.rb:15:in `run'
/home/mpapis/.rvm/gems/ruby-2.1.0/gems/capistrano-3.1.0/bin/cap:3:in `<top (required)>'
/home/mpapis/.rvm/gems/ruby-2.1.0/bin/cap:23:in `load'
/home/mpapis/.rvm/gems/ruby-2.1.0/bin/cap:23:in `<main>'
/home/mpapis/.rvm/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `eval'
/home/mpapis/.rvm/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `<main>'
(See full trace by running task with --trace)
```
