### PR TITLE
Add `validate` to the DSL so that `cap` works!

### DIFF
--- a/lib/capistrano/dsl/env.rb
+++ b/lib/capistrano/dsl/env.rb
@@ -64,6 +64,10 @@ module Capistrano
         env.primary(role)
       end
 
+      def validate(key, &validator)
+        env.validate(key, &validator)
+      end
+
       def env
         Configuration.env
       end


### PR DESCRIPTION
`validate` is defined as `Configuration#validate`, but that is never mixed into the DSL. To make the `validate` method visible within the runtime environment (i.e. the `main` object), we have to explicitly add it to `Capistrano::DSL`.

Fixes #1511.