### PR TITLE
Correctly filter literal hostnames in on() block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
 
 * Removed the post-install message (@Kriechi)
 
+* Minor changes
+  * Fix filtering behaviour when using literal hostnames in on() block (@townsen)
+
 ## `3.4.0`
 
 https://github.com/capistrano/capistrano/compare/v3.3.5...v3.4.0

--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -99,7 +99,7 @@ module Capistrano
       @filters = cmdline_filters.clone
       @filters << Filter.new(:role, ENV['ROLES']) if ENV['ROLES']
       @filters << Filter.new(:host, ENV['HOSTS']) if ENV['HOSTS']
-      fh = fetch_for(:filter,{})
+      fh = fetch_for(:filter,{}) || {}
       @filters << Filter.new(:host, fh[:host]) if fh[:host]
       @filters << Filter.new(:role, fh[:role]) if fh[:role]
     end

--- a/lib/capistrano/configuration/filter.rb
+++ b/lib/capistrano/configuration/filter.rb
@@ -46,9 +46,9 @@ module Capistrano
         when :none then return []
         when :all  then return servers
         when :host
-          as.select {|s| @rex.match s.hostname}
+          as.select {|s| @rex.match s.to_s}
         when :role
-          as.select {|s| s.roles.any? {|r| @rex.match r} }
+          as.select { |s| s.is_a?(String) ? false : s.roles.any? {|r| @rex.match r} }
         end
       end
     end


### PR DESCRIPTION
When a literal hostname was supplied instead of a server object created
by the DSL 'server' keyword, on-filtering would not work.

Now host filtering works as expected, and role filtering causes no
servers to be returned (as literally-defined servers have no roles)