### PR TITLE
Remove 'vendor/bundle' from default :linked_dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Reverse Chronological Order:
 
 https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
 
+* Remove 'vendor/bundle' from default :linked_dirs (@ojab)
 * Removed the post-install message (@Kriechi)
 
 * Minor changes

--- a/lib/capistrano/templates/deploy.rb.erb
+++ b/lib/capistrano/templates/deploy.rb.erb
@@ -26,7 +26,7 @@ set :repo_url, 'git@example.com:me/my_repo.git'
 # set :linked_files, fetch(:linked_files, []).push('config/database.yml', 'config/secrets.yml')
 
 # Default value for linked_dirs is []
-# set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system')
+# set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'public/system')
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -29,7 +29,7 @@ module TestApp
   end
 
   def linked_dirs
-    %w{bin log public/system vendor/bundle}
+    %w{bin log public/system}
   end
 
   def create_test_app


### PR DESCRIPTION
capistrano-bundler uses "#{fetch(:deploy_to)}/shared/bundle" directory, so vendor/bundle is useless,