### PR TITLE
fix rescue for asset_manifest_prefix

### DIFF
--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -7,7 +7,7 @@ _cset :assets_prefix, "assets"
 _cset :shared_assets_prefix, "assets"
 _cset :assets_role, [:web]
 _cset :expire_assets_after, (3600 * 24 * 7)
-_cset :asset_manifest_prefix, (`sprockets -v`.chomp < "3.0" ? "manifest" : ".sprockets-manifest") rescue "manifest"
+_cset(:asset_manifest_prefix) { (`sprockets -v`.chomp < "3.0" ? "manifest" : ".sprockets-manifest") rescue "manifest" }
 
 _cset :normalize_asset_timestamps, false
 


### PR DESCRIPTION
The code in 2.15.6 doesn't assign :asset_manifest_prefix if an exception is thrown, since
the rescue applies to the whole line not to the value being assigned.

Move the value into a block so that the rescue is processed as intended.