### PR TITLE
Configuration.new accepts initial hash

### DIFF
--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -6,6 +6,10 @@ require_relative 'configuration/servers'
 module Capistrano
   class Configuration
 
+    def initialize(config = nil)
+      @config ||= config
+    end
+
     def self.env
       @env ||= new
     end

--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -5,6 +5,13 @@ module Capistrano
     let(:config) { Configuration.new }
     let(:servers) { stub }
 
+    describe '.new' do
+      it 'accepts initial hash' do
+        configuration = described_class.new(custom: 'value')
+        expect(configuration.fetch(:custom)).to eq('value')
+      end
+    end
+
     describe '.env' do
       it 'is a global accessor to a single instance' do
         Configuration.env.set(:test, true)


### PR DESCRIPTION
for easier testing of Capistrano plugins
