### PR TITLE
Update assertions for 'git:check' test scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ https://github.com/capistrano/capistrano/compare/v3.2.1...HEAD
   * Added tests for after/before hooks features (@juanibiapina, @miry)
   * Improved the output of `cap --help`. (@mbrictson)
   * Cucumber suite now runs on the latest version of Vagrant (@tpett)
+  * Update assertions for 'git:check' scenario (@bruno-)
 
 ## `3.2.1`
 

--- a/features/deploy.feature
+++ b/features/deploy.feature
@@ -6,7 +6,8 @@ Feature: Deploy
 
   Scenario: Creating the repo
     When I run cap "git:check"
-    Then references in the remote repo are listed
+    Then the task is successful
+    And references in the remote repo are listed
 
   Scenario: Creating the directory structure
     When I run cap "deploy:check:directories"

--- a/features/step_definitions/assertions.rb
+++ b/features/step_definitions/assertions.rb
@@ -1,4 +1,5 @@
 Then(/^references in the remote repo are listed$/) do
+  expect(@output).to include('refs/heads/master')
 end
 
 Then(/^the shared path is created$/) do

--- a/features/step_definitions/cap_commands.rb
+++ b/features/step_definitions/cap_commands.rb
@@ -1,5 +1,5 @@
 When(/^I run cap "(.*?)"$/) do |task|
-  @success = TestApp.cap(task)
+  @success, @output = TestApp.cap(task)
 end
 
 When(/^I run cap "(.*?)" as part of a release$/) do |task|


### PR DESCRIPTION
Capistrano 'git:check' task executes a `git ls-remote -h #{repo_url}`
command to check if remote repo is accessible. If successful, command
output is a list of references and their SHAs.

Task should be successful and we're pretty sure remote repo will have a
`master` reference, so that's what we're asserting.

We're NOT asserting:
- repo references other than master - likely to change
- reference SHAs - will definitely change

I have reviewed and made sure the pull request complies with [CONTRIBUTING.md](https://github.com/capistrano/capistrano/blob/master/CONTRIBUTING.md).
