### PR TITLE
Ensures that the git-ssh script is readable. Fixes #1500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
   * Ensure task invocation within after hooks is namespace aware (@thickpaddy)
   * Deduplicate list of linked directories
   * Allow dot in :application name (@marcovtwout)
+  * Fixed git-ssh permission error (@spight)
 
 ## `3.4.0`
 

--- a/lib/capistrano/tasks/git.rake
+++ b/lib/capistrano/tasks/git.rake
@@ -16,7 +16,7 @@ namespace :git do
     on release_roles :all do
       execute :mkdir, "-p", "#{fetch(:tmp_dir)}/#{fetch(:application)}/"
       upload! StringIO.new("#!/bin/sh -e\nexec /usr/bin/ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no \"$@\"\n"), "#{fetch(:tmp_dir)}/#{fetch(:application)}/git-ssh.sh"
-      execute :chmod, "+x", "#{fetch(:tmp_dir)}/#{fetch(:application)}/git-ssh.sh"
+      execute :chmod, "+rx", "#{fetch(:tmp_dir)}/#{fetch(:application)}/git-ssh.sh"
     end
   end
 


### PR DESCRIPTION
git-ssh requires both read and write permissions, and no checks exist before this point to ensure that the given ssh user has read access on this file, so let's do it here.

I looked for other instances that could be related to this issue, but a recursive grep for ":chmod" revealed only this single instance.