### PR TITLE
Use svnversion to capture svn revision number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Breaking Changes:
   * Cucumber suite now runs on the latest version of Vagrant (@tpett)
   * The `ask` method now supports the `echo: false` option. (@mbrictson, @kaikuchn)
   * Added suggestion to Capfile to use 'capistrano-passenger' gem, replacing suggestion in config/deploy.rb to re-implement 'deploy:restart' (@betesh)
+  * Updated svn fetch_revision method to use `svnversion`
 
 ## `3.2.1`
 

--- a/lib/capistrano/svn.rb
+++ b/lib/capistrano/svn.rb
@@ -32,7 +32,7 @@ class Capistrano::Svn < Capistrano::SCM
     end
 
     def fetch_revision
-      context.capture(:svn, "log -l 1 -q | tail -n 2 | head -n 1 | sed s/\\ \\|.*/''/")
+      context.capture(:svnversion, repo_path)
     end
   end
 end

--- a/spec/lib/capistrano/svn_spec.rb
+++ b/spec/lib/capistrano/svn_spec.rb
@@ -68,16 +68,9 @@ module Capistrano
 
     describe "#fetch_revision" do
       it "should run fetch revision" do
-        require 'open3'
-        parse_revision = "tail -n 2 | head -n 1 | sed s/\\ \\|.*/''/"
-        Open3.popen2(parse_revision) do |stdin, stdout, wait_thr|
-          stdin.puts("---\nr12345 | xxxxxxx\n---") # output of svn log
-          stdin.close
-          expect(stdout.gets).to eq "r12345\n"
-          expect(wait_thr.value).to eq 0
-        end
+        context.expects(:repo_path).returns(:path)
 
-        context.expects(:capture).with(:svn, "log -l 1 -q | " + parse_revision)
+        context.expects(:capture).with(:svnversion, :path)
 
         subject.fetch_revision
       end


### PR DESCRIPTION
I was running into an issue with the sed part of the previous implementation (using GNU sed 4.2.1, from Debian Wheezy), so at first I set out to fix that issue. But then I discovered the svnversion command that ships with svn, and that seems to do the trick just as well.
