### PR TITLE
cp assets_manifest file to latest_release instead of current_release in assets.rb

### DIFF
--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -77,7 +77,7 @@ namespace :deploy do
 
       # Copy manifest to release root (for clean_expired task)
       run <<-CMD.compact
-        cp -- #{shared_manifest_path.shellescape} #{current_release.to_s.shellescape}/assets_manifest#{File.extname(shared_manifest_path)}
+        cp -- #{shared_manifest_path.shellescape} #{latest_release.to_s.shellescape}/assets_manifest#{File.extname(shared_manifest_path)}
       CMD
     end
 


### PR DESCRIPTION
On the first deploy, current_release doesn't seem to be set, so it tries to copy the assets_manifest to /assets_manifest.json, which it doesn't have permission to do. Switching it to latest_release seems to fix that, but I'm not sure if that's correct in all other cases.
