### PR TITLE
Allow to customize username in revision log via local_user variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ https://github.com/capistrano/capistrano/compare/v3.2.1...HEAD
   * Fixed compatibility with FreeBSD tar (@robbertkl)
 
 * Minor Changes
+  * Capistrano now allows to customize `local_user` for revision log. (@sauliusgrigaitis)
   * Added tests for after/before hooks features (@juanibiapina, @miry)
   * Improved the output of `cap --help`. (@mbrictson)
   * Cucumber suite now runs on the latest version of Vagrant (@tpett)

--- a/lib/capistrano/defaults.rb
+++ b/lib/capistrano/defaults.rb
@@ -10,3 +10,5 @@ set :format, :pretty
 set :log_level, :debug
 
 set :pty, false
+
+set :local_user, -> { Etc.getlogin }

--- a/lib/capistrano/dsl.rb
+++ b/lib/capistrano/dsl.rb
@@ -42,7 +42,7 @@ module Capistrano
     end
 
     def local_user
-      Etc.getlogin
+      fetch(:local_user)
     end
 
     def lock(locked_version)

--- a/spec/integration/dsl_spec.rb
+++ b/spec/integration/dsl_spec.rb
@@ -488,4 +488,34 @@ describe Capistrano::DSL do
       end
     end
   end
+
+  describe 'local_user' do
+    before do
+      dsl.set :local_user, -> { Etc.getlogin }
+    end
+
+    describe 'fetching local_user' do
+      subject { dsl.local_user }
+
+      context 'where a local_user is not set' do
+        before do
+          Etc.expects(:getlogin).returns('login')
+        end
+
+        it 'returns the login name' do
+          expect(subject.to_s).to eq 'login'
+        end
+      end
+
+      context 'where a local_user is set' do
+        before do
+          dsl.set(:local_user, -> { 'custom login' })
+        end
+
+        it 'returns the custom name' do
+          expect(subject.to_s).to eq 'custom login'
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/capistrano/dsl_spec.rb
+++ b/spec/lib/capistrano/dsl_spec.rb
@@ -48,16 +48,5 @@ module Capistrano
         dsl.sudo(:my, :command)
       end
     end
-
-    describe '#local_user' do
-
-      before do
-        Etc.expects(:getlogin)
-      end
-
-      it 'delegates to Etc#getlogin' do
-        dsl.local_user
-      end
-    end
   end
 end


### PR DESCRIPTION
I believe it's too edge case to add one more default variable, but this looks like nice solution for #1030
