### PR TITLE
Sort releases by timestamp for rollback/cleanup

### DIFF
--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -135,7 +135,7 @@ namespace :deploy do
   desc 'Clean up old releases'
   task :cleanup do
     on release_roles :all do |host|
-      releases = capture(:ls, '-x', releases_path).split
+      releases = capture(:ls, '-xtr', releases_path).split
       if releases.count >= fetch(:keep_releases)
         info t(:keeping_releases, host: host.to_s, keep_releases: fetch(:keep_releases), releases: releases.count)
         directories = (releases - releases.last(fetch(:keep_releases)))
@@ -154,7 +154,7 @@ namespace :deploy do
   desc 'Remove and archive rolled-back release.'
   task :cleanup_rollback do
     on release_roles(:all) do
-      last_release = capture(:ls, '-xr', releases_path).split.first
+      last_release = capture(:ls, '-xt', releases_path).split.first
       last_release_path = releases_path.join(last_release)
       if test "[ `readlink #{current_path}` != #{last_release_path} ]"
         execute :tar, '-czf',
@@ -189,7 +189,7 @@ namespace :deploy do
 
   task :rollback_release_path do
     on release_roles(:all) do
-      releases = capture(:ls, '-xr', releases_path).split
+      releases = capture(:ls, '-xt', releases_path).split
       if releases.count < 2
         error t(:cannot_rollback)
         exit 1


### PR DESCRIPTION
When you just use Capistrano for deployment, sorting the releases by name is just working fine. I have a different scenario though, where it does not work: I use Chef and the application/application_ruby cookbook to do the first deployment. This one creates a sha based directory name, by default. So the sorting by name will be messed up for Capistrano.

Example:

``` console
drwxrwxr-x 14 deploy deploy 4096 Sep 28 18:49 20140928164907
drwxrwxr-x 14 deploy deploy 4096 Sep 28 18:49 20140928164944
drwxrwxr-x 14 deploy deploy 4096 Sep 28 18:50 20140928164958
drwxrwxr-x 14 deploy deploy 4096 Sep 28 18:50 20140928165015
drwxr-xr-x 16 deploy deploy 4096 Sep 28 18:48 765a5c8c3879a124c30a4c1de46737acfd863a05
```

Here the oldest deployement is the one (765a5c8c3879a124c30a4c1de46737acfd863a05), made by Chef at 18:48 o'clock. But Capistrano will clean up 20140928164907.

I know that Chef has a different deployment strategy called Chef::Provider::Deploy::Timestamped. I have tried to use that one, but it does not play well with the application/application_ruby cookbook. And getting a change into the opscode repositories takes ages :(. So I decided to fix this on the Capistrano side :). This will also fix other scenarios where something else than Chef was deploying into the releases folder without naming it in the same scheme as Capistrano.

If you decide this is a good change, please have a close look if I got the logic right! I don't want to mess up other people's deployments :). It's a bit confusing because `-t` is already reversing the order.

Thanks,
plu
