### PR TITLE
Rollback using the sudo context if available.

### DIFF
--- a/lib/capistrano/recipes/deploy.rb
+++ b/lib/capistrano/recipes/deploy.rb
@@ -249,7 +249,7 @@ namespace :deploy do
     defaults to :checkout).
   DESC
   task :update_code, :except => { :no_release => true } do
-    on_rollback { run "rm -rf #{release_path}; true" }
+    on_rollback { run "#{try_sudo} rm -rf #{release_path}; true" }
     strategy.deploy!
     finalize_update
   end


### PR DESCRIPTION
When rolling back, if the sudo parameter has been set, the operation will throw PermissionDenied exceptions. The rollback should use the same user/sudo as the deploy.

This branch is still used by the Capifony (Symfony version). 
