### PR TITLE
Bump mocha version to support Ruby 2.1

### DIFF
--- a/capistrano.gemspec
+++ b/capistrano.gemspec
@@ -28,13 +28,13 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency(%q<net-sftp>, [">= 2.0.0"])
     s.add_runtime_dependency(%q<net-scp>, [">= 1.0.0"])
     s.add_runtime_dependency(%q<net-ssh-gateway>, [">= 1.1.0"])
-    s.add_development_dependency(%q<mocha>, ["0.9.12"])
+    s.add_development_dependency(%q<mocha>, ["0.14.0"])
   else
     s.add_dependency(%q<net-ssh>, [">= 2.0.14"])
     s.add_dependency(%q<net-sftp>, [">= 2.0.0"])
     s.add_dependency(%q<net-scp>, [">= 1.0.0"])
     s.add_dependency(%q<net-ssh-gateway>, [">= 1.1.0"])
     s.add_dependency(%q<highline>, [">= 0"])
-    s.add_dependency(%q<mocha>, ["0.9.12"])
+    s.add_dependency(%q<mocha>, ["0.14.0"])
   end
 end

--- a/test/utils.rb
+++ b/test/utils.rb
@@ -2,7 +2,7 @@ require 'rubygems'
 require 'bundler/setup'
 
 require 'test/unit'
-require 'mocha'
+require 'mocha/setup'
 
 require 'capistrano/server_definition'
 require 'pry'


### PR DESCRIPTION
:information_desk_person: NB, these changes target the `legacy-v2` branch.

Due to the interface of `minitest` in Ruby's standard library changing in v2.1, the version of `mocha` needs to be updated to get the test suite passing for that version.

```
bundle exec rake
/opt/rubies/ruby-2.1.2/bin/ruby -I"lib:lib:test" -I"/Users/s/.gem/ruby/2.1.2/gems/rake-10.3.2/lib" "/Users/s/.gem/ruby/2.1.2/gems/rake-10.3.2/lib/rake/rake_test_loader.rb" "test/**/*_test.rb" 
Run options: 

# Running tests:

[  1/618] AccurevTest#test_internal_revision_parse/Users/s/.gem/ruby/2.1.2/gems/mocha-0.9.12/lib/mocha/integration/mini_test/version_201_to_202.rb:19:in `run': uninitialized constant MiniTest::Unit::TestCase::SUPPORTS_INFO_SIGNAL (NameError)
```
