### PR TITLE
deduplicate directory list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
   * Return first 12 characters (instead of 7) of SHA1 hash when determining current git revision (@sds)
   * Clean up rubocop lint warnings (@cshaffer)
   * Ensure task invocation within after hooks is namespace aware (@thickpaddy)
+  * Deduplicate list of linked directories
 
 ## `3.4.0`
 

--- a/lib/capistrano/dsl/paths.rb
+++ b/lib/capistrano/dsl/paths.rb
@@ -96,7 +96,7 @@ module Capistrano
       end
 
       def map_dirnames(paths)
-        paths.map { |path| path.dirname }
+        paths.map { |path| path.dirname }.uniq
       end
     end
   end

--- a/spec/lib/capistrano/dsl/paths_spec.rb
+++ b/spec/lib/capistrano/dsl/paths_spec.rb
@@ -7,7 +7,7 @@ describe Capistrano::DSL::Paths do
   let(:paths) { Class.new.extend Capistrano::DSL::Paths }
 
   let(:linked_dirs) { %w{log public/system} }
-  let(:linked_files) { %w{config/database.yml log/my.log} }
+  let(:linked_files) { %w{config/database.yml log/my.log log/access.log} }
 
   before do
     dsl.set(:deploy_to, '/var/www')
@@ -21,7 +21,10 @@ describe Capistrano::DSL::Paths do
     end
 
     it 'returns the full pathnames' do
-      expect(subject).to eq [Pathname.new('/var/shared/log'), Pathname.new('/var/shared/public/system')]
+      expect(subject).to eq [
+        Pathname.new('/var/shared/log'),
+        Pathname.new('/var/shared/public/system'),
+      ]
     end
   end
 
@@ -34,7 +37,11 @@ describe Capistrano::DSL::Paths do
     end
 
     it 'returns the full pathnames' do
-      expect(subject).to eq [Pathname.new('/var/shared/config/database.yml'), Pathname.new('/var/shared/log/my.log')]
+      expect(subject).to eq [
+        Pathname.new('/var/shared/config/database.yml'),
+        Pathname.new('/var/shared/log/my.log'),
+        Pathname.new('/var/shared/log/access.log'),
+      ]
     end
   end
 
@@ -46,7 +53,10 @@ describe Capistrano::DSL::Paths do
     end
 
     it 'returns the full paths names of the parent dirs' do
-      expect(subject).to eq [Pathname.new('/var/shared/config'), Pathname.new('/var/shared/log')]
+      expect(subject).to eq [
+        Pathname.new('/var/shared/config'),
+        Pathname.new('/var/shared/log'),
+      ]
     end
   end
 
@@ -58,7 +68,10 @@ describe Capistrano::DSL::Paths do
     end
 
     it 'returns the full paths names of the parent dirs' do
-      expect(subject).to eq [Pathname.new('/var/shared'), Pathname.new('/var/shared/public')]
+      expect(subject).to eq [
+        Pathname.new('/var/shared'),
+        Pathname.new('/var/shared/public'),
+      ]
     end
   end
 


### PR DESCRIPTION
I noticed that directories of linked files are handled multiple times if multiple files in the same directory are being linked.

Most of all, the unneeded noise bothered me. But I guess that some shell have different limits in command-length, so this could solve a real issue.

### known issues

The following tasks are open tasks which I want to do as well. However, perfect first steps are hard, so there's your spoiler for season 2 of this PR:

- [x] check travis build and act accordingly
- [x] update CHANGELOG
- [x] squash the commits with a nice message