### PR TITLE
Fix broken deploy_failure.feature tests

### DIFF
--- a/spec/support/tasks/fail.rake
+++ b/spec/support/tasks/fail.rake
@@ -1,6 +1,7 @@
 set :fail, proc { fail }
 before 'deploy:starting', :fail do
   on roles :all do
+    execute :mkdir, '-p', shared_path
     execute :touch, shared_path.join('fail')
   end
   fetch(:fail)

--- a/spec/support/tasks/failed.rake
+++ b/spec/support/tasks/failed.rake
@@ -1,4 +1,4 @@
-after 'deploy:failed', :failed do
+after 'deploy:failed', :custom_failed do
   on roles :all do
     execute :touch, shared_path.join('failed')
   end


### PR DESCRIPTION
It seems that enhancing a task using an `after` block will not have desired effect if the new task shares the same name (excluding namespace) as the task being enhanced. In other words, `after 'deploy:failed', :failed do ...` will not work (the block will never be executed). This behavior was recently introduced in 5fcf3da.

To fix the feature test using this code, I renamed the task to be a unique name. The test now works as intended.

Also, I noticed the task defined in `fail.rake` was sometimes not working as intended, because the `shared_path` did not exist on the VM's filesystem. This meant that `touch` was failing. Corrected by issuing `mkdir -p` first.

With these changes, all feature tests now pass.