### PR TITLE
remove post-install message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Reverse Chronological Order:
 
 https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
 
+* Removed the post-install message (@Kriechi)
+
 ## `3.4.0`
 
 https://github.com/capistrano/capistrano/compare/v3.3.5...v3.4.0

--- a/capistrano.gemspec
+++ b/capistrano.gemspec
@@ -19,14 +19,6 @@ Gem::Specification.new do |gem|
 
   gem.licenses      = ['MIT']
 
-  gem.post_install_message = <<eos
-Capistrano 3.1 has some breaking changes. Please check the CHANGELOG: http://goo.gl/SxB0lr
-
-If you're upgrading Capistrano from 2.x, we recommend to read the upgrade guide: http://goo.gl/4536kB
-
-The `deploy:restart` hook for passenger applications is now in a separate gem called capistrano-passenger.  Just add it to your Gemfile and require it in your Capfile.
-eos
-
   gem.required_ruby_version = '>= 1.9.3'
   gem.add_dependency 'sshkit', '~> 1.3'
   gem.add_dependency 'rake', '>= 10.0.0'


### PR DESCRIPTION
This PR removes the post_install_message from `gemspec`.

v3.0 and v3.1 are both over a year old (Oct-2013 and Jan-2014).
IMHO the message is not needed anymore.