### PR TITLE
Relax :application validator to allow hyphens

### DIFF
--- a/lib/capistrano/defaults.rb
+++ b/lib/capistrano/defaults.rb
@@ -1,7 +1,8 @@
 validate :application do |_key, value|
-  changed_value = value.gsub(/[^[[:alnum:]]]/, '_')
+  changed_value = value.gsub(/[^A-Z0-9\-]/i, '_')
   if value != changed_value
-    warn "Invalid value for :application detected! Try using this: "
+    warn %(The :application value "#{value}" is invalid!)
+    warn "Use only letters, numbers, hyphens, and underscores. For example:"
     warn "  set :application, '#{changed_value}'"
     raise Capistrano::ValidationError
   end


### PR DESCRIPTION
Also improve the error message to explain what characters are allowed, and include the offending value.

Addresses #1512.

Note: I could not find any existing test for the `:application` validator, and I wasn't sure how to add it. However since this is a small regex and string change, perhaps it can be merged as-is.