### PR TITLE
Replaced Hash#has_key? is deprecated method with Hash#key?

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require "bundler/gem_tasks"
 require "cucumber/rake/task"
 require "rspec/core/rake_task"
 
-task :default => :spec
+task default: :spec
 RSpec::Core::RakeTask.new
 
 Cucumber::Rake::Task.new(:features)

--- a/lib/capistrano/configuration/server.rb
+++ b/lib/capistrano/configuration/server.rb
@@ -79,7 +79,7 @@ module Capistrano
         end
 
         def respond_to?(method)
-          @properties.has_key?(method)
+          @properties.key?(method)
         end
 
         def roles
@@ -112,7 +112,7 @@ module Capistrano
         end
 
         def self.for(options)
-          if options.has_key?(:exclude)
+          if options.key?(:exclude)
             Exclusive
           else
             self


### PR DESCRIPTION
http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/43765