### PR TITLE
fixes Encoding::UndefinedConversionError, xC4 from ASCII-8BIT to UTF-8 from logger.rb

### DIFF
--- a/lib/capistrano/logger.rb
+++ b/lib/capistrano/logger.rb
@@ -134,9 +134,9 @@ module Capistrano
         indent = "%*s" % [MAX_LEVEL, "*" * (MAX_LEVEL - level)]
         (RUBY_VERSION >= "1.9" ? message.lines : message).each do |line|
           if line_prefix
-            device.puts "#{indent} [#{line_prefix}] #{line.strip}\n"
+            device.puts "#{indent} [#{line_prefix}] #{line.strip}\n".force_encoding('UTF-8')
           else
-            device.puts "#{indent} #{line.strip}\n"
+            device.puts "#{indent} #{line.strip}\n".force_encoding('UTF-8')
           end
         end
       end


### PR DESCRIPTION
```
$ ruby -v
ruby 1.9.3p448 (2013-06-27 revision 41675) [x86_64-linux]
```
```
(master)$ bundle exec cap staging deploy
  (...)
```
```
  * executing "sudo -u mongrel find /home/httpd/html/my_app/releases/20150617094735/public/images /home/httpd/html/my_app/releases/20150617094735/public/stylesheets /home/httpd/html/my_app/releases/20150617094735/public/javascripts -exec touch -t 201506170947.44 -- {} ';'; true"
    servers: ["dev55.non.3dart.com"]
    [dev55.non.3dart.com] executing command
*** [deploy:update_code] rolling back
  * executing "sudo -i -u mongrel rm -rf /home/httpd/html/my_app/releases/20150617094735; true"
    servers: ["dev55.non.3dart.com"]
 ** [deploy:update_code] exception while rolling back: Encoding::UndefinedConversionError, "\xC4" from ASCII-8BIT to UTF-8
/home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/logger.rb:137:in `write': "\xC5" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/logger.rb:137:in `puts'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/logger.rb:137:in `block in log'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/logger.rb:135:in `lines'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/logger.rb:135:in `each'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/logger.rb:135:in `log'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/logger.rb:146:in `important'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/actions/invocation.rb:15:in `block in included'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/command.rb:245:in `[]'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/command.rb:245:in `block (4 levels) in open_channels'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/net-ssh-2.9.1/lib/net/ssh/connection/channel.rb:578:in `call'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/net-ssh-2.9.1/lib/net/ssh/connection/channel.rb:578:in `do_extended_data'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/net-ssh-2.9.1/lib/net/ssh/connection/session.rb:571:in `channel_extended_data'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/net-ssh-2.9.1/lib/net/ssh/connection/session.rb:465:in `dispatch_incoming_packets'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/net-ssh-2.9.1/lib/net/ssh/connection/session.rb:221:in `preprocess'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/processable.rb:17:in `block in process_iteration'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/processable.rb:45:in `block in ensure_each_session'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/processable.rb:43:in `each'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/processable.rb:43:in `ensure_each_session'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/processable.rb:17:in `process_iteration'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/command.rb:171:in `block (2 levels) in process!'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/command.rb:170:in `loop'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/command.rb:170:in `block in process!'
  from /home/mkalita/.rvm/rubies/ruby-1.9.3-p448/lib/ruby/1.9.1/benchmark.rb:295:in `realtime'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/command.rb:169:in `process!'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/command.rb:140:in `process'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/actions/invocation.rb:198:in `block in run_tree'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/connections.rb:205:in `block in execute_on_servers'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/connections.rb:193:in `each'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/connections.rb:193:in `each_slice'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/connections.rb:193:in `execute_on_servers'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/actions/invocation.rb:196:in `run_tree'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/actions/invocation.rb:155:in `run'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/artrails_capistrano-0.0.14/lib/artrails_capistrano/capistrano.rb:45:in `run'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/namespaces.rb:191:in `method_missing'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/recipes/deploy.rb:298:in `block (2 levels) in load'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:138:in `instance_eval'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:138:in `invoke_task_directly'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/callbacks.rb:25:in `invoke_task_directly_with_callbacks'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:89:in `execute_task'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/namespaces.rb:191:in `method_missing'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/namespaces.rb:110:in `block in define_task'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/recipes/deploy.rb:254:in `block (2 levels) in load'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:138:in `instance_eval'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:138:in `invoke_task_directly'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/callbacks.rb:25:in `invoke_task_directly_with_callbacks'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:89:in `execute_task'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/namespaces.rb:191:in `method_missing'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/namespaces.rb:110:in `block in define_task'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/recipes/deploy.rb:234:in `block (3 levels) in load'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:56:in `transaction'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/namespaces.rb:191:in `method_missing'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/recipes/deploy.rb:233:in `block (2 levels) in load'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:138:in `instance_eval'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:138:in `invoke_task_directly'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/callbacks.rb:25:in `invoke_task_directly_with_callbacks'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:89:in `execute_task'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/namespaces.rb:191:in `method_missing'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/namespaces.rb:110:in `block in define_task'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/recipes/deploy.rb:201:in `block (2 levels) in load'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:138:in `instance_eval'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:138:in `invoke_task_directly'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/callbacks.rb:25:in `invoke_task_directly_with_callbacks'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:89:in `execute_task'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:101:in `find_and_execute_task'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/cli/execute.rb:46:in `block in execute_requested_actions'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/cli/execute.rb:45:in `each'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/cli/execute.rb:45:in `execute_requested_actions'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/cli/help.rb:19:in `execute_requested_actions_with_help'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/cli/execute.rb:34:in `execute!'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/lib/capistrano/cli/execute.rb:14:in `execute'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/gems/capistrano-2.15.5/bin/cap:4:in `<top (required)>'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/bin/cap:23:in `load'
  from /home/me/my_app/vendor/bundle/ruby/1.9.1/bin/cap:23:in `<main>'
```