### PR TITLE
Add Subversion authentication options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ https://github.com/capistrano/capistrano/compare/v3.2.1...HEAD
   * Cucumber suite now runs on the latest version of Vagrant (@tpett)
   * The `ask` method now supports the `echo: false` option. (@mbrictson)
   * Capistrano now depends on the `highline` gem.
+  * Added HTTP authentication options for Subversion (@synewaves)
 
 ## `3.2.1`
 

--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ The following variables are settable:
 | `:branch`             | The branch you wish to deploy                                        | This only has meaning for git and hg repos, to specify the branch of an svn repo, set `:repo_url` to the branch location. |
 | `:scm`                | The source control system used                                       | `:git`, `:hg`, `:svn` are currently supported                   |
 | `:tmp_dir`            | The (optional) temp directory that will be used (default: /tmp)      | if you have a shared web host, this setting may need to be set (i.e. /home/user/tmp/capistrano). |
+| `:svn_username`       | Subversion username                                                  | Use if you access Subversion over HTTP and use HTTP authentication. |
+| `:svn_password`       | Subversion password                                                  | Use if you access Subversion over HTTP and use HTTP authentication. Useful with [using password authentication](#using-password-authentication) |
 
 __Support removed__ for following variables:
 

--- a/lib/capistrano/svn.rb
+++ b/lib/capistrano/svn.rb
@@ -16,23 +16,35 @@ class Capistrano::Svn < Capistrano::SCM
     end
 
     def check
-      test! :svn, :info, repo_url
+      test! :svn, :info, repo_url, authentication
     end
 
     def clone
-      svn :checkout, repo_url, repo_path
+      svn :checkout, repo_url, repo_path, authentication
     end
 
     def update
-      svn :update
+      svn :update, authentication
     end
 
     def release
-      svn :export, '.', release_path
+      svn :export, '.', release_path, authentication
     end
 
     def fetch_revision
       context.capture(:svn, "log -r HEAD -q | tail -n 2 | head -n 1 | sed s/\ \|.*/''/")
     end
+
+    private
+
+      def authentication
+        username = fetch(:svn_username)
+        password = fetch(:svn_password)
+        return "" unless username && password
+        result = %(--username "#{username}" )
+        result << %(--password "#{password}" )
+        result << "--no-auth-cache "
+        result.strip
+      end
   end
 end

--- a/spec/lib/capistrano/svn_spec.rb
+++ b/spec/lib/capistrano/svn_spec.rb
@@ -30,8 +30,9 @@ module Capistrano
 
     describe "#check" do
       it "should test the repo url" do
+        subject.expects(:authentication).returns("")
         context.expects(:repo_url).returns(:url)
-        context.expects(:test).with(:svn, :info, :url).returns(true)
+        context.expects(:test).with(:svn, :info, :url, "").returns(true)
 
         subject.check
       end
@@ -39,10 +40,11 @@ module Capistrano
 
     describe "#clone" do
       it "should run svn checkout" do
+        subject.expects(:authentication).returns("")
         context.expects(:repo_url).returns(:url)
         context.expects(:repo_path).returns(:path)
  
-        context.expects(:execute).with(:svn, :checkout, :url, :path)
+        context.expects(:execute).with(:svn, :checkout, :url, :path, "")
 
         subject.clone
       end
@@ -50,19 +52,44 @@ module Capistrano
 
     describe "#update" do
       it "should run svn update" do
-        context.expects(:execute).with(:svn, :update)
+        subject.expects(:authentication).returns("")
+        context.expects(:execute).with(:svn, :update, "")
 
         subject.update
       end
     end
 
     describe "#release" do
-      it "should run svn export" do        
+      it "should run svn export" do
+        subject.expects(:authentication).returns("")
         context.expects(:release_path).returns(:path)
         
-        context.expects(:execute).with(:svn, :export, '.', :path)
+        context.expects(:execute).with(:svn, :export, '.', :path, "")
 
         subject.release
+      end
+    end
+
+    describe "#authentication" do
+      before do
+        subject.stubs(:fetch).with(:svn_username).returns("username")
+        subject.stubs(:fetch).with(:svn_password).returns("password")
+      end
+
+      it "should skip if no username" do
+        subject.stubs(:fetch).with(:svn_username).returns(nil)
+
+        expect(subject.send(:authentication)).to eq("")
+      end
+
+      it "should skip if no password" do
+        subject.stubs(:fetch).with(:svn_password).returns(nil)
+
+        expect(subject.send(:authentication)).to eq("")
+      end
+
+      it "should build the authentication options" do
+        expect(subject.send(:authentication)).to eq('--username "username" --password "password" --no-auth-cache')
       end
     end
   end


### PR DESCRIPTION
This builds off work started in PR 838 (#838) which added basic Subversion support. There were no options for authentication, which is used in most Subversion servers (usually when used over HTTP/S).

This adds two configuration variables:

:svn_username - Username
:svn_password - Password

When both are set, authentication is passed to the relevant Subversion commands.