### PR TITLE
Call branch proc by default in deploy.rb template.

### DIFF
--- a/lib/capistrano/templates/deploy.rb.erb
+++ b/lib/capistrano/templates/deploy.rb.erb
@@ -5,7 +5,7 @@ set :application, 'my_app_name'
 set :repo_url, 'git@example.com:me/my_repo.git'
 
 # Default branch is :master
-# ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }
+# ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call
 
 # Default deploy_to directory is /var/www/my_app
 # set :deploy_to, '/var/www/my_app'


### PR DESCRIPTION
If a proc is used in an ask and no input is entered for the ask, `question.rb` will use the default value, which is a proc object and _not_ its returned value. 

Without `.call`, we can get issues like the following, from `capistrano-rsync`:

Code:

``` ruby
checkout = %W[git reset --hard origin/#{fetch(:branch)}]
Kernel.system *checkout
```

Error:

```
Please enter branch: |master|

fatal: Invalid object name 'origin/#<Proc'.
cap aborted!
```
