### PR TITLE
Remove Ruby 1.9.3 from Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 rvm:
   - 2.1.0
   - 2.0.0
-  - 1.9.3
   - rbx-2
 script: bundle exec rake spec
 install: bundle install --jobs=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
 * Refactor `Configuration::Filter` to use filtering strategies instead
   of case statements (@cshaffer)
 * Old versions of SSHKit (before 1.7.1) are no longer supported
+* Drop support for Ruby 1.9.3 (Capistrano may still work with 1.9.3, but it is
+  no longer officially supported)
 
 * Minor changes
   * Fix filtering behaviour when using literal hostnames in on() block (@townsen)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Get <a href="http://codersclan.net/?repo_id=325&source=link">Capistrano support 
 
 ## Requirements
 
-* Ruby >= 1.9.3 (JRuby and C-Ruby/YARV are supported)
+* Ruby >= 2.0.0 (JRuby and C-Ruby/YARV are supported)
 
 Capistrano support these source code version control systems out of the box:
 


### PR DESCRIPTION
As discussed in #1508, we have decided to drop support for Ruby 1.9.3. This will fix intermittent Travis failures due to Bundler not being smart enough to resolve a 1.9.3-compatible version of net-ssh.

SSHKit has already dropped 1.9.3 support as well: https://github.com/capistrano/sshkit/commit/847a14b0fa5c635d95929db4f03c5522e5733726