### PR TITLE
Create release as part of publishing.

### DIFF
--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -5,8 +5,9 @@ namespace :deploy do
     invoke 'deploy:set_previous_revision'
   end
 
-  task :updating => :new_release_path do
-    invoke "#{scm}:create_release"
+  task :updating do
+    set :release_path, repo_path
+    invoke "#{scm}:update"
     invoke "deploy:set_current_revision"
     invoke 'deploy:symlink:shared'
   end
@@ -16,6 +17,8 @@ namespace :deploy do
   end
 
   task :publishing do
+    invoke 'deploy:new_release_path'
+    invoke "#{scm}:create_release"
     invoke 'deploy:symlink:release'
   end
 

--- a/lib/capistrano/tasks/git.rake
+++ b/lib/capistrano/tasks/git.rake
@@ -57,7 +57,7 @@ namespace :git do
   end
 
   desc 'Copy repo to releases'
-  task create_release: :'git:update' do
+  task :create_release do
     on release_roles :all do
       with fetch(:git_environmental_variables) do
         within repo_path do


### PR DESCRIPTION
This is an approach we have been using in production for a while now. I do not propose you just outright merge this, but consider the idea instead.

With this change, the release folder gets created as part of the publishing step. This is a huge advantage to us, since it allows us to reuse the repo directory when compiling assets for instance. We also believe it is more straightforward to think of it this way.

On the other hand, this is a hack. During most of the deploy, the `release_path` will be pointing to `repo_path`, which might be misleading (if not even problematic). We need to do this because many other places will refer to `release_path` assuming it has been created before the publishing step.

A better solution could be to work on these assumptions and make everyone refer to `repo_path` until the `release_path` is actually valid (which is only during and after publishing). I would like to hear your thoughts before proceeding.