### PR TITLE
Enabling the printing of config variables with certain command line p…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
 * Old versions of SSHKit (before 1.7.1) are no longer supported
 * Drop support for Ruby 1.9.3 (Capistrano may still work with 1.9.3, but it is
   no longer officially supported)
+* Added new runtime option `--print-config-variables` that inspect all defined config variables in order to assist development of new capistrano tasks (@gerardo-navarro)
 
 * Minor changes
   * Fix filtering behaviour when using literal hostnames in on() block (@townsen)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ $ bundle exec cap production deploy --prereqs
 
 # trace through task invocations
 $ bundle exec cap production deploy --trace
+
+# lists all config variable before deployment tasks
+$ bundle exec cap production deploy --print-config-variables
 ```
 
 ## Validation of variables

--- a/lib/capistrano/application.rb
+++ b/lib/capistrano/application.rb
@@ -21,7 +21,7 @@ module Capistrano
         switch =~ /--#{Regexp.union(not_applicable_to_capistrano)}/
       end
 
-      super.push(version, dry_run, roles, hostfilter)
+      super.push(version, dry_run, roles, hostfilter, print_config_variables)
     end
 
     def handle_options
@@ -131,6 +131,15 @@ module Capistrano
        "Run SSH commands only on matching hosts",
        lambda { |value|
          Configuration.env.add_cmdline_filter(:host, value)
+       }
+      ]
+    end
+
+    def print_config_variables
+      ['--print-config-variables', '-p',
+       "Display the defined config variables before starting the deployment tasks.",
+       lambda { |_value|
+         Configuration.env.set(:print_config_variables, true)
        }
       ]
     end

--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -28,6 +28,10 @@ module Capistrano
     def set(key, value=nil, &block)
       invoke_validations(key, value, &block)
       config[key] = block || value
+      
+      puts "Config variable set: #{key.inspect} => #{config[key].inspect}" if fetch(:print_config_variables, false)
+
+      config[key]
     end
 
     def set_if_empty(key, value=nil, &block)
@@ -54,6 +58,11 @@ module Capistrano
 
     def keys
       config.keys
+    end
+
+    def is_question?(key)
+      value = fetch_for(key, nil)
+      not value.nil? and value.is_a?(Question)
     end
 
     def role(name, hosts, options={})

--- a/lib/capistrano/dsl/env.rb
+++ b/lib/capistrano/dsl/env.rb
@@ -10,6 +10,10 @@ module Capistrano
         env.fetch(key, default, &block)
       end
 
+      def is_question?(key)
+        env.is_question?(key)
+      end
+
       def any?(key)
         value = fetch(key)
         if value && value.respond_to?(:any?)

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -1,8 +1,30 @@
 namespace :deploy do
 
   task :starting do
+    invoke 'deploy:print_config_variables' if fetch(:print_config_variables, false)
     invoke 'deploy:check'
     invoke 'deploy:set_previous_revision'
+  end
+
+  task :print_config_variables do
+
+    puts 
+    puts '------- Printing current config variables -------'
+    env.keys.each do |config_variable_key|
+      if is_question?(config_variable_key)
+        puts "#{config_variable_key.inspect} => Question (awaits user input on next fetch(#{config_variable_key.inspect}))"
+      else
+        puts "#{config_variable_key.inspect} => #{fetch(config_variable_key).inspect}"
+      end
+    end
+
+    puts
+    puts '------- Printing current config variables of SSHKit mechanism -------'
+    puts env.backend.config.inspect
+    # puts env.backend.config.backend.config.ssh_options.inspect
+    # puts env.backend.config.command_map.defaults.inspect
+
+    puts
   end
 
   task :updating => :new_release_path do

--- a/spec/lib/capistrano/application_spec.rb
+++ b/spec/lib/capistrano/application_spec.rb
@@ -41,6 +41,13 @@ describe Capistrano::Application do
     expect(sshkit_backend).to eq(SSHKit::Backend::Printer)
   end
 
+  it 'enables printing all config variables on command line parameter' do
+    capture_io do
+      flags '--print-config-variables', '-p'
+    end
+    expect(Capistrano::Configuration.fetch(:print_config_variables)).to be true
+  end
+
   def flags(*sets)
     sets.each do |set|
       ARGV.clear


### PR DESCRIPTION
When developing new capistrano tasks, it's very helpful to inspect all defined config variables. For this purpose, the new branch contains a new parameter for the command line `--print-config-variables` or `-p` that displays the defined config variables before starting the deployment tasks.

This feature was really valuable to during development and debugging of custom capistrano tasks.