### PR TITLE
Ensure capistrano CLI options override rake's

### DIFF
--- a/lib/capistrano/application.rb
+++ b/lib/capistrano/application.rb
@@ -21,8 +21,7 @@ module Capistrano
         switch =~ /--#{Regexp.union(not_applicable_to_capistrano)}/
       end
 
-      options.push(version, roles, dry_run, hostfilter)
-      super
+      super.push(version, roles, dry_run, hostfilter)
     end
 
     def handle_options

--- a/spec/lib/capistrano/application_spec.rb
+++ b/spec/lib/capistrano/application_spec.rb
@@ -33,6 +33,14 @@ describe Capistrano::Application do
     expect(out).to match(/\b#{RAKEVERSION}\b/)
   end
 
+  it "overrides the rake method, and sets the sshkit_backend to SSHKit::Backend::Printer" do
+    out, _ = capture_io do
+      flags '--dry-run', '-n'
+    end
+    sshkit_backend = Capistrano::Configuration.fetch(:sshkit_backend)
+    expect(sshkit_backend).to eq(SSHKit::Backend::Printer)
+  end
+
   def flags(*sets)
     sets.each do |set|
       ARGV.clear


### PR DESCRIPTION
[rake's implementation](https://github.com/jimweirich/rake/blob/f374191fdeca537c57472bb2b469f4b5faa8ed7f/lib/rake/application.rb#L381) of `#sort_options` was ordering capistrano's version of --dry-run first, rake's second.

During [option parsing](https://github.com/capistrano/capistrano/blob/2a291169dffc672eaa3ca79eca13b60dd66b19a3/lib/capistrano/application.rb#L51), this meant rake's was added last, overwriting cap's.

Let me know if you need anything else.  Thanks!
