### PR TITLE
Use :release_timestamp variable from env

### DIFF
--- a/lib/capistrano/dsl.rb
+++ b/lib/capistrano/dsl.rb
@@ -33,7 +33,7 @@ module Capistrano
           branch: fetch(:branch),
           user: local_user,
           sha: fetch(:current_revision),
-          release: release_timestamp)
+          release: fetch(:release_timestamp))
        )
     end
 


### PR DESCRIPTION
In https://github.com/capistrano/capistrano/blob/master/lib/capistrano/dsl/paths.rb you expose  :release_timestamp but don't use it in lib/capistrano/dsl.rb.
