### PR TITLE
Add method has? to Properties

### DIFF
--- a/lib/capistrano/configuration/server.rb
+++ b/lib/capistrano/configuration/server.rb
@@ -98,6 +98,15 @@ module Capistrano
         def keys
           @properties.keys
         end
+        
+        def has?(properties)
+          properties.keys.each do |key|
+            unless @properties.has_key?(key) && (@properties[key] == properties[key])
+              return false
+            end
+          end
+          true
+        end
 
         def method_missing(key, value=nil)
           if value


### PR DESCRIPTION
In Capistrano 2.X we could filter on properties with
the keyword only: . has? aims to bring back a similar
feature.
