### PR TITLE
Log correct SHA when deploying non master branch.

### DIFF
--- a/lib/capistrano/dsl.rb
+++ b/lib/capistrano/dsl.rb
@@ -55,8 +55,8 @@ module Capistrano
     end
 
     private
-    def fetch_revision
-      capture("cd #{repo_path} && git rev-parse --short HEAD")
+    def fetch_revision(branch = fetch(:branch, 'HEAD'))
+      capture("cd #{repo_path.to_s.shellescape} && git rev-parse --short #{branch.to_s.shellescape}")
     end
   end
 end


### PR DESCRIPTION
Every call that depends on fetch_revision used wrong SHA, when non master/HEAD branch was deployed.

This patch changes it to ask for branch or HEAD if not supplied.

Also properly escapes path and branch name.
