### PR TITLE
Require SSHKit >= 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
 * Removed the post-install message (@Kriechi)
 * Refactor `Configuration::Filter` to use filtering strategies instead
   of case statements (@cshaffer)
+* Old versions of SSHKit (before 1.7.1) are no longer supported
 
 * Minor changes
   * Fix filtering behaviour when using literal hostnames in on() block (@townsen)

--- a/capistrano.gemspec
+++ b/capistrano.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.licenses      = ['MIT']
 
   gem.required_ruby_version = '>= 1.9.3'
-  gem.add_dependency 'sshkit', '~> 1.3'
+  gem.add_dependency 'sshkit', '>= 1.7.1'
   gem.add_dependency 'rake', '>= 10.0.0'
   gem.add_dependency 'i18n'
 


### PR DESCRIPTION
To make Airbrussh the default formatter in the next version of Capistrano (fingers crossed), we will need the latest version of SSHKit (currently 1.7.1). This is because Airbrussh itself depends on recent changes to SSHKit internals.

Is this reasonable? Capistrano has long had a very relaxed requirement for SSHKit, so this is definitely a change in policy.

/cc @leehambley @robd 