### PR TITLE
Fixes #1221: Remove static path definition for git ssh wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
     instead of `Capfile`. (@mattbrictson)
   * Return first 12 characters (instead of 7) of SHA1 hash when determining current git revision (@sds)
   * Clean up rubocop lint warnings (@cshaffer)
+  * Remove the static path to ssh in the git ssh wrapper to allow for greater
+    platform flexibility
 
 ## `3.4.0`
 

--- a/lib/capistrano/tasks/git.rake
+++ b/lib/capistrano/tasks/git.rake
@@ -15,7 +15,7 @@ namespace :git do
   task :wrapper do
     on release_roles :all do
       execute :mkdir, "-p", "#{fetch(:tmp_dir)}/#{fetch(:application)}/"
-      upload! StringIO.new("#!/bin/sh -e\nexec /usr/bin/ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no \"$@\"\n"), "#{fetch(:tmp_dir)}/#{fetch(:application)}/git-ssh.sh"
+      upload! StringIO.new("#!/bin/sh -e\nexec /usr/bin/env ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no \"$@\"\n"), "#{fetch(:tmp_dir)}/#{fetch(:application)}/git-ssh.sh"
       execute :chmod, "+x", "#{fetch(:tmp_dir)}/#{fetch(:application)}/git-ssh.sh"
     end
   end


### PR DESCRIPTION
Used bare 'ssh' rather than '$(which ssh)' because /bin/sh could be something other than bash (e.g. csh or bourne sh) on platforms such as Solaris.

Since $(which ssh) (or `which ssh`) is simply using the path, it serves no specific purpose in the code.
