### PR TITLE
fix match server: different ports

### DIFF
--- a/lib/capistrano/configuration/server.rb
+++ b/lib/capistrano/configuration/server.rb
@@ -62,7 +62,7 @@ module Capistrano
       end
 
       def matches?(other)
-        hostname == other.hostname
+        hostname == other.hostname && port == other.port
       end
 
       private

--- a/lib/capistrano/configuration/servers.rb
+++ b/lib/capistrano/configuration/servers.rb
@@ -11,7 +11,6 @@ module Capistrano
         new_host = Server[host]
         if (server = servers.find { |s| s.matches? new_host })
           server.user = new_host.user if new_host.user
-          server.port = new_host.port if new_host.port
           server.with(properties)
         else
           servers << new_host.with(properties)

--- a/spec/integration/dsl_spec.rb
+++ b/spec/integration/dsl_spec.rb
@@ -273,22 +273,24 @@ describe Capistrano::DSL do
       end
 
       describe 'fetching all servers' do
-        it 'creates one server per hostname, ignoring user and port combinations' do
-          expect(dsl.roles(:all).size).to eq(1)
+        it 'creates one server per hostname, ignoring user combinations' do
+          expect(dsl.roles(:all).size).to eq(2)
         end
       end
 
       describe 'fetching servers for a role' do
         it 'roles defined using the `server` syntax are included' do
           as = dsl.roles(:web).map { |server| "#{server.user}@#{server.hostname}:#{server.port}" }
-          expect(as.size).to eq(1)
-          expect(as[0]).to eq("deployer@example1.com:5678")
+          expect(as.size).to eq(2)
+          expect(as[0]).to eq("deployer@example1.com:1234")
+          expect(as[1]).to eq("@example1.com:5678")
         end
 
         it 'roles defined using the `role` syntax are included' do
           as = dsl.roles(:app).map { |server| "#{server.user}@#{server.hostname}:#{server.port}" }
-          expect(as.size).to eq(1)
-          expect(as[0]).to eq("deployer@example1.com:5678")
+          expect(as.size).to eq(2)
+          expect(as[0]).to eq("deployer@example1.com:1234")
+          expect(as[1]).to eq("@example1.com:5678")
         end
       end
 

--- a/spec/lib/capistrano/configuration/servers_spec.rb
+++ b/spec/lib/capistrano/configuration/servers_spec.rb
@@ -140,7 +140,7 @@ module Capistrano
           servers.add_host('1', roles: [:app, 'web'], test: :value, user: 'root', port: 34)
           servers.add_host('1', roles: [:app, 'web'], test: :value, user: 'deployer', port: 34)
           servers.add_host('1', roles: [:app, 'web'], test: :value, user: 'deployer', port: 56)
-          expect(servers.count).to eq(1)
+          expect(servers.count).to eq(5)
         end
 
         describe "with a :user property" do


### PR DESCRIPTION
Same hostname might be used as a gateway to different servers.

```ruby
set :user, `whoami`.strip
# first server
server "192.168.1.100:1234", roles: %i{web}
# second server, same hostname
server "192.168.1.100:1235", roles: %i{redis}, user: "redisuser"
```
In this case, we have 1st server with user "redisuser", unless we explicitly define :user for server 1