### PR TITLE
Isolate Gemfile used for Ruby 1.9 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ language: ruby
 rvm:
   - 2.1.0
   - 2.0.0
-  - 1.9.3
   - rbx-2
+matrix:
+  include:
+    - rvm: 1.9.3
+      gemfile: ruby19.gemfile
 script: bundle exec rake spec
 install: bundle install --jobs=1
 cache: bundler

--- a/ruby19.gemfile
+++ b/ruby19.gemfile
@@ -1,0 +1,14 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in capistrano.gemspec
+gemspec
+
+# Version 3 of net-ssh requires Ruby 2, and Bundler is not yet smart enough
+# to resolve to a lower version of net-ssh when running Ruby 1.9. So we have
+# to give Bundler a hint.
+gem 'net-ssh', '~> 2.8'
+
+group :cucumber do
+  gem 'cucumber'
+  gem 'rspec', '~> 3.0.0'
+end


### PR DESCRIPTION
Bundler sometimes resolves net-ssh 3.x when Travis builds against 1.9.3, and fails because these versions are incompatible. Work around this by explicitly specifying net-ssh ~> 2.8 when building against 1.9.3.