### PR TITLE
don't check git connection

### DIFF
--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -34,7 +34,6 @@ namespace :deploy do
 
   desc 'Check required files and directories exist'
   task :check do
-    invoke "#{scm}:check"
     invoke 'deploy:check:directories'
     invoke 'deploy:check:linked_dirs'
     invoke 'deploy:check:make_linked_dirs'


### PR DESCRIPTION
It may not be required or allowed to have a connection to the git
server from the app host. When using capistrano-rsync it isn't even required to have git
installed. I don't see why this is required. Perhaps the check can be
moved to just before the create_release command, but I don't see the
point in doing that.

We are using capistrano-rsync for the purpose of not having a network connection from the app server to the office git server, and it is just a bonus that git isn't even required to be installed. Hopefully the problem that the check is solving can be solved in another location or can be opt-in some how. I don't see a reason for it though, so I just removed it.