### PR TITLE
Do not suggest `bin/` as a shared directory by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Reverse Chronological Order:
 ## master
 * Fixed updating roles when custom user or port is specified. (@ayastreb)
 
+* `bin/` is not suggested to be in `linked_dirs` anymore (@kirs)
+  * bin/ is often checked out into repo
+  * https://github.com/capistrano/bundler/issues/45#issuecomment-69349237
+
 https://github.com/capistrano/capistrano/compare/v3.3.5...HEAD
 
 ## `3.3.5`

--- a/lib/capistrano/templates/deploy.rb.erb
+++ b/lib/capistrano/templates/deploy.rb.erb
@@ -26,7 +26,7 @@ set :repo_url, 'git@example.com:me/my_repo.git'
 # set :linked_files, fetch(:linked_files, []).push('config/database.yml')
 
 # Default value for linked_dirs is []
-# set :linked_dirs, fetch(:linked_dirs, []).push('bin', 'log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system')
+# set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system')
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }


### PR DESCRIPTION
Two reasons:
1) `bin/` is often checked out into repo
2) https://github.com/capistrano/bundler/issues/45#issuecomment-69349237