### PR TITLE
Release roles bug - improve property filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Reverse Chronological Order:
   * bin/ is often checked out into repo
   * https://github.com/capistrano/bundler/issues/45#issuecomment-69349237
 
+* Bugfix:
+  * release_roles did not honour additional property filtering (@townsen)
+  * Refactored and simplified property filtering code (@townsen)
+
+* Minor changes
+  * Add equality syntax ( eg. port: 1234) for property filtering (@townsen)
+  * Add documentation regarding property filtering (@townsen)
+
 https://github.com/capistrano/capistrano/compare/v3.3.5...HEAD
 
 ## `3.3.5`

--- a/lib/capistrano/dsl/env.rb
+++ b/lib/capistrano/dsl/env.rb
@@ -48,7 +48,11 @@ module Capistrano
       end
 
       def release_roles(*names)
-        names << { exclude: :no_release } unless names.last.is_a? Hash
+        if names.last.is_a? Hash
+          names.last.merge!({ :exclude => :no_release })
+        else
+          names << { exclude: :no_release }
+        end
         roles(*names)
       end
 

--- a/spec/integration/dsl_spec.rb
+++ b/spec/integration/dsl_spec.rb
@@ -15,7 +15,7 @@ describe Capistrano::DSL do
         dsl.server 'example2.com', roles: %w{web}
         dsl.server 'example3.com', roles: %w{app web}, active: true
         dsl.server 'example4.com', roles: %w{app}, primary: true
-        dsl.server 'example5.com', roles: %w{db}, no_release: true
+        dsl.server 'example5.com', roles: %w{db}, no_release: true, active:true
       end
 
       describe 'fetching all servers' do

--- a/spec/lib/capistrano/configuration/server_spec.rb
+++ b/spec/lib/capistrano/configuration/server_spec.rb
@@ -172,6 +172,18 @@ module Capistrano
           end
 
           context 'value does not match server properly' do
+            context 'with :active true' do
+              let(:options) { { active: true }}
+              it { expect(subject).to be_truthy }
+            end
+
+            context 'with :active false' do
+              let(:options) { { active: false }}
+              it { expect(subject).to be_falsey }
+            end
+          end
+
+          context 'value does not match server properly' do
             context 'with :filter' do
               let(:options) { { filter: :inactive }}
               it { expect(subject).to be_falsey }
@@ -186,6 +198,18 @@ module Capistrano
               let(:options) { { exclude: :inactive }}
               it { expect(subject).to be_truthy }
             end
+          end
+        end
+
+        context 'key is a property' do
+          context 'with :active true' do
+            let(:options) { { active: true }}
+            it { expect(subject).to be_truthy }
+          end
+
+          context 'with :active false' do
+            let(:options) { { active: false }}
+            it { expect(subject).to be_falsey }
           end
         end
 


### PR DESCRIPTION
Property filtering did not honour multiple filter options. Highlighted by changing `dsl_spec.rb:18`. This PR fixes that, cleans up the property filter code and adds a new capability (testing server property equality). I'll PR some documentation to capistrano.github.io to describe this.