### PR TITLE
clarify wording and syntaxes in stage template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Reverse Chronological Order:
 * Minor changes
   * Add equality syntax ( eg. port: 1234) for property filtering (@townsen)
   * Add documentation regarding property filtering (@townsen)
+  * Clarify wording and recommendation in stage template. (@Kriechi)
+    * Both available syntaxes provide similar functionality, do not use both for the same server+role combination.
 
 https://github.com/capistrano/capistrano/compare/v3.3.5...HEAD
 

--- a/lib/capistrano/templates/stage.rb.erb
+++ b/lib/capistrano/templates/stage.rb.erb
@@ -1,27 +1,43 @@
-# Simple Role Syntax
-# ==================
-# Supports bulk-adding hosts to roles, the primary server in each group
-# is considered to be the first unless any hosts have the primary
-# property set.  Don't declare `role :all`, it's a meta role.
-
-role :app, %w{deploy@example.com}
-role :web, %w{deploy@example.com}
-role :db,  %w{deploy@example.com}
-
-
-# Extended Server Syntax
+# server-based syntax
 # ======================
-# This can be used to drop a more detailed server definition into the
-# server list. The second argument is a, or duck-types, Hash and is
-# used to set extended properties on the server.
+# Defines a single server with a list of roles and multiple properties.
+# You can define all roles on a single server, or split them:
 
-server 'example.com', user: 'deploy', roles: %w{web app}, my_property: :my_value
+# server 'example.com', user: 'deploy', roles: %w{app db web}, my_property: :my_value
+# server 'example.com', user: 'deploy', roles: %w{app web}, other_property: :other_value
+# server 'db.example.com', user: 'deploy', roles: %w{db}
+
+
+
+# role-based syntax
+# ==================
+
+# Defines a role with one or multiple servers. The primary server in each
+# group is considered to be the first unless any  hosts have the primary
+# property set. Specify the username and a domain or IP for the server.
+# Don't use `:all`, it's a meta role.
+
+# role :app, %w{deploy@example.com}, my_property: :my_value
+# role :web, %w{user1@primary.com user2@additional.com}, other_property: :other_value
+# role :db,  %w{deploy@example.com}
+
+
+
+# Configuration
+# =============
+# You can set any configuration variable like in config/deploy.rb
+# These variables are then only loaded and set in this stage.
+# For available Capistrano configuration variables see the documentation page.
+# http://capistranorb.com/documentation/getting-started/configuration/
+# Feel free to add new variables to customise your setup.
+
 
 
 # Custom SSH Options
 # ==================
 # You may pass any option but keep in mind that net/ssh understands a
-# limited set of options, consult[net/ssh documentation](http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start).
+# limited set of options, consult the Net::SSH documentation.
+# http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start
 #
 # Global options
 # --------------
@@ -31,7 +47,7 @@ server 'example.com', user: 'deploy', roles: %w{web app}, my_property: :my_value
 #    auth_methods: %w(password)
 #  }
 #
-# And/or per server (overrides global)
+# The server-based syntax can be used to override options:
 # ------------------------------------
 # server 'example.com',
 #   user: 'user_name',


### PR DESCRIPTION
closes #1301 

This is a first draft of my ideas on the discussion in #1301.

Add a short note that the server-based syntax can be used to override global (or existing) options.
Renamed the simple and extended syntaxes to more representative names:
* server-based syntax
* role-based syntax

Everything is commented out by choice. So the user has to read through the comments and can choose the best syntax for their setup. IMHO the syntax-based syntax is adequate for most users, therefore I put it first.

This might need additional comments about overwritting options and stuff discussed in https://github.com/capistrano/capistrano/pull/1301#issuecomment-71712716

I'm unsure about the provided examples? Should there be more? Complex ones? Or only the most basic example?

/cc @townsen @ain @kirs 