### PR TITLE
Fix ssh option merge

### DIFF
--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -86,7 +86,7 @@ module Capistrano
         sshkit.backend.configure do |backend|
           backend.pty                = fetch(:pty)
           backend.connection_timeout = fetch(:connection_timeout)
-          backend.ssh_options        = fetch(:ssh_options) if fetch(:ssh_options)
+          backend.ssh_options        = (backend.ssh_options || {}).merge(fetch(:ssh_options,{}))
         end
       end
     end

--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -180,6 +180,17 @@ module Capistrano
         config.backend = :test
         expect(config.backend).to eq :test
       end
+
+      describe "ssh_options for Netssh" do
+        it 'merges them with the :ssh_options variable' do
+          config.set :format, :pretty
+          config.set :log_level, :debug
+          config.set :ssh_options, { user: 'albert' }
+          SSHKit::Backend::Netssh.configure do |ssh| ssh.ssh_options = { password: 'einstein' } end
+          config.configure_backend
+          expect(config.backend.config.backend.config.ssh_options).to eq({ user: 'albert', password: 'einstein' })
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Turns out that the [documentation I updated](http://capistranorb.com/documentation/advanced-features/properties/) wasn't quite right: There are some corner cases with `ssh_options` at different levels that don't get merged properly. There are two issues, one in  Capistrano and one in SSHKit. This fixes the Capistrano case - see SSHKit PR's for the other