### PR TITLE
Added "No-Op" deploy strategy

### DIFF
--- a/lib/capistrano/noop.rb
+++ b/lib/capistrano/noop.rb
@@ -1,0 +1,25 @@
+load File.expand_path("../tasks/noop.rake", __FILE__)
+
+require 'capistrano/scm'
+
+class Capistrano::Noop < Capistrano::SCM
+
+  # The Capistrano default strategy for git. You should want to use this.
+  module DefaultStrategy
+    def test
+    end
+
+    def check
+      test! " [ -d #{repo_path} ] "
+    end
+
+    def clone
+    end
+
+    def update
+    end
+
+    def release
+    end
+  end
+end

--- a/lib/capistrano/tasks/noop.rake
+++ b/lib/capistrano/tasks/noop.rake
@@ -1,0 +1,31 @@
+namespace :noop do
+
+  def strategy
+    @strategy ||= Capistrano::Noop.new(self, fetch(:noop_strategy, Capistrano::Noop::DefaultStrategy))
+  end
+
+  desc 'Check that the repository is reachable'
+  task :check do
+    on release_roles :all do
+      exit 1 unless strategy.check
+    end
+  end
+
+  desc 'Clone the repo to the cache'
+  task :clone do
+  end
+
+  desc 'Update the repo mirror to reflect the origin state'
+  task :update do
+  end
+
+  desc 'Copy repo to releases'
+  task :create_release do
+    on release_roles :all do
+      within repo_path do
+        execute :ln, '-s', repo_path, release_path
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Development using Vagrant VMs is quite common so far. Still, some tasks should be executed automatically both on dev and test/prod environments, so it makes sense to write Capistrano tasks for them. This deploy strategy allows to have a network mount (NFS, Virtualbox shared folders or anything else) to share the source code with the VM, and allows developers to write/work with capistrano tasks and test them locally before using them to production, retaining the ability to change code on-the-fly and see the effects immediately on the VM.
By default, it uses the "repo" folder, as used by the other SCM classes.
Basically, this strategy does nothing except for creating a symlink to the "repo" folder every time the deploy is executed, then the "current" symlink can be created. Yeah, a symlink pointing to a symlink is not the best, but...better ideas?
