### PR TITLE
Return longer SHA1 hash when fetching current revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
   * Fix filtering behaviour when using literal hostnames in on() block (@townsen)
   * Added options to set username and password when using Subversion as SCM (@dsthode)
   * Allow after() to refer to tasks that have not been loaded yet (@jcoglan)
+  * Return first 12 characters (instead of 7) of SHA1 hash when determining current git revision (@sds)
 
 ## `3.4.0`
 

--- a/lib/capistrano/git.rb
+++ b/lib/capistrano/git.rb
@@ -40,7 +40,7 @@ class Capistrano::Git < Capistrano::SCM
     end
 
     def fetch_revision
-      context.capture(:git, "rev-list --max-count=1 --abbrev-commit #{fetch(:branch)}")
+      context.capture(:git, "rev-list --max-count=1 --abbrev-commit --abbrev=12 #{fetch(:branch)}")
     end
   end
 end


### PR DESCRIPTION
The mechanism Capistrano used to get the current commit hash of a
repository only returned the first 7 characters of the hash (thanks to the
`--abbrev-commit` flag).

While usually more convenient, the problem with a 7 character
abbreviation is that by the time a repository reaches 10,000 commits, it
becomes quite likely that you'll have a collision in the first 7
characters of at least two commits (~17% chance).

A collision is problematic if you intend to use these hashes to generate
links in emails or chat messages notifying your team of a deploy.

Increasing the minimum number of characters to 12 keeps the hash short
but virtually eliminates the possibility of a collision for all
practical purposes. (12 is the number used by the Linux kernel's git repo)