### PR TITLE
Apply HostFilter for fetch_primary

### DIFF
--- a/lib/capistrano/configuration/servers.rb
+++ b/lib/capistrano/configuration/servers.rb
@@ -23,8 +23,9 @@ module Capistrano
       end
 
       def fetch_primary(role)
-        hosts = roles_for([role])
-        hosts.find(&:primary) || hosts.first
+        hosts = fetch([role])
+        primary_host = hosts.find(&:primary) || hosts.first
+        HostFilter.for([primary_host]).first
       end
 
       def each

--- a/lib/capistrano/configuration/servers.rb
+++ b/lib/capistrano/configuration/servers.rb
@@ -23,9 +23,8 @@ module Capistrano
       end
 
       def fetch_primary(role)
-        hosts = fetch([role])
-        primary_host = hosts.find(&:primary) || hosts.first
-        HostFilter.for([primary_host]).first
+        hosts = roles_for([role])
+        hosts.find(&:primary) || hosts.first
       end
 
       def each

--- a/spec/integration/dsl_spec.rb
+++ b/spec/integration/dsl_spec.rb
@@ -605,6 +605,23 @@ describe Capistrano::DSL do
       dsl.on(all)
     end
 
+    context 'primary' do
+      it 'with primary not filtered' do
+        all = dsl.roles(:app)
+        host = dsl.primary :app
+        SSHKit::Coordinator.expects(:new).with([host]).returns(@coordinator)
+        dsl.set :filter, { host: 'example4.com' }
+        dsl.on(all)
+      end
+
+      it 'with primary filtered out' do
+        all = dsl.primary(:app)
+        SSHKit::Coordinator.expects(:new).with([]).returns(@coordinator)
+        dsl.set :filter, { host: 'example3.com' }
+        dsl.on(all)
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
When use capistrano with rails migration task, it will fetch the primary db server to run the migration. If I use HostFilter which does not include the primary db server. A "Directory Not Exists" error will occure.

So I think add the HostFilter to the `fetch_primary` method will help, and it does(for my situation).

## How to reproduce
```ruby
# deploy.rb
server "server1", roles: %w/app db web/
server "server2", roles: %w/app web/
```

### Deploy with hosts filter
```bash
cap production deploy --hosts=server2
```

### err logs
```
** Invoke deploy:migrate (first_time)
** Invoke deploy:set_rails_env
** Execute deploy:migrate
DEBUG [59ff49e4] Running /usr/bin/env if test ! -d /home/oob/apps/alioob/releases/20140528095735; then echo "Directory does not exist '/home/oob/apps/alioob/
releases/20140528095735'" 1>&2; false; fi on server1
DEBUG [59ff49e4] Command: if test ! -d /home/oob/apps/alioob/releases/20140528095735; then echo "Directory does not exist '/home/oob/apps/alioob/releases/201
40528095735'" 1>&2; false; fi
DEBUG [59ff49e4]        Directory does not exist '/home/oob/apps/alioob/releases/20140528095735'
```

The key point is db migration task on server1 is triggered, which is not as expected with the hostfilter.