### PR TITLE
Support Git submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Reverse Chronological Order:
   * Readme corrections (@nathanstitt)
   * Allow roles to be fetched with a variable containing an array (@seenmyfate)
   * Improve console (@jage)
+  * Support Git submodules by setting `git_strategy` to `:clone` (@seenmyfate)
 
 ## `3.0.1`
 

--- a/features/deploy_via_clone.feature
+++ b/features/deploy_via_clone.feature
@@ -1,0 +1,11 @@
+Feature: Deploy via clone
+
+  Background:
+    Given a test app with git clone configuration
+    And servers with the roles app and web
+
+  Scenario: Creating a release
+    Given I run cap "deploy:check:directories"
+    When I run cap "git:create_release" as part of a release
+    Then the repo is cloned
+    And the release is created

--- a/features/step_definitions/setup.rb
+++ b/features/step_definitions/setup.rb
@@ -2,6 +2,10 @@ Given(/^a test app with the default configuration$/) do
   TestApp.install
 end
 
+Given(/^a test app with git clone configuration$/) do
+  TestApp.install('set :git_strategy, :clone')
+end
+
 Given(/^servers with the roles app and web$/) do
   vagrant_cli_command('up')
 end

--- a/lib/capistrano/tasks/git.rake
+++ b/lib/capistrano/tasks/git.rake
@@ -54,6 +54,24 @@ namespace :git do
 
   desc 'Copy repo to releases'
   task create_release: :'git:update' do
+    invoke "git:create_release_via_#{fetch(:git_strategy, :archive)}"
+  end
+
+  task :create_release_via_clone do
+    on roles :all do
+      with fetch(:git_environmental_variables) do
+        within repo_path do
+          execute :git, :clone, '--branch', fetch(:branch),               \
+            '--depth 1',                                                  \
+            '--recursive',                                                \
+            '--no-hardlinks',                                             \
+            repo_path, release_path
+        end
+      end
+    end
+  end
+
+  task :create_release_via_archive do
     on release_roles :all do
       with fetch(:git_environmental_variables) do
         within repo_path do

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -2,11 +2,11 @@ require 'fileutils'
 module TestApp
   extend self
 
-  def install
-    install_test_app_with(default_config)
+  def install(override='')
+    install_test_app_with(default_config(override))
   end
 
-  def default_config
+  def default_config(override='')
     %{
       set :deploy_to, '#{deploy_to}'
       set :repo_url, 'git://github.com/capistrano/capistrano.git'
@@ -15,6 +15,7 @@ module TestApp
       server 'vagrant@localhost:2220', roles: %w{web app}
       set :linked_files, #{linked_files}
       set :linked_dirs, #{linked_dirs}
+      #{override}
     }
   end
 


### PR DESCRIPTION
An alternative approach to #822 - this allows the setting of a single
`git_strategy` variable which can be set to `:archive` (the default, as
it is the current functionality) or `:clone` which includes the
`--recursive` flag in order to support submodules.
