### PR TITLE
Switch to high-quality SVG badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Capistrano [![Build Status](https://travis-ci.org/capistrano/capistrano.png?branch=v3)](https://travis-ci.org/capistrano/capistrano) [![Code Climate](https://codeclimate.com/github/capistrano/capistrano.png)](https://codeclimate.com/github/capistrano/capistrano) <a href="http://codersclan.net/?repo_id=325&source=small"><img src="http://www.codersclan.net/gs_button/?repo_id=325&size=small" width="69"></a>
+# Capistrano [![Build Status](https://travis-ci.org/capistrano/capistrano.svg?branch=master)](https://travis-ci.org/capistrano/capistrano) [![Code Climate](http://img.shields.io/codeclimate/github/capistrano/capistrano.svg)](https://codeclimate.com/github/capistrano/capistrano) <a href="http://codersclan.net/?repo_id=325&source=small"><img src="http://img.shields.io/badge/get-support-blue.svg"></a>
 
 ## Requirements
 


### PR DESCRIPTION
This is so that the badges don't look like a blurry mess on retina screens.

Note that this also fixes the Travis status, which was previously reporting green. It is now correctly showing "error", matching the status shown here: https://travis-ci.org/capistrano/capistrano
