### PR TITLE
Add Configuration#set_default.

### DIFF
--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -24,6 +24,10 @@ module Capistrano
       config[key] = value
     end
 
+    def set_default(key, value)
+      set(key, value) unless config.has_key?(key)
+    end
+
     def delete(key)
       config.delete(key)
     end

--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -105,6 +105,26 @@ module Capistrano
       end
     end
 
+    describe '#set_default' do
+      context 'value is set' do
+        before do
+          config.set(:key, :value)
+        end
+
+        it 'does not call #set' do
+          config.expects(:set).with(:key, :value).never
+          config.set_default(:key, :value)
+        end
+      end
+
+      context 'value is not set' do
+        it 'calls #set' do
+          config.expects(:set).with(:key, :value)
+          config.set_default(:key, :value)
+        end
+      end
+    end
+
     describe 'deleting' do
       before do
         config.set(:key, :value)


### PR DESCRIPTION
It is quite convenient to be able to set default value for some key. It
is possible to use `#fetch(:key, :default)` whenever we need, but `#set_default` seems
more convenient and straightforward.
