### PR TITLE
Fixed a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,9 +258,9 @@ connections behind the scenes in Capistrano. Depending on how deep you dig, you
 might run into interfaces that come directly from SSHKit (the configuration is
 a good example).
 
-## Licence
+## License
 
-The MIT License (MIT)
+MIT License (MIT)
 
 Copyright (c) 2012-2013 Tom Clements, Lee Hambley
 


### PR DESCRIPTION
Fixed simple spelling error with the word License.
Updated the README.md MIT License copy with the exact copy from the LICENSE.txt file.
