### PR TITLE
Cucumber tests will now run with latest version of Vagrant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,3 @@ rvm:
   - rbx
 script: bundle exec rake spec
 cache: bundler
-bundler_args: --without cucumber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ https://github.com/capistrano/capistrano/compare/v3.2.1...HEAD
 * Minor Changes
   * Added tests for after/before hooks features (@juanibiapina, @miry)
   * Improved the output of `cap --help`. (@mbrictson)
+  * Cucumber suite now runs on the latest version of Vagrant (@tpett)
 
 ## `3.2.1`
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :cucumber do
-  gem 'kuroko'
   gem 'cucumber'
 end
 

--- a/README.md
+++ b/README.md
@@ -274,6 +274,27 @@ connections behind the scenes in Capistrano. Depending on how deep you dig, you
 might run into interfaces that come directly from SSHKit (the configuration is
 a good example).
 
+## Testing
+
+Capistrano has two test suites: an RSpec suite and a Cucumber suite. The
+RSpec suite handles quick feedback unit specs. The Cucumber features are
+an integration suite that uses Vagrant to deploy to a real virtual
+server. In order to run the Cucumber suite you will need to install
+[Vagrant](http://www.vagrantup.com/) and Vagrant supported
+virtualization software like
+[VirtualBox](https://www.virtualbox.org/wiki/Downloads).
+
+```
+# To run the RSpec suite
+$ rake spec
+
+# To run the Cucumber suite
+$ rake features
+
+# To run the Cucumber suite and leave the VM running (faster for subsequent runs)
+$ rake features KEEP_RUNNING=1
+```
+
 ## License
 
 MIT License (MIT)

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,9 @@
 require "bundler/gem_tasks"
+require "cucumber/rake/task"
+require "rspec/core/rake_task"
 
 task :default => :spec
-require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new
+
+Cucumber::Rake::Task.new(:features)
+

--- a/features/step_definitions/assertions.rb
+++ b/features/step_definitions/assertions.rb
@@ -100,7 +100,8 @@ end
 
 Then(/^the failure task will not run$/) do
   failed = TestApp.shared_path.join('failed')
-  !run_vagrant_command(test_file_exists(failed))
+  expect { run_vagrant_command(test_file_exists(failed)) }
+    .to raise_error(VagrantHelpers::VagrantSSHCommandError)
 end
 
 When(/^an error is raised$/) do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,12 +1,11 @@
-require 'kuroko'
+PROJECT_ROOT = File.expand_path('../../../', __FILE__)
+VAGRANT_ROOT = File.join(PROJECT_ROOT, 'spec/support')
+VAGRANT_BIN = ENV['VAGRANT_BIN'] || "vagrant"
 
-project_root = File.expand_path('../../../', __FILE__)
-vagrant_root = File.join(project_root, 'spec/support')
-
-Kuroko.configure do |config|
-  config.vagrant_root = 'spec/support'
+at_exit do
+  if ENV['KEEP_RUNNING']
+    VagrantHelpers.run_vagrant_command("rm -rf /home/vagrant/var")
+  end
 end
-
-puts vagrant_root.inspect
 
 require_relative '../../spec/support/test_app'

--- a/features/support/remote_command_helpers.rb
+++ b/features/support/remote_command_helpers.rb
@@ -1,5 +1,4 @@
 module RemoteCommandHelpers
-
   def test_dir_exists(path)
     exists?('d', path)
   end
@@ -13,11 +12,11 @@ module RemoteCommandHelpers
   end
 
   def exists?(type, path)
-    %{[ -#{type} "#{path}" ] && echo "#{path} exists." || echo "Error: #{path} does not exist."}
+    %{[ -#{type} "#{path}" ]}
   end
 
   def safely_remove_file(path)
-    run_vagrant_command("rm #{test_file}") rescue Vagrant::Errors::VagrantError
+    run_vagrant_command("rm #{test_file}") rescue VagrantHelpers::VagrantSSHCommandError
   end
 end
 

--- a/features/support/vagrant_helpers.rb
+++ b/features/support/vagrant_helpers.rb
@@ -1,0 +1,35 @@
+module VagrantHelpers
+  extend self
+
+  class VagrantSSHCommandError < RuntimeError; end
+
+  at_exit do
+    if ENV['KEEP_RUNNING']
+      puts "Vagrant vm will be left up because KEEP_RUNNING is set."
+      puts "Rerun without KEEP_RUNNING set to cleanup the vm."
+    else
+      vagrant_cli_command("destroy -f")
+    end
+  end
+
+  def vagrant_cli_command(command)
+    puts "[vagrant] #{command}"
+    Dir.chdir(VAGRANT_ROOT) do
+      `#{VAGRANT_BIN} #{command} 2>&1`.split("\n").each do |line|
+        puts "[vagrant] #{line}"
+      end
+    end
+    $?
+  end
+
+  def run_vagrant_command(command)
+    if (status = vagrant_cli_command("ssh -c #{command.inspect}")).success?
+      true
+    else
+      fail VagrantSSHCommandError, status
+    end
+  end
+
+end
+
+World(VagrantHelpers)

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -1,4 +1,6 @@
 require 'fileutils'
+require 'pathname'
+
 module TestApp
   extend self
 


### PR DESCRIPTION
This removes the dependency on the `kuroko` gem and uses the Vagrant
command line application to control the virtual environment. The
`vagrant` command should be in your path, but if it isn't the path can
be set with the `VAGRANT_BIN` environment variable. This may even work
on older versions of Vagrant, but they are untested.

The `VagrantHelpers` module was added to mimic some of the API that was
provided by `kuroko`. The `RemoteCommandHelpers` module was modified to
accommodate those changes. Any non-zero exit status on a remote command
will raise a `VagrantHelpers::VagrantSSHCommandError` and should be
expected by any tests using the command helpers. All existing tests
work as expected.

In addition, a couple of minor changes were made. The TestApp utilizes
the Pathname library but does not require it. This was causing the suite
to fail for me so I added an explicit require. Also, the test for the
existence of a release directory would give a false positive on
subsequent runs if the `KEEP_RUNNING` option was used. I added an
`at_exit` that removes the test deployment directory to clean up the
box for the next run.

This also resolves Issue #948
