### PR TITLE
Fix order of before and after hooks.

### DIFF
--- a/lib/capistrano/dsl/task_enhancements.rb
+++ b/lib/capistrano/dsl/task_enhancements.rb
@@ -2,16 +2,14 @@ module Capistrano
   module TaskEnhancements
     def before(task, prerequisite, *args, &block)
       prerequisite = Rake::Task.define_task(prerequisite, *args, &block) if block_given?
-      Rake::Task[task].enhance do
-        Rake::Task[prerequisite].invoke(*args)
-      end
+      Rake::Task[task].enhance [prerequisite]
     end
 
-    def after(task, post_task, *args, &block)
-      Rake::Task.define_task(post_task, *args, &block) if block_given?
+    def after(task, post_task, *formal_args, &block)
+      Rake::Task.define_task(post_task, *formal_args, &block) if block_given?
       post_task = Rake::Task[post_task]
-      Rake::Task[task].enhance do
-        post_task.invoke(args)
+      Rake::Task[task].enhance do |t, real_args|
+        post_task.invoke(*real_args)
       end
     end
 

--- a/spec/lib/capistrano/dsl/task_enhancements_spec.rb
+++ b/spec/lib/capistrano/dsl/task_enhancements_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+module Capistrano
+  class DummyTaskEnhancements
+    include TaskEnhancements
+  end
+
+  describe TaskEnhancements do
+    let(:task_enhancements) { DummyTaskEnhancements.new }
+
+    describe 'ordering' do
+      let!(:task) do
+        Rake::Task.define_task('task', [:order]) do |t, args|
+          args['order'].push 'task'
+        end
+      end
+!
+      let!(:before_task) do
+        Rake::Task.define_task('before_task', [:order]) do |t, args|
+          args['order'].push 'before_task'
+        end
+      end
+
+      let!(:after_task) do
+        Rake::Task.define_task('after_task', [:order]) do |t, args|
+          args['order'].push 'after_task'
+        end
+      end
+
+      it 'invokes in proper order and forwarding arguments' do
+        task_enhancements.after('task', 'after_task')
+        task_enhancements.before('task', 'before_task')
+
+        order = []
+
+        Rake::Task['task'].invoke(order)
+
+        expect(order).to eq(['before_task', 'task', 'after_task'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Also fix passing arguments to tasks executed by before and after hooks.

This fixes both issues and has tests, although somewhat weird tests. I would prefer the tests were refactored, but I'm almost running out of time to work on this.

The code itself seems fine. It uses rake task prerequisites for the before hooks (which already pass arguments) and manually passes the arguments to after hooks (and I included a small variable name change to clarify what I understood to be the formal and real parameters).

Bug report was #1004 and original pull request was #928.
