### PR TITLE
Revert "Strip trailing whitespace for scm fetch_revision"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
   * Added options to set username and password when using Subversion as SCM (@dsthode)
   * Allow after() to refer to tasks that have not been loaded yet (@jcoglan)
   * Ensure scm fetch_revision methods strip trailing whitespace (@mattbrictson)
+    * Reverted - no longer needed due to [SSHKit PR249](https://github.com/capistrano/sshkit/pull/249) (@robd)
   * Allow use "all" as string for server filtering (@theist)
 
 ## `3.4.0`

--- a/lib/capistrano/git.rb
+++ b/lib/capistrano/git.rb
@@ -40,7 +40,7 @@ class Capistrano::Git < Capistrano::SCM
     end
 
     def fetch_revision
-      context.capture(:git, "rev-list --max-count=1 --abbrev-commit #{fetch(:branch)}").strip
+      context.capture(:git, "rev-list --max-count=1 --abbrev-commit #{fetch(:branch)}")
     end
   end
 end

--- a/lib/capistrano/hg.rb
+++ b/lib/capistrano/hg.rb
@@ -37,7 +37,7 @@ class Capistrano::Hg < Capistrano::SCM
     end
 
     def fetch_revision
-      context.capture(:hg, "log --rev #{fetch(:branch)} --template \"{node}\n\"").strip
+      context.capture(:hg, "log --rev #{fetch(:branch)} --template \"{node}\n\"")
     end
   end
 end

--- a/lib/capistrano/svn.rb
+++ b/lib/capistrano/svn.rb
@@ -36,7 +36,7 @@ class Capistrano::Svn < Capistrano::SCM
     end
 
     def fetch_revision
-      context.capture(:svnversion, repo_path).strip
+      context.capture(:svnversion, repo_path)
     end
   end
 end

--- a/spec/lib/capistrano/git_spec.rb
+++ b/spec/lib/capistrano/git_spec.rb
@@ -79,9 +79,9 @@ module Capistrano
     end
 
     describe "#fetch_revision" do
-      it "should strip trailing whitespace" do
+      it "should capture git rev-list" do
         context.expects(:fetch).with(:branch).returns(:branch)
-        context.expects(:capture).with(:git, "rev-list --max-count=1 --abbrev-commit branch").returns("01abcde\n")
+        context.expects(:capture).with(:git, "rev-list --max-count=1 --abbrev-commit branch").returns("01abcde")
         revision = subject.fetch_revision
         expect(revision).to eq("01abcde")
       end

--- a/spec/lib/capistrano/hg_spec.rb
+++ b/spec/lib/capistrano/hg_spec.rb
@@ -79,9 +79,9 @@ module Capistrano
     end
 
     describe "#fetch_revision" do
-      it "should strip trailing whitespace" do
+      it "should capture hg log" do
         context.expects(:fetch).with(:branch).returns(:branch)
-        context.expects(:capture).with(:hg, "log --rev branch --template \"{node}\n\"").returns("01abcde\n")
+        context.expects(:capture).with(:hg, "log --rev branch --template \"{node}\n\"").returns("01abcde")
         revision = subject.fetch_revision
         expect(revision).to eq("01abcde")
       end

--- a/spec/lib/capistrano/svn_spec.rb
+++ b/spec/lib/capistrano/svn_spec.rb
@@ -77,10 +77,10 @@ module Capistrano
     end
 
     describe "#fetch_revision" do
-      it "should run fetch revision and strip trailing whitespace" do
+      it "should capture svn version" do
         context.expects(:repo_path).returns(:path)
 
-        context.expects(:capture).with(:svnversion, :path).returns("12345\n")
+        context.expects(:capture).with(:svnversion, :path).returns("12345")
 
         revision = subject.fetch_revision
         expect(revision).to eq("12345")


### PR DESCRIPTION
This reverts the stripping added in commit ad8682d. 

The original change to SSHKit which made it necessary to strip in capistrano was reverted in https://github.com/capistrano/sshkit/pull/249, so we no longer need to strip, at least for the moment.

If we update the SSHKit default capture behaviour in some future SSHKit release, we will need to revisit this, but for the moment I think it's best not to confuse things by implying stripping is needed and having tests which incorrectly show SSHKit as not stripping. Therefore, I kept the tests which were added, but updated the behaviour to match what SSHKit actually does.

@mattbrictson Since this reverts some of your original commit :(, I'd like to check whether this is OK with you.