### PR TITLE
Don't overwrite existing config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ https://github.com/capistrano/capistrano/compare/v3.2.1...HEAD
   * Cucumber suite now runs on the latest version of Vagrant (@tpett)
   * The `ask` method now supports the `echo: false` option. (@mbrictson)
   * Capistrano now depends on the `highline` gem.
+  * `cap install` no longer overwrites existing files. (@dmarkow)
 
 ## `3.2.1`
 

--- a/lib/capistrano/tasks/install.rake
+++ b/lib/capistrano/tasks/install.rake
@@ -14,25 +14,28 @@ task :install do
 
   mkdir_p deploy_dir
 
-  template = File.read(deploy_rb)
-  file = config_dir.join('deploy.rb')
-  File.open(file, 'w+') do |f|
-    f.write(ERB.new(template).result(binding))
-    puts I18n.t(:written_file, scope: :capistrano, file: file)
-  end
+  entries = [{template: deploy_rb, file: config_dir.join('deploy.rb')}]
+  entries += envs.split(',').map { |stage| {template: stage_rb, file: deploy_dir.join("#{stage}.rb")} }
 
-  template = File.read(stage_rb)
-  envs.split(',').each do |stage|
-    file = deploy_dir.join("#{stage}.rb")
-    File.open(file, 'w+') do |f|
-      f.write(ERB.new(template).result(binding))
-      puts I18n.t(:written_file, scope: :capistrano, file: file)
+  entries.each do |entry|
+    if File.exists?(entry[:file])
+      warn "[skip] #{entry[:file]} already exists"
+    else
+      File.open(entry[:file], 'w+') do |f|
+        f.write(ERB.new(File.read(entry[:template])).result(binding))
+        puts I18n.t(:written_file, scope: :capistrano, file: entry[:file])
+      end
     end
   end
 
   mkdir_p tasks_dir
 
-  FileUtils.cp(capfile, 'Capfile')
+  if File.exists?('Capfile')
+    warn "[skip] Capfile already exists"
+  else
+    FileUtils.cp(capfile, 'Capfile')
+    puts I18n.t(:written_file, scope: :capistrano, file: 'Capfile')
+  end
 
 
   puts I18n.t :capified, scope: :capistrano


### PR DESCRIPTION
Addresses #1094. Also, there was no `:written_file` notification for `Capfile` even though there was for all other config files, so I added it. Now, if all the files already exist, you'll see this output (similar to Cap 2):

```
$ bundle exec cap install
mkdir -p config/deploy
[skip] config/deploy.rb already exists
[skip] config/deploy/staging.rb already exists
[skip] config/deploy/production.rb already exists
mkdir -p lib/capistrano/tasks
[skip] Capfile already exists
Capified
```

A next step might be to prompt the user if they want to overwrite, but I didn't have time to get that implemented (and I'm not sure how necessary it would be).

The existing code was already a little bit repetitive, so I refactored the template files into one array to iterate though (rather than executing basically the same code separately for config/deploy.rb and the stage files). Let me know if this is problematic and I can revert just that part and update this request. Thanks!!
