### PR TITLE
Allow lambdas with arity > 0 as config options

### DIFF
--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -30,7 +30,7 @@ module Capistrano
 
     def fetch(key, default=nil, &block)
       value = fetch_for(key, default, &block)
-      while value.respond_to?(:call)
+      while callable_without_parameters?(value)
         value = set(key, value.call)
       end
       return value
@@ -98,5 +98,8 @@ module Capistrano
       end
     end
 
+    def callable_without_parameters?(x)
+      x.respond_to?(:call) && ( !x.respond_to?(:arity) || x.arity == 0)
+    end
   end
 end

--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -96,6 +96,13 @@ module Capistrano
         end
       end
 
+      context 'lambda with parameters' do
+        subject { config.fetch(:key, lambda { |c| c }).call(42) }
+        it 'is returned as a lambda' do
+          expect(subject).to eq 42
+        end
+      end
+
       context 'block is passed to fetch' do
         subject { config.fetch(:key, :default) { fail 'we need this!' } }
 


### PR DESCRIPTION
Previously it was possible to `set` a lambda with one or more
parameters as a configuration option, but at runtime an error was
thrown when `fetch`ing it. This was caused by the fact that every
callable was directly invoke in `fetch`.

This PR allows for lambdas with an arity > 0 to be retrieved
through `fetch`. All values that respond to call and NOT to
`arity` are still invoked directly by `fetch`.
