### PR TITLE
Refactor enumeration of deployed releases

### DIFF
--- a/lib/capistrano/deploy.rb
+++ b/lib/capistrano/deploy.rb
@@ -1,3 +1,16 @@
 require 'capistrano/framework'
 
+# Fetches the currently deployed releases. Can be overwritten by setting :releases to a
+# different lambda.
+#
+# Example (inside a task)
+#
+#   releases = fetch(:releases).call(self)
+#   # => ["20140507122109", "20140507122237", "20140507122531"]
+#
+# Returns an array of folder names inside the releases_path, sorted oldest first.
+set :releases, lambda { |context|
+  context.capture(:ls, "-xt #{context.releases_path}").split.sort
+}
+
 load File.expand_path("../tasks/deploy.rake", __FILE__)

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -136,7 +136,7 @@ namespace :deploy do
   desc 'Clean up old releases'
   task :cleanup do
     on release_roles :all do |host|
-      releases = capture(:ls, '-xtr', releases_path).split
+      releases = fetch(:releases).call(self)
       if releases.count >= fetch(:keep_releases)
         info t(:keeping_releases, host: host.to_s, keep_releases: fetch(:keep_releases), releases: releases.count)
         directories = (releases - releases.last(fetch(:keep_releases)))
@@ -155,7 +155,7 @@ namespace :deploy do
   desc 'Remove and archive rolled-back release.'
   task :cleanup_rollback do
     on release_roles(:all) do
-      last_release = capture(:ls, '-xt', releases_path).split.first
+      last_release = fetch(:releases).call(self).reverse.first
       last_release_path = releases_path.join(last_release)
       if test "[ `readlink #{current_path}` != #{last_release_path} ]"
         execute :tar, '-czf',
@@ -190,7 +190,7 @@ namespace :deploy do
 
   task :rollback_release_path do
     on release_roles(:all) do
-      releases = capture(:ls, '-xt', releases_path).split
+      releases = fetch(:releases).call(self).reverse
       if releases.count < 2
         error t(:cannot_rollback)
         exit 1


### PR DESCRIPTION
As mentioned in #994, our project structure requires folders other
than actual releases to exist in the releases_path. To be able to
customize the logic to enumerate releases (to exclude said non-
release folders), it has been refactored into a "configuration lambda"
`:releases`.

:warning: We haven't extensively tested this change yet. I hope that I didn't introduce any subtle errors, but you never know :smile: Hopefully some people can test this with their deployment to see if it breaks anything. The affected tasks should be `deploy:cleanup` (and thus implicitly `deploy`) and `deploy:rollback`.

I would write unit tests, but there doesn't seem to be a SSHKit backend suitable for that purpose at the moment. If there is and I just have missed it, please point me to it!