### PR TITLE
Make git wrapper work better with multi-user deployment systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Reverse Chronological Order:
 
 https://github.com/capistrano/capistrano/compare/v3.5.0...HEAD
 
+  * Make path to git wrapper script configurable (@thickpaddy)
+
 ## `3.5.0`
 
 https://github.com/capistrano/capistrano/compare/v3.4.1...v3.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Reverse Chronological Order:
 https://github.com/capistrano/capistrano/compare/v3.5.0...HEAD
 
   * Make path to git wrapper script configurable (@thickpaddy)
+  * Change git wrapper path to work better with multiple users (@thickpaddy)
 
 ## `3.5.0`
 

--- a/lib/capistrano/tasks/git.rake
+++ b/lib/capistrano/tasks/git.rake
@@ -4,7 +4,10 @@ namespace :git do
   end
 
   set :git_wrapper_path, lambda {
-    "#{fetch(:tmp_dir)}/#{fetch(:application)}/git-ssh.sh"
+    # Try to avoid permissions issues when multiple users deploy the same app
+    # by using different file names in the same dir for each deployer and stage.
+    suffix = [:application, :stage, :local_user].map { |key| fetch(key).to_s }.join("-")
+    "#{fetch(:tmp_dir)}/git-ssh-#{suffix}.sh"
   }
 
   set :git_environmental_variables, lambda {

--- a/lib/capistrano/tasks/git.rake
+++ b/lib/capistrano/tasks/git.rake
@@ -3,6 +3,10 @@ namespace :git do
     @strategy ||= Capistrano::Git.new(self, fetch(:git_strategy, Capistrano::Git::DefaultStrategy))
   end
 
+  set :git_wrapper_path, lambda {
+    "#{fetch(:tmp_dir)}/#{fetch(:application)}/git-ssh.sh"
+  }
+
   set :git_environmental_variables, lambda {
     {
       git_askpass: "/bin/echo",
@@ -13,9 +17,9 @@ namespace :git do
   desc "Upload the git wrapper script, this script guarantees that we can script git without getting an interactive prompt"
   task :wrapper do
     on release_roles :all do
-      execute :mkdir, "-p", "#{fetch(:tmp_dir)}/#{fetch(:application)}/"
-      upload! StringIO.new("#!/bin/sh -e\nexec /usr/bin/ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no \"$@\"\n"), "#{fetch(:tmp_dir)}/#{fetch(:application)}/git-ssh.sh"
-      execute :chmod, "+rx", "#{fetch(:tmp_dir)}/#{fetch(:application)}/git-ssh.sh"
+      execute :mkdir, "-p", File.dirname(fetch(:git_wrapper_path))
+      upload! StringIO.new("#!/bin/sh -e\nexec /usr/bin/ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no \"$@\"\n"), fetch(:git_wrapper_path)
+      execute :chmod, "+rx", fetch(:git_wrapper_path)
     end
   end
 


### PR DESCRIPTION
The wrapper script is known to cause problems on multi-user deployment systems, because the script is uploaded to the same location within tmp_dir, resulting in permissions issues when multiple users attempt to write to the same file, which is (sensibly) only writeable by its owner.

Using the application name in the path goes some way to addressing this, but doesn't help when multiple users deploy the same application.

I've worked around this by updating the path so it should "just work" on most systems by using a different file name for each deployer/application/stage. This seems to work well, but it does look a little fugly.

I've also made the path to the git wrapper script configurable, to make it simpler for devs and sysadmins to customise the behaviour to suit their systems if necessary, and to allow the path be referenced in any custom cleanup tasks.