### PR TITLE
fix 'filter' variable so it works as documented

### DIFF
--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -100,6 +100,8 @@ module Capistrano
       @filters << Filter.new(:role, ENV['ROLES']) if ENV['ROLES']
       @filters << Filter.new(:host, ENV['HOSTS']) if ENV['HOSTS']
       fh = fetch_for(:filter,{}) || {}
+      @filters << Filter.new(:host, fh[:hosts]) if fh[:hosts]
+      @filters << Filter.new(:role, fh[:roles]) if fh[:roles]
       @filters << Filter.new(:host, fh[:host]) if fh[:host]
       @filters << Filter.new(:role, fh[:role]) if fh[:role]
     end


### PR DESCRIPTION
The variable ':filter' is documented as requiring the keys 'hosts' and
'roles' to set Host and Role filters. In actual fact it uses 'host' and
'role'. This commit adds support and tests for both.

Fixes #1457