### PR TITLE
use a meeker test command for Git check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Reverse Chronological Order:
 * Minor changes:
   * Added `keys` method to Server properties to allow introspection of automatically added
     properties.
+  * Amended the git check command, "ls-remote", to use "-h", limiting the list to refs/heads
 
 ## `3.1.0`
 

--- a/lib/capistrano/git.rb
+++ b/lib/capistrano/git.rb
@@ -18,7 +18,7 @@ class Capistrano::Git < Capistrano::SCM
     end
 
     def check
-      test! :git, :'ls-remote', repo_url
+      test! :git, :'ls-remote -h', repo_url
     end
 
     def clone

--- a/spec/lib/capistrano/git_spec.rb
+++ b/spec/lib/capistrano/git_spec.rb
@@ -31,7 +31,7 @@ module Capistrano
     describe "#check" do
       it "should test the repo url" do
         context.expects(:repo_url).returns(:url)
-        context.expects(:test).with(:git, :'ls-remote', :url).returns(true)
+        context.expects(:test).with(:git, :'ls-remote -h', :url).returns(true)
 
         subject.check
       end


### PR DESCRIPTION
i'm suggesting an alternate, less eager, Git.check command. my understanding is that the "ls-remote" is a somewhat arbitrary command to check the existence of a repo (correct me if i'm wrong).

in the project i'm working on, this dumps 13,000 lines of git tags\* to the console, which is a bummer.

the amended command will return a more limited list, and works for me. and will perhaps work out until someone comes along that has 13,000 branches on their repo.

then plumbing a higher log level through for this command might be worthwhile.

let me know what you think

*if this seems extreme, just imagine CI tagging a busy repo several times a day for several years
