### PR TITLE
Allow introspection of configuration values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Reverse Chronological Order:
 
 https://github.com/capistrano/capistrano/compare/v3.2.0...HEAD
 
+* Minor changes:
+  * Added `keys` method to Configuration to allow introspection of configuration options. (@juanibiapina)
+
 ## `3.2.0`
 
 The changelog entries here are incomplete, because many authors choose not to

--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -36,6 +36,10 @@ module Capistrano
       return value
     end
 
+    def keys
+      config.keys
+    end
+
     def role(name, hosts, options={})
       if name == :all
         raise ArgumentError.new("#{name} reserved name for role. Please choose another name")

--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -112,6 +112,19 @@ module Capistrano
       end
     end
 
+    describe 'keys' do
+      subject { config.keys }
+
+      before do
+        config.set(:key1, :value1)
+        config.set(:key2, :value2)
+      end
+
+      it 'returns all set keys' do
+        expect(subject).to match_array [:key1, :key2]
+      end
+    end
+
     describe 'deleting' do
       before do
         config.set(:key, :value)


### PR DESCRIPTION
Add a 'keys' method to capistrano/configuration. This method can be used
to introspect on all currently set configuration keys to allow
configuration dumps, for instance.

Improved from #958 and initial idea from #957.

I have squashed everything in one commit, rebased with master and reworked the commit message and description block. Also added an entry to the changelog under master. I checked the tag comparison and it also looks good to me. Anything else?
