### PR TITLE
Allow use "all" as string for server filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
   * Added options to set username and password when using Subversion as SCM (@dsthode)
   * Allow after() to refer to tasks that have not been loaded yet (@jcoglan)
   * Ensure scm fetch_revision methods strip trailing whitespace (@mattbrictson)
+  * Allow use "all" as string for server filtering (@theist)
 
 ## `3.4.0`
 

--- a/lib/capistrano/configuration/filter.rb
+++ b/lib/capistrano/configuration/filter.rb
@@ -9,6 +9,7 @@ module Capistrano
         @mode = case
                 when av.size == 0 then :none
                 when av.include?(:all) then :all
+                when av.include?('all') then :all
                 else type
                 end
         @rex = case @mode

--- a/spec/lib/capistrano/configuration/filter_spec.rb
+++ b/spec/lib/capistrano/configuration/filter_spec.rb
@@ -68,6 +68,11 @@ module Capistrano
           expect(set.size).to eq(available.size)
           expect(set.first.hostname).to eq('server1')
         end
+        it 'return all hosts using all as string' do
+          set = Filter.new(:role, 'all').filter(available)
+          expect(set.size).to eq(available.size)
+          expect(set.first.hostname).to eq('server1')
+        end
         it 'returns hosts in a single string role' do
           set = Filter.new(:role, 'web').filter(available)
           expect(set.size).to eq(2)


### PR DESCRIPTION
Hi! 

Sorry I called it a bug but I do not know if it was a feature. 

Using capistrano I ran into a extrange behaviour, defined roles can be user as symbol or string for filtering, but special role all only could be specified as symbol

See relevant pry session at https://gist.github.com/theist/9ebf13d8aaee8a7ec01e

So wrote a test to match the behaviour I wanted and modify the Filter class code to pass it

