### PR TITLE
do not use `--abbrev-commit` in git revision

### DIFF
--- a/lib/capistrano/git.rb
+++ b/lib/capistrano/git.rb
@@ -40,7 +40,7 @@ class Capistrano::Git < Capistrano::SCM
     end
 
     def fetch_revision
-      context.capture(:git, "rev-list --max-count=1 --abbrev-commit #{fetch(:branch)}").strip
+      context.capture(:git, "rev-list --max-count=1 #{fetch(:branch)}").strip
     end
   end
 end

--- a/spec/lib/capistrano/git_spec.rb
+++ b/spec/lib/capistrano/git_spec.rb
@@ -81,9 +81,9 @@ module Capistrano
     describe "#fetch_revision" do
       it "should strip trailing whitespace" do
         context.expects(:fetch).with(:branch).returns(:branch)
-        context.expects(:capture).with(:git, "rev-list --max-count=1 --abbrev-commit branch").returns("01abcde\n")
+        context.expects(:capture).with(:git, "rev-list --max-count=1 branch").returns("abcdef1234567890abcdef1234567890abcdef12\n")
         revision = subject.fetch_revision
-        expect(revision).to eq("01abcde")
+        expect(revision).to eq("abcdef1234567890abcdef1234567890abcdef12")
       end
     end
   end


### PR DESCRIPTION
Github's API only works with full SHAs.
In general, the possibility of any tool/service
failing without a full SHA negates any benefit of
saving a few characters with `--abbrev-commit`.