### PR TITLE
remove Question dependency on env

### DIFF
--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -15,7 +15,7 @@ module Capistrano
     end
 
     def ask(key, default=nil, options={})
-      question = Question.new(self, key, default, options)
+      question = Question.new(key, default, options)
       set(key, question)
     end
 

--- a/lib/capistrano/configuration/question.rb
+++ b/lib/capistrano/configuration/question.rb
@@ -2,24 +2,20 @@ module Capistrano
   class Configuration
     class Question
 
-      def initialize(env, key, default, options = {})
-        @env, @key, @default, @options = env, key, default, options
+      def initialize(key, default, options = {})
+        @key, @default, @options = key, default, options
       end
 
       def call
         ask_question
-        save_response
+        value_or_default
       end
 
       private
-      attr_reader :env, :key, :default, :options
+      attr_reader :key, :default, :options
 
       def ask_question
         $stdout.print question
-      end
-
-      def save_response
-        env.set(key, value_or_default)
       end
 
       def value_or_default

--- a/spec/lib/capistrano/configuration/question_spec.rb
+++ b/spec/lib/capistrano/configuration/question_spec.rb
@@ -5,11 +5,10 @@ module Capistrano
 
     describe Question do
 
-      let(:question) { Question.new(env, key, default, options) }
-      let(:question_without_echo) { Question.new(env, key, default, echo: false) }
+      let(:question) { Question.new(key, default, options) }
+      let(:question_without_echo) { Question.new(key, default, echo: false) }
       let(:default) { :default }
       let(:key) { :branch }
-      let(:env) { stub }
       let(:options) { nil }
 
       describe '.new' do
@@ -26,20 +25,18 @@ module Capistrano
             $stdout.expects(:print).with('Please enter branch (default): ')
           end
 
-          it 'sets the echoed value' do
+          it 'returns the echoed value' do
             $stdin.expects(:gets).returns(branch)
             $stdin.expects(:noecho).never
-            env.expects(:set).with(key, branch)
 
-            question.call
+            expect(question.call).to eq(branch)
           end
 
-          it 'sets the value but does not echo it' do
+          it 'returns the value but does not echo it' do
             $stdin.expects(:noecho).returns(branch)
             $stdout.expects(:print).with("\n")
-            env.expects(:set).with(key, branch)
 
-            question_without_echo.call
+            expect(question_without_echo.call).to eq(branch)
           end
         end
 
@@ -51,9 +48,9 @@ module Capistrano
             $stdin.expects(:gets).returns('')
           end
 
-          it 'sets the default as the value' do
-            env.expects(:set).with(key, branch)
-            question.call
+
+          it 'returns the default as the value' do
+            expect(question.call).to eq(branch)
           end
         end
       end

--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -154,7 +154,7 @@ module Capistrano
       let(:options) { Hash.new }
 
       before do
-        Configuration::Question.expects(:new).with(config, :branch, :default, options).
+        Configuration::Question.expects(:new).with(:branch, :default, options).
           returns(question)
       end
 


### PR DESCRIPTION
- Question was setting itself to the env but env itself persists it
- Env#fetch saves everyting that responds to #call by set

maybe there is a use case I don't see?

My plan for the future is to have questions overridable by env params like:

``` ruby
set :branch, ENV.fetch('branch') { Question.new(:branch, 'master') }
```
