### PR TITLE
Consistant version interface

### DIFF
--- a/lib/capistrano/version.rb
+++ b/lib/capistrano/version.rb
@@ -8,4 +8,6 @@ module Capistrano
       "#{MAJOR}.#{MINOR}.#{PATCH}"
     end
   end
+
+  VERSION = Version.to_s
 end

--- a/test/version_test.rb
+++ b/test/version_test.rb
@@ -1,0 +1,11 @@
+require 'capistrano/version'
+
+class VersionTest < Test::Unit::TestCase
+  def test_version_constant_is_not_nil
+    assert_not_nil Capistrano::VERSION
+  end
+
+  def test_version_constant_matches_class_method
+    assert_equal Capistrano::VERSION, Capistrano::Version.to_s
+  end
+end


### PR DESCRIPTION
:information_desk_person: The latest version of Capistrano uses `Capistrano::VERSION` for storing the gem version. This change adds a constant to match this interface for v2.
