### PR TITLE
Strip trailing whitespace for scm fetch_revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
   * Fix filtering behaviour when using literal hostnames in on() block (@townsen)
   * Added options to set username and password when using Subversion as SCM (@dsthode)
   * Allow after() to refer to tasks that have not been loaded yet (@jcoglan)
+  * Ensure scm fetch_revision methods strip trailing whitespace (@mattbrictson)
 
 ## `3.4.0`
 

--- a/lib/capistrano/git.rb
+++ b/lib/capistrano/git.rb
@@ -40,7 +40,7 @@ class Capistrano::Git < Capistrano::SCM
     end
 
     def fetch_revision
-      context.capture(:git, "rev-list --max-count=1 --abbrev-commit #{fetch(:branch)}")
+      context.capture(:git, "rev-list --max-count=1 --abbrev-commit #{fetch(:branch)}").strip
     end
   end
 end

--- a/lib/capistrano/hg.rb
+++ b/lib/capistrano/hg.rb
@@ -37,7 +37,7 @@ class Capistrano::Hg < Capistrano::SCM
     end
 
     def fetch_revision
-      context.capture(:hg, "log --rev #{fetch(:branch)} --template \"{node}\n\"")
+      context.capture(:hg, "log --rev #{fetch(:branch)} --template \"{node}\n\"").strip
     end
   end
 end

--- a/lib/capistrano/svn.rb
+++ b/lib/capistrano/svn.rb
@@ -36,7 +36,7 @@ class Capistrano::Svn < Capistrano::SCM
     end
 
     def fetch_revision
-      context.capture(:svnversion, repo_path)
+      context.capture(:svnversion, repo_path).strip
     end
   end
 end

--- a/spec/lib/capistrano/git_spec.rb
+++ b/spec/lib/capistrano/git_spec.rb
@@ -77,5 +77,14 @@ module Capistrano
         subject.release
       end
     end
+
+    describe "#fetch_revision" do
+      it "should strip trailing whitespace" do
+        context.expects(:fetch).with(:branch).returns(:branch)
+        context.expects(:capture).with(:git, "rev-list --max-count=1 --abbrev-commit branch").returns("01abcde\n")
+        revision = subject.fetch_revision
+        expect(revision).to eq("01abcde")
+      end
+    end
   end
 end

--- a/spec/lib/capistrano/hg_spec.rb
+++ b/spec/lib/capistrano/hg_spec.rb
@@ -77,5 +77,14 @@ module Capistrano
         subject.release
       end
     end
+
+    describe "#fetch_revision" do
+      it "should strip trailing whitespace" do
+        context.expects(:fetch).with(:branch).returns(:branch)
+        context.expects(:capture).with(:hg, "log --rev branch --template \"{node}\n\"").returns("01abcde\n")
+        revision = subject.fetch_revision
+        expect(revision).to eq("01abcde")
+      end
+    end
   end
 end

--- a/spec/lib/capistrano/svn_spec.rb
+++ b/spec/lib/capistrano/svn_spec.rb
@@ -77,12 +77,13 @@ module Capistrano
     end
 
     describe "#fetch_revision" do
-      it "should run fetch revision" do
+      it "should run fetch revision and strip trailing whitespace" do
         context.expects(:repo_path).returns(:path)
 
-        context.expects(:capture).with(:svnversion, :path)
+        context.expects(:capture).with(:svnversion, :path).returns("12345\n")
 
-        subject.fetch_revision
+        revision = subject.fetch_revision
+        expect(revision).to eq("12345")
       end
     end
   end


### PR DESCRIPTION
[A recent change to SSHKit](https://github.com/capistrano/sshkit/pull/239) means that `capture` no longer strips trailing whitespace. This affects the behavior of `fetch_revision`, such that the returned revision now includes a newline.

This PR restores the previous behavior of `fetch_revision` by explicitly calling `strip` on the captured output.