### PR TITLE
Issue 1196: Let Configuration#set take a block.

### DIFF
--- a/lib/capistrano/dsl/env.rb
+++ b/lib/capistrano/dsl/env.rb
@@ -19,12 +19,12 @@ module Capistrano
         end
       end
 
-      def set(key, value)
-        env.set(key, value)
+      def set(key, value=nil, &block)
+        env.set(key, value, &block)
       end
 
-      def set_if_empty(key, value)
-        env.set_if_empty(key, value)
+      def set_if_empty(key, value=nil, &block)
+        env.set_if_empty(key, value, &block)
       end
 
       def delete(key)

--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -45,25 +45,37 @@ module Capistrano
     describe 'setting and fetching' do
       subject { config.fetch(:key, :default) }
 
-      context 'value is set' do
-        before do
+      context 'set' do
+        it 'sets by value' do
           config.set(:key, :value)
+          expect(subject).to eq :value
         end
 
-        it 'returns the set value' do
+        it 'sets by block' do
+          config.set(:key) { :value }
           expect(subject).to eq :value
+        end
+
+        it 'raises an exception when given both a value and block' do
+          expect{ config.set(:key, :value) { :value } }.to raise_error(Capistrano::ValidationError)
         end
       end
 
       context 'set_if_empty' do
-        it 'sets the value when none is present' do
+        it 'sets by value when none is present' do
           config.set_if_empty(:key, :value)
           expect(subject).to eq :value
         end
 
-        it 'does not overwrite the value' do
+        it 'sets by block when none is present' do
+          config.set_if_empty(:key) { :value }
+          expect(subject).to eq :value
+        end
+
+        it 'does not overwrite existing values' do
           config.set(:key, :value)
           config.set_if_empty(:key, :update)
+          config.set_if_empty(:key) { :update }
           expect(subject).to eq :value
         end
       end


### PR DESCRIPTION
My proposed fix for https://github.com/capistrano/capistrano/issues/1196

Allows the behavior of the set functions to match Ruby conventions, but shouldn't interfere with any apps that are using the current method of passing in blocks for delayed execution.