### PR TITLE
Update dsl#local_user method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Reverse Chronological Order:
 https://github.com/capistrano/capistrano/compare/v3.2.0...HEAD
 
 * Minor changes:
+  * Update dsl#local_user method and add test for it. (@bruno-)
   * Revert short sha1 revision with git. (@blaugueux)
   * Changed asking question to more standard format (like common unix commandline tools) (@sponomarev)
   * Fixed typos in the README. (@sponomarev)

--- a/lib/capistrano/dsl.rb
+++ b/lib/capistrano/dsl.rb
@@ -1,3 +1,4 @@
+require 'etc'
 require 'capistrano/dsl/task_enhancements'
 require 'capistrano/dsl/paths'
 require 'capistrano/dsl/stages'
@@ -41,7 +42,7 @@ module Capistrano
     end
 
     def local_user
-      `whoami`
+      Etc.getlogin
     end
 
     def lock(locked_version)

--- a/spec/lib/capistrano/dsl_spec.rb
+++ b/spec/lib/capistrano/dsl_spec.rb
@@ -48,5 +48,16 @@ module Capistrano
         dsl.sudo(:my, :command)
       end
     end
+
+    describe '#local_user' do
+
+      before do
+        Etc.expects(:getlogin)
+      end
+
+      it 'delegates to Etc#getlogin' do
+        dsl.local_user
+      end
+    end
   end
 end


### PR DESCRIPTION
- uses more portable `Etc#getlogin`.
- previous implementation with `whoami` returns a string with a newline
  at the end. This implementation returns a clean string. As a
  consequence `revisions.log` does not have a trailing `;` character at
  the end.

As mentioned above, this change has impact to `revisions.log` file (for the better I think). Here's the `revisions.log` before the change:

```
Branch master (at 94e6a4f) deployed as release 20140420124518 by user;
Branch master (at 94e6a4f) deployed as release 20140420130613 by user;
```

after:

```
Branch master (at 94e6a4f) deployed as release 20140420124518 by user
Branch master (at 94e6a4f) deployed as release 20140420130613 by user
```

Notice the semicolon at the end is gone - that's the only change.
