### PR TITLE
Change local_user default to use environment vars instead of getlogin

### DIFF
--- a/lib/capistrano/defaults.rb
+++ b/lib/capistrano/defaults.rb
@@ -21,4 +21,4 @@ set_if_empty :log_level, :debug
 
 set_if_empty :pty, false
 
-set_if_empty :local_user, -> { Etc.getlogin }
+set_if_empty :local_user, -> { ENV['USER'] || ENV['LOGNAME'] || ENV['USERNAME'] }

--- a/lib/capistrano/dsl.rb
+++ b/lib/capistrano/dsl.rb
@@ -1,4 +1,3 @@
-require 'etc'
 require 'capistrano/dsl/task_enhancements'
 require 'capistrano/dsl/paths'
 require 'capistrano/dsl/stages'

--- a/spec/integration/dsl_spec.rb
+++ b/spec/integration/dsl_spec.rb
@@ -467,36 +467,6 @@ describe Capistrano::DSL do
 
   end
 
-  describe 'local_user' do
-    before do
-      dsl.set :local_user, -> { Etc.getlogin }
-    end
-
-    describe 'fetching local_user' do
-      subject { dsl.local_user }
-
-      context 'where a local_user is not set' do
-        before do
-          Etc.expects(:getlogin).returns('login')
-        end
-
-        it 'returns the login name' do
-          expect(subject.to_s).to eq 'login'
-        end
-      end
-
-      context 'where a local_user is set' do
-        before do
-          dsl.set(:local_user, -> { 'custom login' })
-        end
-
-        it 'returns the custom name' do
-          expect(subject.to_s).to eq 'custom login'
-        end
-      end
-    end
-  end
-
   describe 'on()' do
 
     describe "when passed server objects" do


### PR DESCRIPTION
The return value of Etc.getlogin is not reliable on at least BSD style systems, because it can be changed any time by processes using the setlogin syscall, even after su to another user.

Instead we rely on USER (BSD style), LOGNAME (SystemV style) or USERNAME (Windows) environment variables. On modern unix systems both USER and LOGNAME should be set, but it doesn't hurt to check for both to be on the safe side.

This also removes the dependency on the Etc module and fixes #1520.

I have removed the dsl spec for local_user, because it gave the wrong impression of testing the default behavior when in reality it only exercised the dsl's set method.