### PR TITLE
Fix svn fetch_revision error

### DIFF
--- a/lib/capistrano/svn.rb
+++ b/lib/capistrano/svn.rb
@@ -32,7 +32,7 @@ class Capistrano::Svn < Capistrano::SCM
     end
 
     def fetch_revision
-      context.capture(:svn, "log -r HEAD -q | tail -n 2 | head -n 1 | sed s/\ \|.*/''/")
+      context.capture(:svn, "log -l 1 -q | tail -n 2 | head -n 1 | sed s/\\ \\|.*/''/")
     end
   end
 end

--- a/spec/lib/capistrano/svn_spec.rb
+++ b/spec/lib/capistrano/svn_spec.rb
@@ -65,5 +65,22 @@ module Capistrano
         subject.release
       end
     end
+
+    describe "#fetch_revision" do
+      it "should run fetch revision" do
+        require 'open3'
+        parse_revision = "tail -n 2 | head -n 1 | sed s/\\ \\|.*/''/"
+        Open3.popen2(parse_revision) do |stdin, stdout, wait_thr|
+          stdin.puts("---\nr12345 | xxxxxxx\n---") # output of svn log
+          stdin.close
+          expect(stdout.gets).to eq "r12345\n"
+          expect(wait_thr.value).to eq 0
+        end
+
+        context.expects(:capture).with(:svn, "log -l 1 -q | " + parse_revision)
+
+        subject.fetch_revision
+      end
+    end
   end
 end


### PR DESCRIPTION
Escape backslash of `sed` command argument. Close #1061
Use `svn log -l 1` to get the last revision of working directory.
`svn log -r HEAD` outputs empty result if the working directory
is a subdirectory in the repository and a directory outside the
working directory has latest revision.

`svn log -l 1` shows only the first 1 log message.
The default revision range for a local path is BASE:1.
http://svnbook.red-bean.com/en/1.7/svn.ref.svn.c.log.html
