### PR TITLE
fix remote_task inside a namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Breaking Changes:
 
 * Bug Fixes:
   * Fixed compatibility with FreeBSD tar (@robbertkl)
+  * remote_file can be used inside a namespace (@mikz)
 
 * Minor Changes
   * Remove -v flag from mkdir call. (@caligo-mentis)

--- a/lib/capistrano/dsl/task_enhancements.rb
+++ b/lib/capistrano/dsl/task_enhancements.rb
@@ -1,3 +1,5 @@
+require 'capistrano/upload_task'
+
 module Capistrano
   module TaskEnhancements
     def before(task, prerequisite, *args, &block)
@@ -19,7 +21,7 @@ module Capistrano
     end
 
     def define_remote_file_task(task, target_roles)
-      Rake::Task.define_task(task) do |t|
+      Capistrano::UploadTask.define_task(task) do |t|
         prerequisite_file = t.prerequisites.first
         file = shared_path.join(t.name)
 

--- a/lib/capistrano/upload_task.rb
+++ b/lib/capistrano/upload_task.rb
@@ -1,0 +1,9 @@
+require 'rake/file_creation_task'
+
+module Capistrano
+  class UploadTask < Rake::FileCreationTask
+    def needed?
+      true # always needed because we can't check remote hosts
+    end
+  end
+end

--- a/spec/lib/capistrano/dsl/task_enhancements_spec.rb
+++ b/spec/lib/capistrano/dsl/task_enhancements_spec.rb
@@ -69,5 +69,20 @@ module Capistrano
       end
 
     end
+
+    describe 'remote_file' do
+      subject(:remote_file) { task_enhancements.remote_file('source' => 'destination') }
+
+      it { expect(remote_file.name).to eq('source') }
+      it { is_expected.to be_a(Capistrano::UploadTask) }
+
+      describe 'namespaced' do
+        let(:app) { Rake.application }
+        around { |ex| app.in_namespace('namespace', &ex) }
+
+        it { expect(remote_file.name).to eq('source') }
+        it { is_expected.to be_a(Capistrano::UploadTask) }
+      end
+    end
   end
 end

--- a/spec/lib/capistrano/upload_task_spec.rb
+++ b/spec/lib/capistrano/upload_task_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Capistrano::UploadTask do
+  let(:app) { Rake.application = Rake::Application.new }
+
+  subject(:upload_task) { described_class.define_task('path/file.yml') }
+
+  it { is_expected.to be_a(Rake::FileCreationTask) }
+  it { is_expected.to be_needed }
+
+  context 'inside namespace' do
+    let(:normal_task) { Rake::Task.define_task('path/other_file.yml') }
+
+    around { |ex| app.in_namespace('namespace', &ex) }
+
+    it { expect(upload_task.name).to eq('path/file.yml') }
+    it { expect(upload_task.scope.path).to eq('namespace') }
+  end
+end


### PR DESCRIPTION
Previously defining `remote_task` inside a namespace resulted in
scoping the file name to the namespace. For example file named
`config/database.yml` inside `shared` namespace would result in:
`shared:config/database.yml`

That is surely unwanted behaviour. Fix is simple. Introducing
`Capistrano::UploadTask` that inherits from `Rake::FileCreationTask`.
These Rake File tasks are not carrying the namespace in their name.
