### PR TITLE
Release roles bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Reverse Chronological Order:
 
 https://github.com/capistrano/capistrano/compare/v3.3.5...HEAD
 
+* Bugfix:
+  * release_roles did not honour additional property filtering (@townsen)
+  * Refactored and simplified property filtering code (@townsen)
+
+* Minor changes
+  * Add equality syntax ( eg. port: 1234) for property filtering (@townsen)
+  * Add documentation regarding property filtering (@townsen)
+
 ## `3.3.5`
 
 https://github.com/capistrano/capistrano/compare/v3.3.4...v3.3.5

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ basis. An example of that is the 'no_release' property and it's use in the
     * Via the `:filter` variable set in a stage file
 * Property-Filtering
     These are specified by options passed to the `roles()` method (and implicitly in methods
-    like `release_roles()` and `primary()`)
+    like `release_roles()` and `primary()`). See the description below.
 
 To increase the utility of On-Filters they can use regular expressions:
 * If the host name in a filter doesn't match `/^[-A-Za-z0-9.]+$/` (the set of valid characters
@@ -321,6 +321,59 @@ To increase the utility of On-Filters they can use regular expressions:
 When filters are specified using comma separated lists, the final filter is the _union_ of
 all of the components. However when multiple filters are declared the result is the
 _intersection_.
+
+## Property Filtering
+
+Options may be passed to the `roles()` method (and implicitly in methods like
+`release_roles()` and `primary()`) that affect the set of servers returned. These options
+take the form of a Hash passed as the last parameter.  Each of the key/value pairs in the
+hash are evaluated in the sequence they are declared and if all are true for a specific
+server then the server will be returned. The keys must always be symbols which have the
+following meaning:
+
+* `:filter`, or `:select`: The value must return true for the server to be included,
+* `:exclude`: The value must return false for the server to be included, and
+* Any other symbol is taken as a server property name whose value must equal the given value.
+
+In the first two cases the values themselves can be a lambda that will be evaluated with the
+current server. In the last case the value may be anything and is just tested for
+equality.
+
+Examples
+```ruby
+server 'example1.com', roles: %w{web}, active: true
+server 'example2.com', roles: %w{web}
+server 'example3.com', roles: %w{app web}, active: true
+server 'example4.com', roles: %w{app}, primary: true
+server 'example5.com', roles: %w{db}, no_release: true, active:true
+
+task :demo do
+  puts "All active release roles: 1,3"
+  release_roles(:all, filter: :active).each do |r|
+    puts "#{r.hostname}"
+  end
+  puts "All active roles: 1,3,5"
+  roles(:all, active: true).each do |r|
+    puts "#{r.hostname}"
+  end
+  puts "All web and db roles with selected names: 2,3"
+  roles(:web, :db, select: ->(s){ s.hostname =~ /[234]/}).each do |r|
+    puts "#{r.hostname}"
+  end
+  puts "All with no active property: 2,4"
+  roles(:all, active: nil).each do |r|
+    puts "#{r.hostname}"
+  end
+  puts "All except active: 2,4"
+  roles(:all, exclude: :active).each do |r|
+    puts "#{r.hostname}"
+  end
+  puts "All primary: 4"
+  roles(:all, select: :primary).each do |r|
+    puts "#{r.hostname}"
+  end
+end
+```
 
 ## SSHKit
 

--- a/lib/capistrano/dsl/env.rb
+++ b/lib/capistrano/dsl/env.rb
@@ -48,7 +48,11 @@ module Capistrano
       end
 
       def release_roles(*names)
-        names << { exclude: :no_release } unless names.last.is_a? Hash
+        if names.last.is_a? Hash
+          names.last.merge!({ :exclude => :no_release })
+        else
+          names << { exclude: :no_release }
+        end
         roles(*names)
       end
 

--- a/spec/integration/dsl_spec.rb
+++ b/spec/integration/dsl_spec.rb
@@ -15,7 +15,7 @@ describe Capistrano::DSL do
         dsl.server 'example2.com', roles: %w{web}
         dsl.server 'example3.com', roles: %w{app web}, active: true
         dsl.server 'example4.com', roles: %w{app}, primary: true
-        dsl.server 'example5.com', roles: %w{db}, no_release: true
+        dsl.server 'example5.com', roles: %w{db}, no_release: true, active:true
       end
 
       describe 'fetching all servers' do

--- a/spec/lib/capistrano/configuration/server_spec.rb
+++ b/spec/lib/capistrano/configuration/server_spec.rb
@@ -172,6 +172,18 @@ module Capistrano
           end
 
           context 'value does not match server properly' do
+            context 'with :active true' do
+              let(:options) { { active: true }}
+              it { expect(subject).to be_truthy }
+            end
+
+            context 'with :active false' do
+              let(:options) { { active: false }}
+              it { expect(subject).to be_falsey }
+            end
+          end
+
+          context 'value does not match server properly' do
             context 'with :filter' do
               let(:options) { { filter: :inactive }}
               it { expect(subject).to be_falsey }
@@ -186,6 +198,18 @@ module Capistrano
               let(:options) { { exclude: :inactive }}
               it { expect(subject).to be_truthy }
             end
+          end
+        end
+
+        context 'key is a property' do
+          context 'with :active true' do
+            let(:options) { { active: true }}
+            it { expect(subject).to be_truthy }
+          end
+
+          context 'with :active false' do
+            let(:options) { { active: false }}
+            it { expect(subject).to be_falsey }
           end
         end
 


### PR DESCRIPTION
The `release_roles()` function did not handle additional selection options correctly - changing `dsl_spec.rb:18` highlighted the problem with the existing code. I reworked the Property filtering code to make it cleaner and more capable (added shortcut for property equality tests).

Improved documentation and added new tests