### PR TITLE
Add Capistrano Plugin API

### DIFF
--- a/lib/capistrano/ext/sshkit/backend/thread_local.rb
+++ b/lib/capistrano/ext/sshkit/backend/thread_local.rb
@@ -1,0 +1,25 @@
+require "sshkit/backends/abstract"
+
+# Monkey patch older versions of SSHKit to make the currently-executing Backend
+# available via a thread local value.
+#
+# TODO: Remove this code once capistrano.gemspec requires newer SSHKit version.
+
+unless SSHKit::Backend.respond_to?(:current)
+  module SSHKit
+    module Backend
+      def self.current
+        Thread.current["sshkit_backend"]
+      end
+
+      class Abstract
+        def run
+          Thread.current["sshkit_backend"] = self
+          instance_exec(@host, &@block)
+        ensure
+          Thread.current["sshkit_backend"] = nil
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/capistrano/ext/sshkit/backend/thread_local_spec.rb
+++ b/spec/lib/capistrano/ext/sshkit/backend/thread_local_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+require "capistrano/ext/sshkit/backend/thread_local"
+
+module SSHKit
+  module Backend
+    describe "#current" do
+      require "sshkit/dsl"
+
+      it "refers to the currently executing backend" do
+        backend = nil
+        current = nil
+
+        on(:local) do
+          backend = self
+          current = SSHKit::Backend.current
+        end
+
+        expect(current).to eq(backend)
+      end
+
+      it "is nil outside of an on block" do
+        on(:local) do
+          # nothing
+        end
+
+        expect(SSHKit::Backend.current).to be_nil
+      end
+    end
+  end
+end

--- a/spec/lib/capistrano/immutable_task_spec.rb
+++ b/spec/lib/capistrano/immutable_task_spec.rb
@@ -4,6 +4,11 @@ require 'capistrano/immutable_task'
 
 module Capistrano
   describe ImmutableTask do
+    after do
+      # Ensure that any tasks we create in these tests don't pollute other tests
+      Rake::Task.clear
+    end
+
     it 'prints warning and raises when task is enhanced' do
       extend(Rake::DSL)
 

--- a/spec/lib/capistrano/plugin_spec.rb
+++ b/spec/lib/capistrano/plugin_spec.rb
@@ -1,0 +1,82 @@
+require "spec_helper"
+require "capistrano/plugin"
+
+module Capistrano
+  describe Plugin do
+    include Rake::DSL
+    include Capistrano::DSL
+
+    class DummyPlugin < Capistrano::Plugin
+      def define_tasks
+        task :hello do
+        end
+      end
+
+      def register_hooks
+        before "deploy:published", "hello"
+      end
+    end
+
+    class ExternalTasksPlugin < Capistrano::Plugin
+      def define_tasks
+        eval_rakefile(
+          File.expand_path("../../../support/tasks/plugin.rake", __FILE__)
+        )
+      end
+
+      # Called from plugin.rake to demonstrate that helper methods work
+      def hello
+        set :plugin_result, "hello"
+      end
+    end
+
+    before do
+      # Define an example task to allow testing hooks
+      task "deploy:published"
+    end
+
+    after do
+      # Clean up any tasks or variables we created during the tests
+      Rake::Task.clear
+      Capistrano::Configuration.reset!
+    end
+
+    it "defines tasks when constructed" do
+      DummyPlugin.new
+      expect(Rake::Task["hello"]).not_to be_nil
+    end
+
+    it "registers hooks when constructed" do
+      DummyPlugin.new
+      expect(Rake::Task["deploy:published"].prerequisites).to include("hello")
+    end
+
+    it "skips registering hooks if :hooks => false" do
+      DummyPlugin.new(:hooks => false)
+      expect(Rake::Task["deploy:published"].prerequisites).to be_empty
+    end
+
+    it "doesn't call set_defaults immediately" do
+      dummy = DummyPlugin.new
+      dummy.expects(:set_defaults).never
+    end
+
+    it "calls set_defaults during load:defaults" do
+      dummy = DummyPlugin.new
+      dummy.expects(:set_defaults).once
+      Rake::Task["load:defaults"].invoke
+    end
+
+    it "is able to load tasks from a .rake file" do
+      ExternalTasksPlugin.new
+      Rake::Task["plugin_test"].invoke
+      expect(fetch(:plugin_result)).to eq("hello")
+    end
+
+    it "exposes the SSHKit backend to subclasses" do
+      SSHKit::Backend.expects(:current).returns(:backend)
+      plugin = DummyPlugin.new
+      expect(plugin.send(:backend)).to eq(:backend)
+    end
+  end
+end

--- a/spec/support/tasks/plugin.rake
+++ b/spec/support/tasks/plugin.rake
@@ -1,0 +1,6 @@
+# This rake file is used by plugin_spec.rb.
+
+task :plugin_test do
+  # Example of invoking a helper method provided by the plugin
+  hello
+end


### PR DESCRIPTION
This PR is based on my discussion with @leehambley [here](https://github.com/capistrano/capistrano/issues/929#issuecomment-170371959) and my proof-of-concept [here](https://github.com/mattbrictson/experimental-capistrano-git-scm).

I have refrained from any CHANGELOG entry because I don't think we should publicize the Plugin class too much until it has had some real-world use and the API is proven to be stable.

SSHKit doesn't yet support `SSHKit::Backend.current` (I need to open a PR for that), so in the meantime I've added it here as a monkey patch.

I believe everything is well unit-tested. (Please forgive me if my RSpec dialect is awkward; I usually write tests using Minitest. :sweat:)