### PR TITLE
Bind post_task lazily in TaskEnhancements#after.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
 * Minor changes
   * Fix filtering behaviour when using literal hostnames in on() block (@townsen)
   * Added options to set username and password when using Subversion as SCM (@dsthode)
+  * Allow after() to refer to tasks that have not been loaded yet (@jcoglan)
 
 ## `3.4.0`
 

--- a/lib/capistrano/dsl/task_enhancements.rb
+++ b/lib/capistrano/dsl/task_enhancements.rb
@@ -9,9 +9,8 @@ module Capistrano
 
     def after(task, post_task, *args, &block)
       Rake::Task.define_task(post_task, *args, &block) if block_given?
-      post_task = Rake::Task[post_task]
       Rake::Task[task].enhance do
-        post_task.invoke
+        Rake::Task[post_task].invoke
       end
     end
 

--- a/spec/lib/capistrano/dsl/task_enhancements_spec.rb
+++ b/spec/lib/capistrano/dsl/task_enhancements_spec.rb
@@ -54,6 +54,18 @@ module Capistrano
         expect(order).to eq(['before_task', 'task', 'after_task'])
       end
 
+      it 'invokes in proper order when referring to as-yet undefined tasks' do
+        task_enhancements.after('task', 'not_loaded_task')
+
+        Rake::Task.define_task('not_loaded_task') do
+          order.push 'not_loaded_task'
+        end
+
+        Rake::Task['task'].invoke order
+
+        expect(order).to eq(['task', 'not_loaded_task'])
+      end
+
       it 'invokes in proper order and with arguments and block' do
         task_enhancements.after('task', 'after_task_custom', :order) do |t, args|
           order.push 'after_task'


### PR DESCRIPTION
Consider you have two files:

    # a.rake

    task :a do
    end
    after :a, :b

    # b.rake

    task :b do
    end

If `a.rake` is loaded before `b.rake`, it will fail, complaining that
"Don't know how to build task b". This is because TaskEnhancements#after
tries to look up task `b` before it's been defined.

However, the task is not actually needed until execution gets inside the
block that's passed to Rake::Task#enhance, at which point all tasks
should have been loaded and it's legitimate to complain about a task not
being recognised.

Havign this change allows app authors to write something like

    Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

in their Capfile and not explicitly define load order. This cannot be
solved by calling `require` at the top of `a.rake` because `require`
throws a `LoadError` on `.rake` files. It also cannot be solved by
calling `import` at the top of `a.rake`, because Rake's `import` does
not load the referenced file immediately; it puts it in a queue and
continues processing the current file.