### PR TITLE
Freeze load:defaults task after invoking it so further enhancements fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
   * Allow after() to refer to tasks that have not been loaded yet (@jcoglan)
   * Ensure scm fetch_revision methods strip trailing whitespace (@mattbrictson)
   * Allow use "all" as string for server filtering (@theist)
+  * Print a warning and abort if "load:defaults" is erroneously invoked after
+    capistrano is already loaded, e.g. when a plugin is loaded in `deploy.rb`
+    instead of `Capfile`. (@mattbrictson)
 
 ## `3.4.0`
 

--- a/lib/capistrano/immutable_task.rb
+++ b/lib/capistrano/immutable_task.rb
@@ -1,0 +1,29 @@
+module Capistrano
+  # This module extends a Rake::Task to freeze it to prevent it from being
+  # enhanced. This is used to prevent users from enhancing a task at the wrong
+  # point of Capistrano's boot process, which can happen if a Capistrano plugin
+  # is loaded in deploy.rb by mistake (instead of in the Capfile).
+  #
+  # Usage:
+  #
+  # task = Rake.application["load:defaults"]
+  # task.invoke
+  # task.extend(Capistrano::ImmutableTask) # prevent further modifications
+  #
+  module ImmutableTask
+    def self.extended(task)
+      task.freeze
+    end
+
+    def enhance(*args, &block)
+      $stderr.puts <<-MESSAGE
+WARNING: #{name} has already been invoked and can no longer be modified.
+Check that you haven't loaded a Capistrano plugin in deploy.rb by mistake.
+Plugins must be loaded in the Capfile to initialize properly.
+MESSAGE
+
+      # This will raise a frozen object error
+      super(*args, &block)
+    end
+  end
+end

--- a/lib/capistrano/setup.rb
+++ b/lib/capistrano/setup.rb
@@ -1,3 +1,4 @@
+require "capistrano/immutable_task"
 include Capistrano::DSL
 
 namespace :load do
@@ -11,6 +12,7 @@ stages.each do |stage|
     set(:stage, stage.to_sym)
 
     invoke 'load:defaults'
+    Rake.application["load:defaults"].extend(Capistrano::ImmutableTask)
     load deploy_config_path
     load stage_config_path.join("#{stage}.rb")
     load "capistrano/#{fetch(:scm)}.rb"

--- a/spec/lib/capistrano/immutable_task_spec.rb
+++ b/spec/lib/capistrano/immutable_task_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'rake'
+require 'capistrano/immutable_task'
+
+module Capistrano
+  describe ImmutableTask do
+    it 'prints warning and raises when task is enhanced' do
+      extend(Rake::DSL)
+
+      load_defaults = Rake::Task.define_task('load:defaults')
+      load_defaults.extend(Capistrano::ImmutableTask)
+
+      $stderr.expects(:puts).with do |message|
+        message =~ /^WARNING: load:defaults has already been invoked/
+      end
+
+      expect {
+        namespace :load do
+          task :defaults do
+            # Never reached since load_defaults is frozen and can't be enhanced
+          end
+        end
+      }.to raise_error(/frozen/i)
+    end
+  end
+end


### PR DESCRIPTION
This causes a warning to be printed if a capistrano plugin is loaded in `deploy.rb` instead of the proper `Capfile` location. Output in this scenario looks like this:

```
$ cap production deploy:check
WARNING: load:defaults has already been invoked and can no longer be modified. C
heck that you haven't loaded a Capistrano plugin in deploy.rb by mistake. Plugin
s must be loaded in the Capfile to initialize properly.
(Backtrace restricted to imported tasks)
cap aborted!
can't modify frozen #<Class:#<Rake::Task:0x007fc1ef472d28>>

Tasks: TOP => production
(See full trace by running task with --trace)
```

Addresses #1451.

@leehambley This PR is incomplete, because I still have to figure out how to write an appropriate test. In the meantime, does my approach look good to you so far?