### PR TITLE
Fixed fetch_revision method for Capistrano::Svn.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ https://github.com/capistrano/capistrano/compare/v3.2.1...HEAD
 
 * Bug Fixes:
   * Fixed compatibility with FreeBSD tar (@robbertkl)
+  * Fixed error in Capistrano::Svn fetch_revision, #1035 (@il-santo)
 
 * Minor Changes
   * Added tests for after/before hooks features (@juanibiapina, @miry)

--- a/lib/capistrano/svn.rb
+++ b/lib/capistrano/svn.rb
@@ -1,13 +1,13 @@
-load File.expand_path("../tasks/svn.rake", __FILE__)
+load File.expand_path('../tasks/svn.rake', __FILE__)
 
 require 'capistrano/scm'
 
 class Capistrano::Svn < Capistrano::SCM
-  
+
   # execute svn in context with arguments
   def svn(*args)
     args.unshift(:svn)
-    context.execute *args
+    context.execute(*args)
   end
 
   module DefaultStrategy
@@ -32,7 +32,7 @@ class Capistrano::Svn < Capistrano::SCM
     end
 
     def fetch_revision
-      context.capture(:svn, "log -r HEAD -q | tail -n 2 | head -n 1 | sed s/\ \|.*/''/")
+      context.capture(:svn, %(log -r HEAD -q | tail -n 2 | head -n 1 | sed "s/ |.*//"))
     end
   end
 end


### PR DESCRIPTION
Fixes issue #1035.
