### PR TITLE
Rewrite of the Capistrano README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,125 @@
-# Capistrano [![Build Status](https://travis-ci.org/capistrano/capistrano.svg?branch=master)](https://travis-ci.org/capistrano/capistrano) [![Code Climate](https://img.shields.io/codeclimate/github/capistrano/capistrano.svg)](https://codeclimate.com/github/capistrano/capistrano) <a href="http://codersclan.net/?repo_id=325&source=small"><img src="https://img.shields.io/badge/get-support-blue.svg"></a>
 
-## Documentation
+# Capistrano: A deployment automation tool built on Ruby, Rake, and SSH.
 
-Check out the [online documentation](http://capistranorb.com) of Capistrano 3 hosted via this [repository](https://github.com/capistrano/documentation).
+[![Gem Version](https://badge.fury.io/rb/capistrano.svg)](http://badge.fury.io/rb/capistrano) [![Build Status](https://travis-ci.org/capistrano/capistrano.svg?branch=master)](https://travis-ci.org/capistrano/capistrano) [![Code Climate](https://img.shields.io/codeclimate/github/capistrano/capistrano.svg)](https://codeclimate.com/github/capistrano/capistrano) <a href="http://codersclan.net/?repo_id=325&source=small"><img src="https://img.shields.io/badge/get-support-blue.svg"></a>
 
-## Support
+Capistrano is framework for building automated deployment scripts. Although Capistrano itself is written in Ruby, it can easily be used to deploy projects of any language or framework, be it Rails, Java, or PHP.
 
-Need help with getting Capistrano up and running? Got a code problem you want to get solved quickly?
+Once installed, Capistrano gives you a `cap` tool to perform your deployments from the comfort of your command line.
 
-Get <a href="http://codersclan.net/?repo_id=325&source=link">Capistrano support on CodersClan.</a> <a href="http://codersclan.net/?repo_id=325&source=big"><img src="http://www.codersclan.net/gs_button/?repo_id=325" width="150"></a>
-
-## Requirements
-
-* Ruby >= 2.0.0 (JRuby and C-Ruby/YARV are supported)
-
-Capistrano support these source code version control systems out of the box:
-
-* Git 1.8 or higher
-* Mercurial
-* SVN
-
-Binaries for these VCS might be required on the local and/or the remote systems.
-
-## Installation
-
-Add this line to your application's Gemfile:
-
-``` ruby
-gem 'capistrano', '~> 3.4.0'
+```
+$ cd my-capistrano-enabled-project
+$ cap production deploy
 ```
 
-And then execute:
+When you run `cap`, Capistrano dutifully connects to your server(s) via SSH and executes the steps necessary to deploy your project. You can define those steps yourself by writing [Rake](https://github.com/ruby/rake) tasks , or by using pre-built task libraries provided by the Capistrano community.
+
+Tasks are simple to make. Here's an example:
+
+```ruby
+task :restart_sidekiq
+  on roles(:worker) do
+    execute :service, "sidekiq restart"
+  end
+end
+after "deploy:published", "restart_sidekiq"
+```
+
+---
+
+## Contents
+
+* [Features](#features)
+* [Gotchas](#gotchas)
+* [Quick start](#quick-start)
+* [Finding help and documentation](#finding-help-and-documentation)
+* [How to contribute](#how-to-contribute)
+* [License](#license)
+
+## Features
+
+There are many ways to automate deployments, from simple rsync bash scripts to complex containerized toolchains. Capistrano sits somewhere in the middle: it automates what you already know how to do manually with SSH, but in a repeatable, scalable fashion. There is no magic here!
+
+Here's what makes Capistrano great:
+
+#### Strong conventions
+
+Capistrano defines a standard deployment process that all Capistrano-enabled projects follow by default. You don't have to decide how to structure your scripts, where deployed files should be placed on the server, or how to perform common tasks: Capistrano has done this work for you.
+
+#### Multiple stages
+
+Define your deployment once, and then easily parameterize it for multiple *stages* (environments), e.g. `qa`, `staging`, and `production`. No copy-and-paste necessary: you only need to specify what is different for each stage, like IP addresses.
+
+#### Parallel execution
+
+Deploying to a fleet of app servers? Capistrano can run each deployment task concurrently across those servers and uses connection pooling for speed.
+
+#### Server roles
+
+Your application may need many different types of servers: a database server, an app server, two app servers, and a job queue work server, for example. Capistrano lets you tag each server with one or more roles, so you can control what tasks are executed where.
+
+#### Community driven
+
+Capistrano is easily extensible using the rubygems package manager. Deploying a Rails app? Wordpress? Laravel? Chances are, someone has already written Capistrano tasks for your framework of choice and has distributed it as a gem. Many Ruby projects also come with Capistrano tasks built-in.
+
+#### It's just SSH
+
+Everything in Capistrano comes down to running SSH commands on remote servers. On the one hand, that makes Capistrano simple. On the other hand, if you aren't comfortable SSH-ing into a Linux box and doing stuff on the command-line, then Capistrano is probably not for you.
+
+## Gotchas
+
+While Capistrano ships with a strong set of conventions that are common for all types of deployments, it needs help understanding the specifics of your project, and there are some things Capistrano is not suited to do.
+
+#### Project specifics
+
+Out of the box, Capistrano can deploy your code to server(s), but it does not know how to *execute* your code. Does `foreman` need to be run? Does Apache need to be restarted? You'll need to tell Capistrano how to do this part by writing these deployment steps yourself, or by finding a gem in the Capistrano community that does it for you.
+
+#### Key-based SSH
+
+Capistrano depends on connecting to your server(s) with SSH using key-based (i.e. password-less) authentication. You'll need this working before you can use Capistrano.
+
+#### Provisioning
+
+Likewise, your server(s) will likely need supporting software installed before you can perform a deployment. Capistrano itself has no requirements other than SSH, but your application probably needs database software, a web server like Apache or Nginx, and a language runtime like Java, Ruby, or PHP. These *server provisioning* steps are not done by Capistrano.
+
+#### `sudo`, etc.
+
+Capistrano is designed to deploy using a single, non-privileged SSH user, using a *non-interactive* SSH session. If your deployment requires `sudo`, interactive prompts, authenticating as one user but running commands as another, you can probably accomplish this with Capistrano, but it may be difficult. Your automated deployments will be much smoother if you can avoid such requirements.
+
+## Quick start
+
+### Requirements
+
+* Ruby version 2.0 or higher on your local machine (MRI, JRuby, or Rubinius)
+* A project that uses source control (Git, Mercurial, and Subversion support is built-in)
+* The SCM binaries (e.g. `git`, `hg`) needed to check out your project must be installed on the server(s) you are deploying to
+* [Bundler](http://bundler.io), along with a Gemfile for your project, are recommended
+
+### Install the Capistrano gem
+
+Add Capistrano to your project's Gemfile:
+
+``` ruby
+group :development do
+  gem "capistrano", "~> 3.4"
+end
+```
+
+Then run Bundler to ensure Capistrano is downloaded and installed:
 
 ``` sh
 $ bundle install
 ```
 
-Capify:
-*make sure there's no "Capfile" or "capfile" present*
+### "Capify" your project
+
+Make sure your project doesn't already have a "Capfile" or "capfile" present. Then run:
+
 ``` sh
 $ bundle exec cap install
 ```
 
-This creates the following files:
+This creates all the necessary configuration files and directory structure for a Capistrano-enabled project with two stages, `staging` and `production`:
 
 ```
 ├── Capfile
@@ -56,13 +133,15 @@ This creates the following files:
             └── tasks
 ```
 
-To create different stages:
+To customize the stages that are created, use:
 
 ``` sh
 $ bundle exec cap install STAGES=local,sandbox,qa,production
 ```
 
-## Usage
+Note that the files that Capistrano creates are simply templates to get you started. Make sure to edit the `deploy.rb` and stage files so they contain values appropriate for your project and your target servers.
+
+### Command-line usage
 
 ``` sh
 # list all available tasks
@@ -85,51 +164,26 @@ $ bundle exec cap production deploy --prereqs
 $ bundle exec cap production deploy --trace
 ```
 
-## Validation of variables
+## Finding help and documentation
 
-To validate a variable, each time before it is set, define a validation:
+Capistrano is a large project encompassing multiple GitHub repositories and a community of plugins, and it can be overwhelming when you are just getting started. Here are resources that can help:
 
-```ruby
-validate :some_key do |key, value|
-  if value.length < 5
-    raise Capistrano::ValidationError, "Length of #{key} is too short!"
-  end
-end
-```
+* **[The Capistrano website](http://capistranorb.com) is the best place for official documentation**
+* [Stack Overflow](http://stackoverflow.com/questions/tagged/capistrano) has a Capistrano tag with lots of activity
+* [The Capistrano mailing list](https://groups.google.com/forum/#!forum/capistrano) is low-traffic but is monitored by Capistrano contributors
+* [CodersClan](http://codersclan.net/?repo_id=325&source=link) has Capistrano experts available to solve problems for bounties
 
-Multiple validation can be assigned to a single key. Validations will be executed
-in the order of registration.
+Related GitHub repositories:
 
-Validations can be used to ensure certain properties of user-supplied values,
-e.g. from `ask` or `ENV`. ``
+* [capistrano/sshkit](https://github.com/capistrano/sshkit) provides the SSH behavior that underlies Capistrano (when you use `execute` in a Capistrano task, you are using SSHKit)
+* [capistrano/documentation](https://github.com/capistrano/documentation) is what generates the official Capistrano website
+* [capistrano/rails](https://github.com/capistrano/rails) is a very popular gem that adds Ruby on Rails deployment tasks
 
-## Testing
+GitHub issues are for bug reports and feature requests. Please refer to the [CONTRIBUTING](CONTRIBUTING.md) document for guidelines on submitting GitHub issues.
 
-Capistrano has two test suites: an RSpec suite and a Cucumber suite. The
-RSpec suite handles quick feedback unit specs. The Cucumber suite features
-an integration suite that uses Vagrant to deploy to a real virtual
-server. In order to run the Cucumber suite you will need to install
-[Vagrant](https://www.vagrantup.com/) and Vagrant supported
-virtualization software like
-[VirtualBox](https://www.virtualbox.org/wiki/Downloads).
+## How to contribute
 
-```
-# To run the RSpec suite
-$ rake spec
-
-# To run the Cucumber suite
-$ rake features
-
-# To run the Cucumber suite and leave the VM running (faster for subsequent runs)
-$ rake features KEEP_RUNNING=1
-```
-
-## SSHKit
-
-[SSHKit](https://github.com/capistrano/sshkit) is the driver for SSH
-connections behind the scenes in Capistrano. Depending on how deep you dig, you
-might run into interfaces that come directly from SSHKit (the configuration is
-a good example).
+Contributions to Capistrano, in the form of code, documentation or idea, are gladly accepted. Read the [DEVELOPMENT](DEVELOPMENT.md) document to learn how to hack on Capistrano's code, run the tests, and contribute your first pull request.
 
 ## License
 


### PR DESCRIPTION
I was in a documentation writing mood, so I rewrote the README. :grin: 

While Capistrano does have official documentation on its website, I feel that we still need a comprehensive README. (In fact, the website instructs readers to read the README first.)

My goal here was to do a better job of explaining what exactly Capistrano is, why you should use it (there are many options out there for deployment automation, after all), and also importantly, what Capistrano does *not* do.

I also tried to make a more helpful "documentation and help" section, and I removed contribution and testing instructions that are better covered in the new CONTRIBUTION and DEVELOPMENT docs.

Finally, I removed the section about "Validation of variables", which seemed out of place in the README. I think this is more appropriate for the documentation website, since it is a pretty low-level feature.

I realize that the "features" and "gotchas" sections that I've written are quite wordy. If you feel it is better to move these to the documentation website in order to keep the README more concise, I can do that.