### PR TITLE
Refactor Filter to use strategies instead of case statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
 * Added support for git shallow clone
 * Remove 'vendor/bundle' from default :linked_dirs (@ojab)
 * Removed the post-install message (@Kriechi)
+* Refactor `Configuration::Filter` to use filtering strategies instead
+  of case statements (@cshaffer)
 
 * Minor changes
   * Fix filtering behaviour when using literal hostnames in on() block (@townsen)

--- a/lib/capistrano/configuration/empty_filter.rb
+++ b/lib/capistrano/configuration/empty_filter.rb
@@ -1,0 +1,9 @@
+module Capistrano
+  class Configuration
+    class EmptyFilter
+      def filter _servers
+        []
+      end
+    end
+  end
+end

--- a/lib/capistrano/configuration/filter.rb
+++ b/lib/capistrano/configuration/filter.rb
@@ -1,56 +1,26 @@
 require 'capistrano/configuration'
+require 'capistrano/configuration/empty_filter'
+require 'capistrano/configuration/host_filter'
+require 'capistrano/configuration/null_filter'
+require 'capistrano/configuration/role_filter'
 
 module Capistrano
   class Configuration
     class Filter
       def initialize type, values = nil
-        raise "Invalid filter type #{type}" unless [:host,:role].include? type
-        av = Array(values).dup
-        @mode = case
-                when av.size == 0 then :none
-                when av.include?(:all) then :all
-                when av.include?('all') then :all
-                else type
-                end
-        @rex = case @mode
-          when :host
-            av.map!{|v| (v.is_a?(String) && v =~ /^(?<name>[-A-Za-z0-9.]+)(,\g<name>)*$/) ? v.split(',') : v }
-            av.flatten!
-            av.map! do |v|
-              case v
-              when Regexp then v
-              else
-                vs = v.to_s
-                vs =~ /^[-A-Za-z0-9.]+$/ ? vs : Regexp.new(vs)
-              end
-            end
-            Regexp.union av
-          when :role
-            av.map!{|v| v.is_a?(String) ? v.split(',') : v }
-            av.flatten!
-            av.map! do |v|
-              case v
-              when Regexp then v
-              else
-                vs = v.to_s
-                vs =~ %r{^/(.+)/$} ? Regexp.new($1) : %r{^#{vs}$}
-              end
-            end
-            Regexp.union av
-          else
-            nil
-          end
+        raise "Invalid filter type #{type}" unless [:host, :role].include? type
+        av = Array(values)
+        @strategy = case
+                    when av.size == 0 then EmptyFilter.new
+                    when av.include?(:all), av.include?('all') then NullFilter.new
+                    when type == :host then HostFilter.new(values)
+                    when type == :role then RoleFilter.new(values)
+                    else NullFilter.new
+                    end
       end
+
       def filter servers
-        as = Array(servers)
-        case @mode
-        when :none then return []
-        when :all  then return servers
-        when :host
-          as.select {|s| @rex.match s.to_s}
-        when :role
-          as.select { |s| s.is_a?(String) ? false : s.roles.any? {|r| @rex.match r} }
-        end
+        @strategy.filter servers
       end
     end
   end

--- a/lib/capistrano/configuration/host_filter.rb
+++ b/lib/capistrano/configuration/host_filter.rb
@@ -1,0 +1,20 @@
+require 'capistrano/configuration/regex_filter'
+
+module Capistrano
+  class Configuration
+    class HostFilter
+      include RegexFilter
+
+      def initialize values
+        av = Array(values).dup
+        av.map! { |v| (v.is_a?(String) && v =~ /^(?<name>[-A-Za-z0-9.]+)(,\g<name>)*$/) ? v.split(',') : v }
+        av.flatten!
+        @rex = regex_matcher(av)
+      end
+
+      def filter servers
+        Array(servers).select { |s| @rex.match s.to_s }
+      end
+    end
+  end
+end

--- a/lib/capistrano/configuration/null_filter.rb
+++ b/lib/capistrano/configuration/null_filter.rb
@@ -1,0 +1,9 @@
+module Capistrano
+  class Configuration
+    class NullFilter
+      def filter servers
+        servers
+      end
+    end
+  end
+end

--- a/lib/capistrano/configuration/regex_filter.rb
+++ b/lib/capistrano/configuration/regex_filter.rb
@@ -1,0 +1,17 @@
+module Capistrano
+  class Configuration
+    module RegexFilter
+      def regex_matcher values
+        av = values.map do |v|
+          case v
+          when Regexp then v
+          else
+            vs = v.to_s
+            vs =~ %r{^/(.+)/$} ? Regexp.new($1) : %r{^#{vs}$}
+          end
+        end
+        Regexp.union av
+      end
+    end
+  end
+end

--- a/lib/capistrano/configuration/role_filter.rb
+++ b/lib/capistrano/configuration/role_filter.rb
@@ -1,0 +1,20 @@
+require 'capistrano/configuration/regex_filter'
+
+module Capistrano
+  class Configuration
+    class RoleFilter
+      include RegexFilter
+
+      def initialize values
+        av = Array(values).dup
+        av.map! { |v| v.is_a?(String) ? v.split(',') : v }
+        av.flatten!
+        @rex = regex_matcher(av)
+      end
+
+      def filter servers
+        Array(servers).select { |s| s.is_a?(String) ? false : s.roles.any? { |r| @rex.match r } }
+      end
+    end
+  end
+end

--- a/spec/lib/capistrano/configuration/empty_filter_spec.rb
+++ b/spec/lib/capistrano/configuration/empty_filter_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+module Capistrano
+  class Configuration
+    describe EmptyFilter do
+      subject(:empty_filter) { EmptyFilter.new }
+
+      describe '#filter' do
+        let(:servers) { mock('servers') }
+
+        it 'returns an empty array' do
+          expect(empty_filter.filter(servers)).to eq([])
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/capistrano/configuration/host_filter_spec.rb
+++ b/spec/lib/capistrano/configuration/host_filter_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+module Capistrano
+  class Configuration
+    describe HostFilter do
+      subject(:host_filter) { HostFilter.new(values) }
+
+      let(:available) { [ Server.new('server1'),
+                          Server.new('server2'),
+                          Server.new('server3'),
+                          Server.new('server4'),
+                          Server.new('server5') ] }
+
+      shared_examples 'it filters hosts correctly' do |expected|
+        it 'filters correctly' do
+          set = host_filter.filter(available)
+          expect(set.map(&:hostname)).to eq(expected)
+        end
+      end
+
+      describe '#filter' do
+        context 'with a string' do
+          let(:values) { 'server1' }
+          it_behaves_like 'it filters hosts correctly', %w{server1}
+
+          context 'and a single server' do
+            let(:available) { Server.new('server1') }
+            it_behaves_like 'it filters hosts correctly', %w{server1}
+          end
+        end
+
+        context 'with a comma separated string' do
+          let(:values) { 'server1,server3' }
+          it_behaves_like 'it filters hosts correctly', %w{server1 server3}
+        end
+
+        context 'with an array of strings' do
+          let(:values) { %w{server1 server3} }
+          it_behaves_like 'it filters hosts correctly', %w{server1 server3}
+        end
+
+        context 'with a regexp' do
+          let(:values) { 'server[13]$' }
+          it_behaves_like 'it filters hosts correctly', %w{server1 server3}
+        end
+
+        context 'with a regexp with a comma' do
+          let(:values) { 'server\d{1,3}$' }
+          it_behaves_like 'it filters hosts correctly', %w{server1 server2 server3 server4 server5}
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/capistrano/configuration/null_filter_spec.rb
+++ b/spec/lib/capistrano/configuration/null_filter_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+module Capistrano
+  class Configuration
+    describe NullFilter do
+      subject(:null_filter) { NullFilter.new }
+
+      describe '#filter' do
+        let(:servers) { mock('servers') }
+
+        it 'returns the servers passed in as arguments' do
+          expect(null_filter.filter(servers)).to eq(servers)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/capistrano/configuration/role_filter_spec.rb
+++ b/spec/lib/capistrano/configuration/role_filter_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+module Capistrano
+  class Configuration
+    describe RoleFilter do
+      subject(:role_filter) { RoleFilter.new(values) }
+
+      let(:available) { [ Server.new('server1').add_roles([:web,:db]),
+                          Server.new('server2').add_role(:web),
+                          Server.new('server3').add_role(:redis),
+                          Server.new('server4').add_role(:db),
+                          Server.new('server5').add_role(:stageweb) ] }
+
+      shared_examples 'it filters roles correctly' do |expected_size, expected|
+        it 'filters correctly' do
+          set = role_filter.filter(available)
+          expect(set.size).to eq(expected_size)
+          expect(set.map(&:hostname)).to eq(expected)
+        end
+      end
+
+      describe '#filter' do
+        context 'with a single role string' do
+          let(:values) { 'web' }
+          it_behaves_like 'it filters roles correctly', 2, %w{server1 server2}
+        end
+
+        context 'with a single role' do
+          let(:values) { [:web] }
+          it_behaves_like 'it filters roles correctly', 2, %w{server1 server2}
+        end
+
+        context 'with multiple roles in a string' do
+          let(:values) { 'web,db' }
+          it_behaves_like 'it filters roles correctly', 3, %w{server1 server2 server4}
+        end
+
+        context 'with multiple roles' do
+          let(:values) { [:web, :db] }
+          it_behaves_like 'it filters roles correctly', 3, %w{server1 server2 server4}
+        end
+
+        context 'with a regex' do
+          let(:values) { /red/ }
+          it_behaves_like 'it filters roles correctly', 1, %w{server3}
+        end
+
+        context 'with a regex string' do
+          let(:values) { '/red|web/' }
+          it_behaves_like 'it filters roles correctly', 4, %w{server1 server2 server3 server5}
+        end
+
+        context 'with both a string and regex' do
+          let(:values) { 'db,/red/' }
+          it_behaves_like 'it filters roles correctly', 3, %w{server1 server3 server4}
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Reduces complexity of Filter#initialize and Filter#filter
* Consolidate regex matching to a single mixin for host and role
filtering