### PR TITLE
Added options to set username and password when using Subversion as SCM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
 
 * Minor changes
   * Fix filtering behaviour when using literal hostnames in on() block (@townsen)
+  * Added options to set username and password when using Subversion as SCM (@dsthode)
 
 ## `3.4.0`
 

--- a/lib/capistrano/svn.rb
+++ b/lib/capistrano/svn.rb
@@ -7,6 +7,8 @@ class Capistrano::Svn < Capistrano::SCM
   # execute svn in context with arguments
   def svn(*args)
     args.unshift(:svn)
+    args.push "--username #{fetch(:svn_username)}" if fetch(:svn_username)
+    args.push "--password #{fetch(:svn_password)}" if fetch(:svn_password)
     context.execute *args
   end
 

--- a/lib/capistrano/svn.rb
+++ b/lib/capistrano/svn.rb
@@ -18,7 +18,9 @@ class Capistrano::Svn < Capistrano::SCM
     end
 
     def check
-      test! :svn, :info, repo_url
+      svn_username = fetch(:svn_username) ? "--username #{fetch(:svn_username)}" : ''
+      svn_password = fetch(:svn_password) ? "--password #{fetch(:svn_password)}" : ''
+      test! :svn, :info, repo_url, svn_username, svn_password
     end
 
     def clone

--- a/spec/lib/capistrano/svn_spec.rb
+++ b/spec/lib/capistrano/svn_spec.rb
@@ -9,7 +9,9 @@ module Capistrano
 
     describe "#svn" do
       it "should call execute svn in the context, with arguments" do
-        context.expects(:execute).with(:svn, :init)
+        context.expects(:execute).with(:svn, :init, '--username someuser', '--password somepassword')
+        context.expects(:fetch).twice.with(:svn_username).returns('someuser')
+        context.expects(:fetch).twice.with(:svn_password).returns('somepassword')
         subject.svn(:init)
       end
     end
@@ -31,7 +33,9 @@ module Capistrano
     describe "#check" do
       it "should test the repo url" do
         context.expects(:repo_url).returns(:url)
-        context.expects(:test).with(:svn, :info, :url).returns(true)
+        context.expects(:test).with(:svn, :info, :url, '--username someuser', '--password somepassword').returns(true)
+        context.expects(:fetch).twice.with(:svn_username).returns('someuser')
+        context.expects(:fetch).twice.with(:svn_password).returns('somepassword')
 
         subject.check
       end
@@ -41,8 +45,10 @@ module Capistrano
       it "should run svn checkout" do
         context.expects(:repo_url).returns(:url)
         context.expects(:repo_path).returns(:path)
+        context.expects(:fetch).twice.with(:svn_username).returns('someuser')
+        context.expects(:fetch).twice.with(:svn_password).returns('somepassword')
  
-        context.expects(:execute).with(:svn, :checkout, :url, :path)
+        context.expects(:execute).with(:svn, :checkout, :url, :path, '--username someuser', '--password somepassword')
 
         subject.clone
       end
@@ -50,7 +56,9 @@ module Capistrano
 
     describe "#update" do
       it "should run svn update" do
-        context.expects(:execute).with(:svn, :update)
+        context.expects(:execute).with(:svn, :update, '--username someuser', '--password somepassword')
+        context.expects(:fetch).twice.with(:svn_username).returns('someuser')
+        context.expects(:fetch).twice.with(:svn_password).returns('somepassword')
 
         subject.update
       end
@@ -59,8 +67,10 @@ module Capistrano
     describe "#release" do
       it "should run svn export" do        
         context.expects(:release_path).returns(:path)
+        context.expects(:fetch).twice.with(:svn_username).returns('someuser')
+        context.expects(:fetch).twice.with(:svn_password).returns('somepassword')
         
-        context.expects(:execute).with(:svn, :export, '--force', '.', :path)
+        context.expects(:execute).with(:svn, :export, '--force', '.', :path, '--username someuser', '--password somepassword')
 
         subject.release
       end


### PR DESCRIPTION
Add :svn_username and/or :svn_password to the deplyment file if Subversion needs authentication