### PR TITLE
No need to define a method that only calls "super"

### DIFF
--- a/lib/capistrano/application.rb
+++ b/lib/capistrano/application.rb
@@ -20,10 +20,6 @@ module Capistrano
       super
     end
 
-    def load_rakefile
-      super
-    end
-
     def top_level_tasks
       if tasks_without_stage_dependency.include?(@top_level_tasks.first)
         @top_level_tasks


### PR DESCRIPTION
It used to also define "@name = 'cap'" originally: https://github.com/capistrano/capistrano/commit/de6367af4ea3ea786fe78221cfd3838c827c5e0c
