### PR TITLE
add secrets.yml to linked_files in deploy.rb

### DIFF
--- a/lib/capistrano/templates/deploy.rb.erb
+++ b/lib/capistrano/templates/deploy.rb.erb
@@ -23,7 +23,7 @@ set :repo_url, 'git@example.com:me/my_repo.git'
 # set :pty, true
 
 # Default value for :linked_files is []
-# set :linked_files, fetch(:linked_files, []).push('config/database.yml')
+# set :linked_files, fetch(:linked_files, []).push('config/database.yml', 'config/secrets.yml')
 
 # Default value for linked_dirs is []
 # set :linked_dirs, fetch(:linked_dirs, []).push('bin', 'log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system')


### PR DESCRIPTION
Currently linked_files already contains config/database.yml, which 
could be considered a Rails-like configuration default.

Adding config/secrets.yml streamlines the recommended configuration for
Rails 4.1+ applications.

see #1321 which does a similar thing to `linked_dirs` for the same reasons.