### PR TITLE
Don't ignore options passed to release_roles

### DIFF
--- a/lib/capistrano/dsl/env.rb
+++ b/lib/capistrano/dsl/env.rb
@@ -45,11 +45,8 @@ module Capistrano
 
       def release_roles(*names)
         options = { exclude: :no_release }
-        if names.last.is_a? Hash
-          names.last.merge(options)
-        else
-          names << options
-        end
+        options.merge! names.pop if names.last.is_a? Hash
+        names << options
         roles(*names)
       end
 


### PR DESCRIPTION
Previously the merge wouldn't change the options in place.

I thought about changing it to merge! but I'm not sure if it's a good idea to have such side effect.
