### PR TITLE
Fix post task lookup in TaskEnhancements#after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
     instead of `Capfile`. (@mattbrictson)
   * Return first 12 characters (instead of 7) of SHA1 hash when determining current git revision (@sds)
   * Clean up rubocop lint warnings (@cshaffer)
+  * Ensure task invocation within after hooks is namespace aware (@thickpaddy)
 
 ## `3.4.0`
 

--- a/lib/capistrano/dsl/task_enhancements.rb
+++ b/lib/capistrano/dsl/task_enhancements.rb
@@ -9,8 +9,9 @@ module Capistrano
 
     def after(task, post_task, *args, &block)
       Rake::Task.define_task(post_task, *args, &block) if block_given?
-      Rake::Task[task].enhance do
-        Rake::Task[post_task].invoke
+      task = Rake::Task[task]
+      task.enhance do
+        Rake.application.lookup(post_task, task.scope).invoke
       end
     end
 

--- a/spec/lib/capistrano/dsl/task_enhancements_spec.rb
+++ b/spec/lib/capistrano/dsl/task_enhancements_spec.rb
@@ -80,6 +80,26 @@ module Capistrano
         expect(order).to eq(['before_task', 'task', 'after_task'])
       end
 
+      it "invokes using the correct namespace when defined within a namespace" do
+        Rake.application.in_namespace('namespace') {
+          Rake::Task.define_task('task') do |t|
+            order.push(t.name)
+          end
+          task_enhancements.before('task', 'before_task', :order) do |t|
+            order.push(t.name)
+          end
+          task_enhancements.after('task', 'after_task', :order) do |t|
+            order.push(t.name)
+          end
+        }
+
+        Rake::Task['namespace:task'].invoke
+
+        expect(order).to eq(
+          ['namespace:before_task', 'namespace:task', 'namespace:after_task']
+        )
+      end
+
     end
 
     describe 'remote_file' do


### PR DESCRIPTION
Since the change to lazily bind the post task in TaskEnhancements#after,
invocation of the post task is no longer done within the context of the
namespace within which after hooks are defined. This results in runtime
errors when after hooks are defined within a namespace and the post task
name provided as an argument does not include the full namespace.

For example, with the following code, tasks :bar and :baz will be
created within the foo namespace, but invoking foo:bar will cause
RuntimeError, "Don't know how to build task 'baz'" (note: no namespace)

    namespace :foo do
      task :bar do
        ...
      end
      after :bar, :baz do
        ...
      end
    end

Fixed by providing the scope of the after when looking up the post task.