### PR TITLE
Add :scm_path configuration option

### DIFF
--- a/lib/capistrano/setup.rb
+++ b/lib/capistrano/setup.rb
@@ -13,7 +13,7 @@ stages.each do |stage|
     invoke 'load:defaults'
     load deploy_config_path
     load stage_config_path.join("#{stage}.rb")
-    load "capistrano/#{fetch(:scm)}.rb"
+    load "#{fetch(:scm_path, 'capistrano')}/#{fetch(:scm)}.rb"
     I18n.locale = fetch(:locale, :en)
     configure_backend
   end


### PR DESCRIPTION
`:scm_path` configuration option allow to define in which directory to look for custom scm.

Example: to use the custom scm file _my_scm.rb_ located in your application's _lib/capistrano_ folder, set in your config.rb the 2 directives:

```
set :scm, :my_scm
set :scm_path, 'lib/capistrano'
```
