### PR TITLE
Ensure deploy:log_revision obeys `within`

### DIFF
--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -172,7 +172,7 @@ namespace :deploy do
   task :log_revision do
     on release_roles(:all) do
       within releases_path do
-        execute %{echo "#{revision_log_message}" >> #{revision_log}}
+        execute :echo, %{"#{revision_log_message}" >> #{revision_log}}
       end
     end
   end


### PR DESCRIPTION
As the execute statement is not split by command and arguments the `within` block is ignored. Switching to `execute :cmd, "args"` solves this problem.
