### PR TITLE
Address all rubocop lint warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
     capistrano is already loaded, e.g. when a plugin is loaded in `deploy.rb`
     instead of `Capfile`. (@mattbrictson)
   * Return first 12 characters (instead of 7) of SHA1 hash when determining current git revision (@sds)
+  * Clean up rubocop lint warnings (@cshaffer)
 
 ## `3.4.0`
 

--- a/features/step_definitions/assertions.rb
+++ b/features/step_definitions/assertions.rb
@@ -50,26 +50,26 @@ end
 
 Then(/^the deploy\.rb file is created$/) do
   file = TestApp.test_app_path.join('config/deploy.rb')
-  expect(File.exists?(file)).to be true
+  expect(File.exist?(file)).to be true
 end
 
 Then(/^the default stage files are created$/) do
   staging = TestApp.test_app_path.join('config/deploy/staging.rb')
   production = TestApp.test_app_path.join('config/deploy/production.rb')
-  expect(File.exists?(staging)).to be true
-  expect(File.exists?(production)).to be true
+  expect(File.exist?(staging)).to be true
+  expect(File.exist?(production)).to be true
 end
 
 Then(/^the tasks folder is created$/) do
   path = TestApp.test_app_path.join('lib/capistrano/tasks')
-  expect(Dir.exists?(path)).to be true
+  expect(Dir.exist?(path)).to be true
 end
 
 Then(/^the specified stage files are created$/) do
   qa = TestApp.test_app_path.join('config/deploy/qa.rb')
   production = TestApp.test_app_path.join('config/deploy/production.rb')
-  expect(File.exists?(qa)).to be true
-  expect(File.exists?(production)).to be true
+  expect(File.exist?(qa)).to be true
+  expect(File.exist?(production)).to be true
 end
 
 Then(/^it creates the file with the remote_task prerequisite$/) do

--- a/features/support/remote_command_helpers.rb
+++ b/features/support/remote_command_helpers.rb
@@ -15,7 +15,7 @@ module RemoteCommandHelpers
     %{[ -#{type} "#{path}" ]}
   end
 
-  def safely_remove_file(path)
+  def safely_remove_file(_path)
     run_vagrant_command("rm #{test_file}") rescue VagrantHelpers::VagrantSSHCommandError
   end
 end

--- a/lib/capistrano/application.rb
+++ b/lib/capistrano/application.rb
@@ -63,7 +63,7 @@ module Capistrano
 
     def display_error_message(ex)
       unless options.backtrace
-        if loc = Rake.application.find_rakefile_location
+        if (loc = Rake.application.find_rakefile_location)
           whitelist = (@imported.dup << loc[0]).map{|f| File.absolute_path(f, loc[1])}
           pattern = %r@^(?!#{whitelist.map{|p| Regexp.quote(p)}.join('|')})@
           Rake.application.options.suppress_backtrace_pattern = pattern
@@ -101,7 +101,7 @@ module Capistrano
     def version
       ['--version', '-V',
        "Display the program version.",
-       lambda { |value|
+       lambda { |_value|
          puts "Capistrano Version: #{Capistrano::VERSION} (Rake Version: #{RAKEVERSION})"
          exit
        }
@@ -111,7 +111,7 @@ module Capistrano
     def dry_run
       ['--dry-run', '-n',
        "Do a dry run without executing actions",
-       lambda { |value|
+       lambda { |_value|
          Configuration.env.set(:sshkit_backend, SSHKit::Backend::Printer)
        }
       ]

--- a/lib/capistrano/configuration/question.rb
+++ b/lib/capistrano/configuration/question.rb
@@ -28,10 +28,10 @@ module Capistrano
 
       def response
         return @response if defined? @response
-        
+
         @response = (gets || "").chomp
       end
-      
+
       def gets
         if echo?
           $stdin.gets
@@ -40,8 +40,9 @@ module Capistrano
         end
       rescue Errno::EIO
         # when stdio gets closed
+        return
       end
-        
+
       def question
         I18n.t(:question, key: key, default_value: default, scope: :capistrano)
       end

--- a/lib/capistrano/configuration/server.rb
+++ b/lib/capistrano/configuration/server.rb
@@ -98,7 +98,7 @@ module Capistrano
           @properties[key]
         end
 
-        def respond_to?(method, include_all=false)
+        def respond_to?(method, _include_all=false)
           @properties.has_key?(method)
         end
 

--- a/lib/capistrano/configuration/servers.rb
+++ b/lib/capistrano/configuration/servers.rb
@@ -9,7 +9,7 @@ module Capistrano
 
       def add_host(host, properties={})
         new_host = Server[host]
-        if server = servers.find { |s| s.matches? new_host }
+        if (server = servers.find { |s| s.matches? new_host })
           server.user = new_host.user if new_host.user
           server.port = new_host.port if new_host.port
           server.with(properties)

--- a/lib/capistrano/defaults.rb
+++ b/lib/capistrano/defaults.rb
@@ -1,4 +1,4 @@
-validate :application do |key, value|
+validate :application do |_key, value|
   changed_value = value.gsub(/[^[[:alnum:]]]/, '_')
   if value != changed_value
     warn "Invalid value for :application detected! Try using this: "

--- a/lib/capistrano/git.rb
+++ b/lib/capistrano/git.rb
@@ -8,7 +8,7 @@ class Capistrano::Git < Capistrano::SCM
   #
   def git(*args)
     args.unshift :git
-    context.execute *args
+    context.execute(*args)
   end
 
   # The Capistrano default strategy for git. You should want to use this.
@@ -22,7 +22,7 @@ class Capistrano::Git < Capistrano::SCM
     end
 
     def clone
-      if depth = fetch(:git_shallow_clone)
+      if (depth = fetch(:git_shallow_clone))
         git :clone, '--mirror', '--depth', depth, '--no-single-branch', repo_url, repo_path
       else
         git :clone, '--mirror', repo_url, repo_path
@@ -31,7 +31,7 @@ class Capistrano::Git < Capistrano::SCM
 
     def update
       # Note: Requires git version 1.9 or greater
-      if depth = fetch(:git_shallow_clone)
+      if (depth = fetch(:git_shallow_clone))
         git :fetch, '--depth', depth, 'origin', fetch(:branch)
       else
         git :remote, :update
@@ -39,7 +39,7 @@ class Capistrano::Git < Capistrano::SCM
     end
 
     def release
-      if tree = fetch(:repo_tree)
+      if (tree = fetch(:repo_tree))
         tree = tree.slice %r#^/?(.*?)/?$#, 1
         components = tree.split('/').size
         git :archive, fetch(:branch), tree, "| tar -x --strip-components #{components} -f - -C", release_path

--- a/lib/capistrano/hg.rb
+++ b/lib/capistrano/hg.rb
@@ -6,7 +6,7 @@ class Capistrano::Hg < Capistrano::SCM
   # execute hg in context with arguments
   def hg(*args)
     args.unshift(:hg)
-    context.execute *args
+    context.execute(*args)
   end
 
   module DefaultStrategy
@@ -27,7 +27,7 @@ class Capistrano::Hg < Capistrano::SCM
     end
 
     def release
-      if tree = fetch(:repo_tree)
+      if (tree = fetch(:repo_tree))
         tree = tree.slice %r#^/?(.*?)/?$#, 1
         components = tree.split('/').size
         hg "archive --type tgz -p . -I", tree, "--rev", fetch(:branch), "| tar -x --strip-components #{components} -f - -C", release_path

--- a/lib/capistrano/scm.rb
+++ b/lib/capistrano/scm.rb
@@ -25,7 +25,7 @@ module Capistrano
 
     # Call test in context
     def test!(*args)
-      context.test *args
+      context.test(*args)
     end
 
     # The repository URL according to the context

--- a/lib/capistrano/svn.rb
+++ b/lib/capistrano/svn.rb
@@ -3,13 +3,13 @@ load File.expand_path("../tasks/svn.rake", __FILE__)
 require 'capistrano/scm'
 
 class Capistrano::Svn < Capistrano::SCM
-  
+
   # execute svn in context with arguments
   def svn(*args)
     args.unshift(:svn)
     args.push "--username #{fetch(:svn_username)}" if fetch(:svn_username)
     args.push "--password #{fetch(:svn_password)}" if fetch(:svn_password)
-    context.execute *args
+    context.execute(*args)
   end
 
   module DefaultStrategy

--- a/lib/capistrano/tasks/console.rake
+++ b/lib/capistrano/tasks/console.rake
@@ -5,7 +5,7 @@ task :console do
   loop do
     print "#{stage}> "
 
-    if input = $stdin.gets
+    if (input = $stdin.gets)
       command = input.chomp
     else
       command = 'exit'

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -59,7 +59,7 @@ namespace :deploy do
     desc 'Check directories of files to be linked exist in shared'
     task :make_linked_dirs do
       next unless any? :linked_files
-      on release_roles :all do |host|
+      on release_roles :all do |_host|
         execute :mkdir, '-p', linked_file_dirs(shared_path)
       end
     end

--- a/lib/capistrano/tasks/install.rake
+++ b/lib/capistrano/tasks/install.rake
@@ -18,7 +18,7 @@ task :install do
   entries += envs.split(',').map { |stage| {template: stage_rb, file: deploy_dir.join("#{stage}.rb")} }
 
   entries.each do |entry|
-    if File.exists?(entry[:file])
+    if File.exist?(entry[:file])
       warn "[skip] #{entry[:file]} already exists"
     else
       File.open(entry[:file], 'w+') do |f|
@@ -30,7 +30,7 @@ task :install do
 
   mkdir_p tasks_dir
 
-  if File.exists?('Capfile')
+  if File.exist?('Capfile')
     warn "[skip] Capfile already exists"
   else
     FileUtils.cp(capfile, 'Capfile')

--- a/spec/lib/capistrano/application_spec.rb
+++ b/spec/lib/capistrano/application_spec.rb
@@ -7,7 +7,7 @@ describe Capistrano::Application do
   it "provides a --format option which enables the choice of output formatting"
 
   let(:help_output) do
-    out, _ = capture_io do
+    out, _err = capture_io do
       flags '--help', '-h'
     end
     out
@@ -24,7 +24,7 @@ describe Capistrano::Application do
   end
 
   it "overrides the rake method, but still prints the rake version" do
-    out, _ = capture_io do
+    out, _err = capture_io do
       flags '--version', '-V'
     end
     expect(out).to match(/\bCapistrano Version\b/)
@@ -34,7 +34,7 @@ describe Capistrano::Application do
   end
 
   it "overrides the rake method, and sets the sshkit_backend to SSHKit::Backend::Printer" do
-    out, _ = capture_io do
+    capture_io do
       flags '--dry-run', '-n'
     end
     sshkit_backend = Capistrano::Configuration.fetch(:sshkit_backend)
@@ -51,7 +51,7 @@ describe Capistrano::Application do
 
   def command_line(*options)
     options.each { |opt| ARGV << opt }
-    def subject.exit(*args)
+    def subject.exit(*_args)
       throw(:system_exit, :exit)
     end
     subject.run

--- a/spec/lib/capistrano/configuration/filter_spec.rb
+++ b/spec/lib/capistrano/configuration/filter_spec.rb
@@ -13,7 +13,7 @@ module Capistrano
       describe '#new' do
         it "won't create an invalid type of filter" do
           expect {
-            f = Filter.new(:zarg)
+            Filter.new(:zarg)
           }.to raise_error RuntimeError
         end
 

--- a/spec/lib/capistrano/dsl/task_enhancements_spec.rb
+++ b/spec/lib/capistrano/dsl/task_enhancements_spec.rb
@@ -19,7 +19,7 @@ module Capistrano
 
       let(:order) { [] }
       let!(:task) do
-        Rake::Task.define_task('task', [:order]) do |t, args|
+        Rake::Task.define_task('task', [:order]) do |_t, args|
           args['order'].push 'task'
         end
       end
@@ -67,11 +67,11 @@ module Capistrano
       end
 
       it 'invokes in proper order and with arguments and block' do
-        task_enhancements.after('task', 'after_task_custom', :order) do |t, args|
+        task_enhancements.after('task', 'after_task_custom', :order) do |_t, _args|
           order.push 'after_task'
         end
 
-        task_enhancements.before('task', 'before_task_custom', :order) do |t, args|
+        task_enhancements.before('task', 'before_task_custom', :order) do |_t, _args|
           order.push 'before_task'
         end
 

--- a/spec/support/Vagrantfile
+++ b/spec/support/Vagrantfile
@@ -5,15 +5,15 @@ Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
 
   [:app].each_with_index do |role, i|
-    config.vm.define(role, primary: true) do |config|
-      config.vm.define role
-      config.vm.box = 'hashicorp/precise64'
-      config.vm.network "forwarded_port", guest: 22, host: "222#{i}".to_i
-      config.vm.provision :shell, inline: 'sudo apt-get -y install git-core'
+    config.vm.define(role, primary: true) do |primary|
+      primary.vm.define role
+      primary.vm.box = 'hashicorp/precise64'
+      primary.vm.network "forwarded_port", guest: 22, host: "222#{i}".to_i
+      primary.vm.provision :shell, inline: 'sudo apt-get -y install git-core'
 
       vagrantkey = open("https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub", "r",&:read)
 
-      config.vm.provision :shell,
+      primary.vm.provision :shell,
         inline: <<-INLINE
           install -d -m 700 /root/.ssh
           echo -e "#{vagrantkey}" > /root/.ssh/authorized_keys

--- a/spec/support/tasks/root.rake
+++ b/spec/support/tasks/root.rake
@@ -4,7 +4,7 @@ task :am_i_root do
     ident = capture :id, '-a'
     info "I am #{ident}"
   end
-  on roles(:all) do |host|
+  on roles(:all) do |_host|
     ident = capture :id, '-a'
     info "I am #{ident}"
   end


### PR DESCRIPTION
* (File, Dir).exists? -> (File, Dir).exist?
* Prepend unused parameter names with an underscore
* Prefer “safe assignment in condition”
* Disambiguate splat operators with parens
* Remove unnecessary assignments (unused variables)
* No longer shadow Vagrant config variable name in Vagrantfile
* Removed some trailing whitespace

Fixes #1404