### PR TITLE
Disable default extended server syntax in template

### DIFF
--- a/lib/capistrano/templates/stage.rb.erb
+++ b/lib/capistrano/templates/stage.rb.erb
@@ -3,6 +3,7 @@
 # Supports bulk-adding hosts to roles, the primary server in each group
 # is considered to be the first unless any hosts have the primary
 # property set.  Don't declare `role :all`, it's a meta role.
+# ATTENTION! It is recommended to use single syntax, either simple or extended.
 
 role :app, %w{deploy@example.com}
 role :web, %w{deploy@example.com}
@@ -14,8 +15,9 @@ role :db,  %w{deploy@example.com}
 # This can be used to drop a more detailed server definition into the
 # server list. The second argument is a, or duck-types, Hash and is
 # used to set extended properties on the server.
+# ATTENTION! It is recommended to use single syntax, either simple or extended.
 
-server 'example.com', user: 'deploy', roles: %w{web app}, my_property: :my_value
+# server 'example.com', user: 'deploy', roles: %w{web app}, my_property: :my_value
 
 
 # Custom SSH Options


### PR DESCRIPTION
- Comment out extended syntax
- Add attention notice as part of recommendation