### PR TITLE
Support branch in fetch_revision method

### DIFF
--- a/lib/capistrano/dsl.rb
+++ b/lib/capistrano/dsl.rb
@@ -56,7 +56,7 @@ module Capistrano
 
     private
     def fetch_revision
-      capture("cd #{repo_path} && git rev-parse --short HEAD")
+      capture("cd #{repo_path} && git rev-parse --short #{fetch(:branch)}")
     end
   end
 end


### PR DESCRIPTION
Besides the fetch_revision method only working for a scm set to :git it also does not support the set branch.
