### PR TITLE
Fix compatibility with FreeBSD tar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Reverse Chronological Order:
 
 https://github.com/capistrano/capistrano/compare/v3.2.1...HEAD
 
+* Bug Fixes:
+  * Fixed compatibility with FreeBSD tar (@robbertkl)
+
 * Minor Changes
   * Added tests for after/before hooks features (@juanibiapina, @miry)
 

--- a/lib/capistrano/git.rb
+++ b/lib/capistrano/git.rb
@@ -30,7 +30,7 @@ class Capistrano::Git < Capistrano::SCM
     end
 
     def release
-      git :archive, fetch(:branch), '| tar -x -C', release_path
+      git :archive, fetch(:branch), '| tar -x -f - -C', release_path
     end
 
     def fetch_revision

--- a/spec/lib/capistrano/git_spec.rb
+++ b/spec/lib/capistrano/git_spec.rb
@@ -61,7 +61,7 @@ module Capistrano
         context.expects(:fetch).returns(:branch)
         context.expects(:release_path).returns(:path)
 
-        context.expects(:execute).with(:git, :archive, :branch, '| tar -x -C', :path)
+        context.expects(:execute).with(:git, :archive, :branch, '| tar -x -f - -C', :path)
 
         subject.release
       end


### PR DESCRIPTION
This change fixes #677 by adding `-f -` to the tar command.

The problem in #677 still exists, so the issue should be reopened. As the thread describes, running tar with `-f -` fixes the issue on FreeBSD, but it was unclear how that would affect Linux / GNU tar.

I've just tested the `-f -` fix with:
- FreeBSD tar (bsdtar)
- OS X tar (which is also bsdtar, but oddly enough does not seem to suffer from the same issue)
- GNU tar

All three could handle the `-f` flag without a problem, so it seems this change does not break compatibility with Linux / GNU tar.
