### PR TITLE
Use a string for the ensure_stage task for Rake 10.2.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Reverse Chronological Order:
 * Minor changes:
   * Added `keys` method to Server properties to allow introspection of automatically added
     properties.
+  * Compatibility with Rake 10.2.0 - `ensure_task` is now added to `@top_level_tasks` as a string. (@dmarkow)
 
 ## `3.1.0`
 

--- a/lib/capistrano/application.rb
+++ b/lib/capistrano/application.rb
@@ -24,7 +24,7 @@ module Capistrano
       if tasks_without_stage_dependency.include?(@top_level_tasks.first)
         @top_level_tasks
       else
-        @top_level_tasks.unshift(ensure_stage)
+        @top_level_tasks.unshift(ensure_stage.to_s)
       end
     end
 


### PR DESCRIPTION
Rake 10.2.0 changed the way it parses tasks. Previously, its `parse_task_string` method worked fine with `Rake::Task` objects, but the updated logic places the task name on the right side of a `=~` comparison, raising `TypeError: no implicit conversion of Rake::Task into String` when it tries to parse the `ensure_stage` task. While not documented explicitly, the fact that the method is named `def parse_task_string(string)` implies that it should always be given a `String` object.

Making sure `ensure_task` is added to `@top_level_tasks` as a string instead of a Rake::Task object fixes this.
