### PR TITLE
Show useful message when git:check fails, rather than silently exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ https://github.com/capistrano/capistrano/compare/v3.2.0...HEAD
   * Changed asking question to more standard format (like common unix commandline tools) (@sponomarev)
   * Fixed typos in the README. (@sponomarev)
   * Added `keys` method to Configuration to allow introspection of configuration options. (@juanibiapina)
+  * Improve error message when git:check fails (raise instead of silently `exit 1`) (@mbrictson)
 
 ## `3.2.0`
 

--- a/lib/capistrano/git.rb
+++ b/lib/capistrano/git.rb
@@ -18,7 +18,7 @@ class Capistrano::Git < Capistrano::SCM
     end
 
     def check
-      test! :git, :'ls-remote -h', repo_url
+      git :'ls-remote -h', repo_url
     end
 
     def clone

--- a/lib/capistrano/tasks/git.rake
+++ b/lib/capistrano/tasks/git.rake
@@ -25,7 +25,7 @@ namespace :git do
     fetch(:branch)
     on release_roles :all do
       with fetch(:git_environmental_variables) do
-        exit 1 unless strategy.check
+        strategy.check
       end
     end
   end

--- a/spec/lib/capistrano/git_spec.rb
+++ b/spec/lib/capistrano/git_spec.rb
@@ -31,7 +31,7 @@ module Capistrano
     describe "#check" do
       it "should test the repo url" do
         context.expects(:repo_url).returns(:url)
-        context.expects(:test).with(:git, :'ls-remote -h', :url).returns(true)
+        context.expects(:execute).with(:git, :'ls-remote -h', :url).returns(true)
 
         subject.check
       end


### PR DESCRIPTION
Unless `:log_level` is set to debug, `git:check` will not show any useful output when it fails. In fact, unless you check the exit status of the cap process, it will seem as if it succeeded.

This is what a git:check **failure** looks like:

```
INFO [d2be8377] Running /usr/bin/env chmod +x /tmp/myapp/git-ssh.sh on ###.###.###.###
INFO [d2be8377] Finished in 0.151 seconds with exit status 0 (successful).
```

Misleading, no?

This pull request alters the code slightly to use `execute` rather than `test`. This means that an exception is raised when git:check fails. The exception, in turn, provides useful troubleshooting information.

Now a git:check failure will look like:

```
INFO [dae2f9a7] Running /usr/bin/env chmod +x /tmp/myapp/git-ssh.sh on ###.###.###.###
 INFO [dae2f9a7] Finished in 0.172 seconds with exit status 0 (successful).
 INFO [cb8210c0] Running /usr/bin/env git ls-remote -h git@bitbucket.org:mbrictson/myapp.git on ###.###.###.###
cap aborted!
SSHKit::Command::Failed: git exit status: 128
git stdout: Nothing written
git stderr: conq: repository does not exist.
fatal: The remote end hung up unexpectedly
/Users/mbrictson/Work/capistrano/lib/capistrano/git.rb:11:in `git'
/Users/mbrictson/Work/capistrano/lib/capistrano/git.rb:21:in `check'
/Users/mbrictson/Work/capistrano/lib/capistrano/tasks/git.rake:28:in `block (4 levels) in <top (required)>'
/Users/mbrictson/Work/capistrano/lib/capistrano/tasks/git.rake:27:in `block (3 levels) in <top (required)>'
Tasks: TOP => git:check
(See full trace by running task with --trace)
```
