### PR TITLE
`append` DSL method for pushing values like `linked_dirs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Reverse Chronological Order:
 
 https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
 
+* `append` DSL method for pushing values like `linked_dirs`
 * Added support for git shallow clone
 * Remove 'vendor/bundle' from default :linked_dirs (@ojab)
 * Removed the post-install message (@Kriechi)

--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -38,6 +38,10 @@ module Capistrano
       set(key, value, &block) unless config.has_key? key
     end
 
+    def append(key, value)
+      set(key, Array(fetch(key)) << value)
+    end
+
     def delete(key)
       config.delete(key)
     end
@@ -167,7 +171,7 @@ module Capistrano
       unless value.nil? or block.nil?
         raise Capistrano::ValidationError.new("Value and block both passed to Configuration#set")
       end
-      
+
       return unless validators.has_key? key
 
       validators[key].each do |validator|

--- a/lib/capistrano/dsl/env.rb
+++ b/lib/capistrano/dsl/env.rb
@@ -6,7 +6,7 @@ module Capistrano
       extend Forwardable
       def_delegators :env,
                      :configure_backend, :fetch, :set, :set_if_empty, :delete,
-                     :ask, :role, :server, :primary, :validate
+                     :ask, :role, :server, :primary, :validate, :append
 
       def is_question?(key)
         env.is_question?(key)

--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -158,6 +158,23 @@ module Capistrano
           expect{ config.set(:key, 'sho') }.to raise_error(Capistrano::ValidationError)
         end
       end
+
+      context 'appending' do
+        subject { config.append(:linked_dirs, 'vendor/bundle') }
+
+        it "returns appended value" do
+          expect(subject).to eq ['vendor/bundle']
+        end
+
+        context "on non-array variable" do
+          before { config.set(:linked_dirs, "string") }
+          subject { config.append(:linked_dirs, 'vendor/bundle') }
+
+          it "returns appended value" do
+            expect(subject).to eq ['string', 'vendor/bundle']
+          end
+        end
+      end
     end
 
     describe 'keys' do


### PR DESCRIPTION
Before:
`set :linked_dirs, fetch(:linked_dirs, []) << 'vendor/bundle'`

After:
`append :linked_dirs, 'vendor/bundle'`

@leehambley @Kriechi 