### PR TITLE
Disable loading stages configs on `cap -T`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Reverse Chronological Order:
 
 https://github.com/capistrano/capistrano/compare/v3.2.1...HEAD
 
+* Disable loading stages configs on `cap -T`
 * Enhancements (@townsen)
   * Fix matching on hosts with custom ports or users set
   * Previously filtering would affect any generated configuration files so that

--- a/lib/capistrano/application.rb
+++ b/lib/capistrano/application.rb
@@ -75,7 +75,7 @@ module Capistrano
       if options.show_tasks
         invoke 'load:defaults'
         set(:stage, '')
-        Dir[deploy_config_path, stage_definitions].each { |f| add_import f }
+        Dir[deploy_config_path].each { |f| add_import f }
       end
 
       super


### PR DESCRIPTION
I messed with such problem: asking any variable in stage config envokes it in `cap -vT` because of the https://github.com/capistrano/capistrano/blame/1be0fa546ad43d42772b00b3659154de719e79c2/lib/capistrano/application.rb#L79, it is really annoying.
Is it really necessary to load any tasks from stages config?  Any ideas to workaround it?
