### PR TITLE
Fixed updating roles when custom user or port is specified.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Reverse Chronological Order:
 
 ## master
+* Fixed updating roles when custom user or port is specified. (@ayastreb)
 
 https://github.com/capistrano/capistrano/compare/v3.3.5...HEAD
 

--- a/lib/capistrano/configuration/servers.rb
+++ b/lib/capistrano/configuration/servers.rb
@@ -8,7 +8,7 @@ module Capistrano
       include Enumerable
 
       def add_host(host, properties={})
-        servers.add server(host).with(properties)
+        servers.add server(host, properties).with(properties)
       end
 
       def add_role(role, hosts, options={})
@@ -33,8 +33,10 @@ module Capistrano
 
       private
 
-      def server(host)
+      def server(host, properties)
         new_host = Server[host]
+        new_host.with({user: properties[:user]}) unless properties[:user].nil?
+        new_host.with({port: properties[:port]}) unless properties[:port].nil?
         servers.find { |server| server.matches? new_host } || new_host
       end
 

--- a/spec/lib/capistrano/configuration/servers_spec.rb
+++ b/spec/lib/capistrano/configuration/servers_spec.rb
@@ -169,6 +169,20 @@ module Capistrano
           expect(servers.roles_for([:array_test]).first.properties.array_property).to eq [1,2]
         end
 
+        it 'updates roles when custom user defined' do
+          servers.add_host('1', roles: ['foo'], user: 'custom')
+          servers.add_host('1', roles: ['bar'], user: 'custom')
+          expect(servers.roles_for([:foo]).first.hostname).to eq '1'
+          expect(servers.roles_for([:bar]).first.hostname).to eq '1'
+        end
+
+        it 'updates roles when custom port defined' do
+          servers.add_host('1', roles: ['foo'], port: 1234)
+          servers.add_host('1', roles: ['bar'], port: 1234)
+          expect(servers.roles_for([:foo]).first.hostname).to eq '1'
+          expect(servers.roles_for([:bar]).first.hostname).to eq '1'
+        end
+
       end
 
       describe 'selecting roles' do


### PR DESCRIPTION
In my previous PR #1223 I unintentionally reverted the fix from PR #1157, because fix there had no test and I missed it.
Here is my attempt to fix both issues #1071 and #1214, with tests for custom user/port.