### PR TITLE
Improve the output of cap --help.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ https://github.com/capistrano/capistrano/compare/v3.2.1...HEAD
 
 * Minor Changes
   * Added tests for after/before hooks features (@juanibiapina, @miry)
+  * Improved the output of `cap --help`. (@mbrictson)
 
 ## `3.2.1`
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ bundle exec cap install STAGES=local,sandbox,qa,production
 ## Usage
 
 ``` sh
-$ bundle exec cap -vT
+$ bundle exec cap -T
 
 $ bundle exec cap staging deploy
 $ bundle exec cap production deploy

--- a/spec/lib/capistrano/application_spec.rb
+++ b/spec/lib/capistrano/application_spec.rb
@@ -6,11 +6,21 @@ describe Capistrano::Application do
 
   it "provides a --format option which enables the choice of output formatting"
 
-  it "identifies itself as cap and not rake" do
+  let(:help_output) do
     out, _ = capture_io do
       flags '--help', '-h'
     end
-    out.lines.first.should match(/cap \[-f rakefile\]/)
+    out
+  end
+
+  it "displays documentation URL as help banner" do
+    help_output.lines.first.should match(/capistranorb.com/)
+  end
+
+  %w(quiet silent verbose).each do |switch|
+    it "doesn't include --#{switch} in help" do
+      help_output.should_not match(/--#{switch}/)
+    end
   end
 
   it "overrides the rake method, but still prints the rake version" do


### PR DESCRIPTION
Remove options documentation for rake options that aren't applicable to capistrano, briefly explain correct cap usage, and point users to http://capistranorb.com.

Addresses #1015.

```
$ bundle exec cap -h
See full documentation at http://capistranorb.com/.

Install capistrano in a project:
    bundle exec cap install [STAGES=qa,staging,production,...]

Show available tasks:
    bundle exec cap -T

Invoke (or simulate invoking) a task:
    bundle exec cap [--dry-run] STAGE TASK

Advanced options:
        --backtrace=[OUT]            Enable full backtrace.  OUT can be stderr (default) or stdout.
        --comments                   Show commented tasks only
        --job-stats [LEVEL]          Display job statistics. LEVEL=history displays a complete job list
        --rules                      Trace the rules resolution.
        --suppress-backtrace PATTERN Suppress backtrace lines matching regexp PATTERN. Ignored if --trace is on.
    -A, --all                        Show all tasks, even uncommented ones (in combination with -T or -D)
    -B, --build-all                  Build all prerequisites, including those which are up-to-date.
    -D, --describe [PATTERN]         Describe the tasks (matching optional PATTERN), then exit.
    -e, --execute CODE               Execute some Ruby code and exit.
    -E, --execute-continue CODE      Execute some Ruby code, then continue with normal task processing.
    -f, --rakefile [FILENAME]        Use FILENAME as the rakefile to search for.
    -G, --no-system, --nosystem      Use standard project Rakefile search paths, ignore system wide rakefiles.
    -g, --system                     Using system wide (global) rakefiles (usually '~/.rake/*.rake').
    -I, --libdir LIBDIR              Include LIBDIR in the search path for required modules.
    -j, --jobs [NUMBER]              Specifies the maximum number of tasks to execute in parallel. (default is number of CPU cores + 4)
    -m, --multitask                  Treat all tasks as multitasks.
    -n, --dry-run                    Do a dry run without executing actions.
    -N, --no-search, --nosearch      Do not search parent directories for the Rakefile.
    -P, --prereqs                    Display the tasks and dependencies, then exit.
    -p, --execute-print CODE         Execute some Ruby code, print the result, then exit.
        --roles ROLES                Filter command to only apply to these roles (separate multiple roles with a comma)
    -r, --require MODULE             Require MODULE before executing rakefile.
    -R, --rakelibdir RAKELIBDIR,     Auto-import any .rake files in RAKELIBDIR. (default is 'rakelib')
        --rakelib
    -t, --trace=[OUT]                Turn on invoke/execute tracing, enable full backtrace. OUT can be stderr (default) or stdout.
    -T, --tasks [PATTERN]            Display the tasks (matching optional PATTERN) with descriptions, then exit.
    -V, --version                    Display the program version.
    -W, --where [PATTERN]            Describe the tasks (matching optional PATTERN), then exit.
    -X, --no-deprecation-warnings    Disable the deprecation warnings.
    -z, --hosts HOSTS                Filter command to only apply to these hosts (separate multiple hosts with a comma)
    -h, -H, --help                   Display this help message.
```
