### PR TITLE
Allow Capistrano::DSL::Env#set to recive a block instead of value

### DIFF
--- a/lib/capistrano/dsl/env.rb
+++ b/lib/capistrano/dsl/env.rb
@@ -1,6 +1,7 @@
 module Capistrano
   module DSL
     module Env
+      UNKNOWN = Object.new.freeze
 
       def configure_backend
         env.configure_backend
@@ -19,7 +20,15 @@ module Capistrano
         end
       end
 
-      def set(key, value)
+      def set(key, value = UNKNOWN, &block)
+        if UNKNOWN.equal?(value)
+          if block_given?
+            value = block
+          else
+            fail ArgumentError, 'wrong number of arguments (1 for 2)'
+          end
+        end
+
         env.set(key, value)
       end
 

--- a/spec/lib/capistrano/dsl/env_spec.rb
+++ b/spec/lib/capistrano/dsl/env_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+module Capistrano
+  module DSL
+
+    class DummyEnv
+      include Env
+    end
+
+    describe Env do
+      let(:env) { DummyEnv.new }
+
+      context 'set' do
+        it 'accepts value' do
+          set = env.set('key', 'value')
+          expect(set).to eq('value')
+        end
+
+        it 'accepts block' do
+          set = env.set('key') { 'block' }
+          expect(set).to be_a(Proc)
+        end
+
+        it 'raises argument error when only one params is passed' do
+          expect{ env.set('key') }.to raise_error(ArgumentError, 'wrong number of arguments (1 for 2)')
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Adds syntax sugar for defining lazy variables in configuration.
Consider following example before:

``` ruby
set :database_yml, lambda {
  {
    fetch(:rails_env) => {
      ...
    }
  }
}
```

And after:

``` ruby
set :database_yml do
  {
    fetch(:rails_env) => {
      ...
    }
  }
end
```

Also it raises the same `ArgumentError` when neither block or value are
passed to maintain the previous behaviour.
