### PR TITLE
Use --force for svn export command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ https://github.com/capistrano/capistrano/compare/v3.2.0...HEAD
   * Changed asking question to more standard format (like common unix commandline tools) (@sponomarev)
   * Fixed typos in the README. (@sponomarev)
   * Added `keys` method to Configuration to allow introspection of configuration options. (@juanibiapina)
+  * Added `--force` flag to `svn export` command to fix errors when the release
+    directory already exists.
 
 ## `3.2.0`
 

--- a/lib/capistrano/svn.rb
+++ b/lib/capistrano/svn.rb
@@ -28,7 +28,7 @@ class Capistrano::Svn < Capistrano::SCM
     end
 
     def release
-      svn :export, '.', release_path
+      svn :export, '--force', '.', release_path
     end
 
     def fetch_revision

--- a/spec/lib/capistrano/svn_spec.rb
+++ b/spec/lib/capistrano/svn_spec.rb
@@ -60,7 +60,7 @@ module Capistrano
       it "should run svn export" do        
         context.expects(:release_path).returns(:path)
         
-        context.expects(:execute).with(:svn, :export, '.', :path)
+        context.expects(:execute).with(:svn, :export, '--force', '.', :path)
 
         subject.release
       end


### PR DESCRIPTION
Since the release path directory has already been created when the `svn export` command runs, it chokes and won't override the existing directory. This adds the `--force` option to that command so that the release path is allowed.
