### PR TITLE
Use svnversion to capture svn revision number

### DIFF
--- a/lib/capistrano/svn.rb
+++ b/lib/capistrano/svn.rb
@@ -28,7 +28,7 @@ class Capistrano::Svn < Capistrano::SCM
     end
 
     def release
-      svn :export, '.', release_path
+      svn :export, '--force', '.', release_path
     end
 
     def fetch_revision


### PR DESCRIPTION
I was running into an issue with the `sed` part of the previous implementation (using GNU sed 4.2.1, from Debian Wheezy), so at first I set out to fix that issue. But then I discovered the `svnversion` command that ships with `svn`, and that seems to do the trick just as well.
