### PR TITLE
Ensure pry compatibility for Ruby 1.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,10 @@ gemspec
 #
 group :development do
   gem "rake"
-  gem "pry"
+
+  unless RUBY_VERSION >= "1.9"
+    gem "pry", "0.9"
+  else
+    gem "pry"
+  end
 end


### PR DESCRIPTION
:information_desk_person: This should fix the [build error](https://travis-ci.org/capistrano/capistrano/builds/30553023) on the `legacy-v2` branch. :blush: 
- Pry has moved to using Ruby 1.9 hash syntax from v0.10, which causes syntax errors when using Ruby 1.8.
  Locking the version of pry to a compatible version prevents this.
