### PR TITLE
Added 2 fixes.

### DIFF
--- a/lib/capistrano/svn.rb
+++ b/lib/capistrano/svn.rb
@@ -23,8 +23,16 @@ class Capistrano::Svn < Capistrano::SCM
       svn :checkout, repo_url, repo_path
     end
 
+	def switch
+		svn :switch, repo_url, repo_path
+	end
+
     def update
-      svn :update
+	  if repo_url != fetch_repo_url	
+	    switch
+	  else
+	    svn :update
+	  end
     end
 
     def release
@@ -32,7 +40,12 @@ class Capistrano::Svn < Capistrano::SCM
     end
 
     def fetch_revision
-      context.capture(:svn, "log -r HEAD -q | tail -n 2 | head -n 1 | sed s/\ \|.*/''/")
+      context.capture(:svn, "log -r HEAD -q |tail -n 2 |head -n 1 |sed 's/\ \|.*/\'\'/'")
     end
+		
+	def fetch_repo_url
+	  context.capture(:svn, "info |grep 'URL: ' |awk '{print $2}'")
+	end
   end
+
 end


### PR DESCRIPTION
Capistrano Version Used: 3.2.1
1. Fixed fetch_revision method for SVN. Was returning syntax error.
2. Fixed issue with changing the svn repo_path to a new branch. The default set-up of Capistrano and SVN will not work when changing the SVN repo_path to a new branch. Capistrano will do an update in the repo directory and not know about the changes in the new branch. I added a function called fetch_repo_url that will detect what branch is in the repo staging folder. I then modified the update method to do an SVN switch to the new branch if the repo_url does not match the currently downloaded version in the repo staging folder.
