### PR TITLE
Normalize before/after task defn. and invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,22 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
 * Drop support for Ruby 1.9.3 (Capistrano may still work with 1.9.3, but it is
   no longer officially supported)
 
+* `before` and `after` hooks have changed slightly:
+  * Tasks created with a `before` or `after` block within a `namespace` are now
+    executed properly. In prior Capistrano versions, namespaced `after` tasks
+    would fail to be found. (@thickpaddy)
+  * Tasks attached with `before` or `after` outside of a `namespace` are
+    now invoked as root-level tasks. In prior Capistrano versions, a `before`
+    task hooked onto a namespaced task (e.g. `deploy:starting`) would inherit
+    that task's namespace. Note that this behavior is different from Rake's
+    prerequisites feature, where the namespace of the original task is always
+    searched when looking up prerequisites. Your `before` hooks may break if
+    you relied on the Rake-style behavior. (@mattbrictson)
+  * `after` can now refer to tasks that have not been loaded yet (@jcoglan)
+
 * Minor changes
   * Fix filtering behaviour when using literal hostnames in on() block (@townsen)
   * Added options to set username and password when using Subversion as SCM (@dsthode)
-  * Allow after() to refer to tasks that have not been loaded yet (@jcoglan)
   * Ensure scm fetch_revision methods strip trailing whitespace (@mattbrictson)
     * Reverted - no longer needed due to [SSHKit PR249](https://github.com/capistrano/sshkit/pull/249) (@robd)
   * Allow use "all" as string for server filtering (@theist)
@@ -27,7 +39,6 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
     instead of `Capfile`. (@mattbrictson)
   * Return first 12 characters (instead of 7) of SHA1 hash when determining current git revision (@sds)
   * Clean up rubocop lint warnings (@cshaffer)
-  * Ensure task invocation within after hooks is namespace aware (@thickpaddy)
   * Deduplicate list of linked directories
   * Allow dot in :application name (@marcovtwout)
 


### PR DESCRIPTION
Capistrano and Rake both have ways of enhancing existing tasks with additional actions or prerequisites, but the behavior is subtly different.

In Capistrano, before/after implicitly create a new named task (when a block is supplied). When this feature is used, task creation and task invocation take place in two different runtime contexts, which leads to subtle inconsistencies with regards to namespaces.

Rake's solution is to *always* search the task's namespace when looking up a prerequisite. E.g. if we add `foo` as a prerequisite like this:

```ruby
Rake::Task['deploy:starting'].enhance([:foo])
```

Then during task invocation, Rake will look for `foo` in the `deploy` namespace. If it can't find `deploy:foo`, then it falls back to looking for `foo`. (I find this behavior non-intuitive, but that's how it works.)

This is at odds with how Capistrano's system behaves. If we try to accomplish the same thing using Capistrano `before` block syntax:

```ruby
before('deploy:starting', :foo) do
  # ...
end
```

This creates a root-level `foo` task, but then since Capistrano uses Rake's prerequisite system under the hood, at invocation time `deploy:foo` is invoked. **The task being declared and the lookup being performed don't match.**

This commit fixes this inconsistency. Now `foo` is created at the root level as it always has been, but the invocation behavior is changed: Capistrano now correctly invokes the root-level `foo` instead of searching the parent tasks's namespace.

Accomplishing this required some tricky code involving Rake's special `rake:` namespace to force the task lookup behavior we want, and definitely goes against the grain of Rake. However this seemed to be the best solution that makes the task declaration and invocation behavior consistent when `before` and `after` are used.

No existing tests broke as a result of this change, which speaks well for backwards compatibility. I added more tests to cover the edge cases that are impacted.

Fixes #1543 