### PR TITLE
Fixed typos in README, password authentication section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Reverse Chronological Order:
 https://github.com/capistrano/capistrano/compare/v3.2.0...HEAD
 
 * Minor changes:
+  * Fixed typos in the README. (@sponomarev)
   * Added `keys` method to Configuration to allow introspection of configuration options. (@juanibiapina)
 
 ## `3.2.0`

--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ Perfect, who needs telephones.
 
 ## Using password authentication
 
-Password authentication can be done via `set` and `ask` in your deploy environment file (e.g.: config/environments/production.rb)
+Password authentication can be done via `set` and `ask` in your deploy environment file (e.g.: config/deploy/production.rb)
 
 ```ruby
-set :password, ask('Server password:', nil)
+set :password, ask('Server password', nil)
 server 'server.domain.com', user: 'ssh_user_name', port: 22, password: fetch(:password), roles: %w{web app db}
 ```
 


### PR DESCRIPTION
1) First change fixes invalid path for deploy environment file.
2) Second change fix double ':' in password prompt.
