### PR TITLE
Mark version 3.3.3's tracking of anonymous statistics as a breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@ https://github.com/capistrano/capistrano/compare/v3.2.1...v3.3.3
     and --trace options supply it as before.
 
 * Disable loading stages configs on `cap -T` (@sponomarev)
-* Track (anonymous) statistics, see https://github.com/capistrano/stats
 
 * Enhancements (@townsen)
   * Fix matching on hosts with custom ports or users set
@@ -98,6 +97,7 @@ https://github.com/capistrano/capistrano/compare/v3.2.1...v3.3.3
 
 Breaking Changes:
   * By using Ruby's noecho method introduced in Ruby version 1.9.3, we dropped support for Ruby versions prior to 1.9.3. See [issue #878](https://github.com/capistrano/capistrano/issues/878) and [PR #1112](https://github.com/capistrano/capistrano/pull/1112) for more information. (@kaikuchn)
+  * Track (anonymous) statistics, see https://github.com/capistrano/stats. This breaks automated deployment on continuous integration servers until the `.capistrano/metrics` file is created (with content `full` to simulate a "yes") via the interactive prompt or manually.
 
 * Bug Fixes:
   * Fixed compatibility with FreeBSD tar (@robbertkl)


### PR DESCRIPTION
After upgrading from 3.2.x to 3.3.x and scanning the changelog for breaking changes, this change broke automated deployment via our continuous deployment. I had to run a manual deploy to create the settings file, after which our CI server could deploy again.

I'm baffled that this was not marked as a breaking change, but I hope to rectify it after the fact with this commit.