### PR TITLE
Ignores Capistrano config files by default when deploying

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+Capfile           export-ignore
+config/deploy.rb  export-ignore
+config/deploy/    export-ignore
+lib/capistrano/   export-ignore
+.gitattributes    export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
     instead of `Capfile`. (@mattbrictson)
   * Return first 12 characters (instead of 7) of SHA1 hash when determining current git revision (@sds)
   * Clean up rubocop lint warnings (@cshaffer)
+  * Added default .gitattributes to ignore Capistrano files when deploying (@cickes)  
 
 ## `3.4.0`
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,11 @@ in the order of registration.
 
 Validations can be used to ensure certain properties of user-supplied values,
 e.g. from `ask` or `ENV`. ``
-
+  
+## Ignore Files when Deploying  
+Edit `.gitattributes` with file or directory names,   
+e.g. `Capfile export-ignore`  
+  
 ## Testing
 
 Capistrano has two test suites: an RSpec suite and a Cucumber suite. The


### PR DESCRIPTION
Capistrano config & task files were ending up on production servers,
which was less than ideal.

Base Capistrano files are now automatically ignored when deploying
via .gitattributes.