### PR TITLE
Convert specs to RSpec expect syntax with transpec

### DIFF
--- a/spec/integration/dsl_spec.rb
+++ b/spec/integration/dsl_spec.rb
@@ -218,11 +218,11 @@ describe Capistrano::DSL do
 
       describe 'fetching servers for a role' do
         it 'roles defined using the `server` syntax are included' do
-          expect(dsl.roles(:web)).to have(2).items
+          expect(dsl.roles(:web).size).to eq(2)
         end
 
         it 'roles defined using the `role` syntax are included' do
-          expect(dsl.roles(:app)).to have(2).items
+          expect(dsl.roles(:app).size).to eq(2)
         end
       end
 

--- a/spec/lib/capistrano/application_spec.rb
+++ b/spec/lib/capistrano/application_spec.rb
@@ -14,12 +14,12 @@ describe Capistrano::Application do
   end
 
   it "displays documentation URL as help banner" do
-    help_output.lines.first.should match(/capistranorb.com/)
+    expect(help_output.lines.first).to match(/capistranorb.com/)
   end
 
   %w(quiet silent verbose).each do |switch|
     it "doesn't include --#{switch} in help" do
-      help_output.should_not match(/--#{switch}/)
+      expect(help_output).not_to match(/--#{switch}/)
     end
   end
 
@@ -27,10 +27,10 @@ describe Capistrano::Application do
     out, _ = capture_io do
       flags '--version', '-V'
     end
-    out.should match(/\bCapistrano Version\b/)
-    out.should match(/\b#{Capistrano::VERSION}\b/)
-    out.should match(/\bRake Version\b/)
-    out.should match(/\b#{RAKEVERSION}\b/)
+    expect(out).to match(/\bCapistrano Version\b/)
+    expect(out).to match(/\b#{Capistrano::VERSION}\b/)
+    expect(out).to match(/\bRake Version\b/)
+    expect(out).to match(/\b#{RAKEVERSION}\b/)
   end
 
   def flags(*sets)

--- a/spec/lib/capistrano/configuration/servers_spec.rb
+++ b/spec/lib/capistrano/configuration/servers_spec.rb
@@ -61,13 +61,13 @@ module Capistrano
       describe 'finding the primary server' do
         it 'takes the first server if none have the primary property' do
           servers.add_role(:app, %w{1 2})
-          servers.fetch_primary(:app).hostname.should == '1'
+          expect(servers.fetch_primary(:app).hostname).to eq('1')
         end
 
         it 'takes the first server with the primary have the primary flag' do
           servers.add_role(:app, %w{1 2})
           servers.add_host('2', primary: true)
-          servers.fetch_primary(:app).hostname.should == '2'
+          expect(servers.fetch_primary(:app).hostname).to eq('2')
         end
       end
 
@@ -115,7 +115,7 @@ module Capistrano
           servers.add_host('1', roles: [:app, 'web'], test: :value, user: 'root', port: 34)
           servers.add_host('1', roles: [:app, 'web'], test: :value, user: 'deployer', port: 34)
           servers.add_host('1', roles: [:app, 'web'], test: :value, user: 'deployer', port: 56)
-          servers.should have(8).items
+          expect(servers.count).to eq(8)
         end
       end
 

--- a/spec/lib/capistrano/scm_spec.rb
+++ b/spec/lib/capistrano/scm_spec.rb
@@ -50,21 +50,21 @@ module Capistrano
       describe "#repo_url" do
         it "should return the repo url according to the context" do
           context.expects(:repo_url).returns(:url)
-          subject.repo_url.should == :url
+          expect(subject.repo_url).to eq(:url)
         end
       end
 
       describe "#repo_path" do
         it "should return the repo path according to the context" do
           context.expects(:repo_path).returns(:path)
-          subject.repo_path.should == :path
+          expect(subject.repo_path).to eq(:path)
         end
       end
 
       describe "#release_path" do
         it "should return the release path according to the context" do
           context.expects(:release_path).returns('/path/to/nowhere')
-          subject.release_path.should == '/path/to/nowhere'
+          expect(subject.release_path).to eq('/path/to/nowhere')
         end
       end
 


### PR DESCRIPTION
This conversion is done by Transpec 1.13.1 with the following command:
    transpec
- 11 conversions
  from: obj.should
    to: expect(obj).to
- 5 conversions
  from: == expected
    to: eq(expected)
- 2 conversions
  from: expect(collection).to have(n).items
    to: expect(collection.size).to eq(n)
- 1 conversion
  from: collection.should have(n).items
    to: expect(collection.size).to eq(n)
- 1 conversion
  from: obj.should_not
    to: expect(obj).not_to
