### PR TITLE
Fix overly-broad use of `raise_error` with no argument

### DIFF
--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -139,7 +139,7 @@ module Capistrano
         subject { config.fetch(:key, :default) { fail 'we need this!' } }
 
         it 'returns the block value' do
-          expect { subject }.to raise_error
+          expect { subject }.to raise_error(RuntimeError)
         end
       end
 
@@ -151,7 +151,7 @@ module Capistrano
         end
 
         it 'validates without error' do
-          expect{ config.set(:key, 'longer_value') }.not_to raise_error
+          config.set(:key, 'longer_value')
         end
 
         it 'raises an exception' do

--- a/spec/lib/capistrano/version_validator_spec.rb
+++ b/spec/lib/capistrano/version_validator_spec.rb
@@ -31,7 +31,7 @@ module Capistrano
           let(:version) { '3.0.0' }
 
           it 'fails' do
-            expect { subject }.to raise_error
+            expect { subject }.to raise_error(RuntimeError)
           end
         end
 
@@ -39,7 +39,7 @@ module Capistrano
           let(:version) { '3.0.2' }
 
           it 'fails' do
-            expect { subject }.to raise_error
+            expect { subject }.to raise_error(RuntimeError)
           end
         end
 
@@ -55,7 +55,7 @@ module Capistrano
           let(:version) { '<= 2.0.0' }
 
           it 'fails' do
-            expect { subject }.to raise_error
+            expect { subject }.to raise_error(RuntimeError)
           end
         end
       end
@@ -73,7 +73,7 @@ module Capistrano
             let(:version) { '~> 3.1.0' }
 
             it 'fails' do
-              expect { subject }.to raise_error
+              expect { subject }.to raise_error(RuntimeError)
             end
           end
         end
@@ -89,7 +89,7 @@ module Capistrano
           context 'invalid' do
             let(:version) { '~> 3.6' }
             it 'fails' do
-              expect { subject }.to raise_error
+              expect { subject }.to raise_error(RuntimeError)
             end
           end
         end


### PR DESCRIPTION
Fixes these RSpec warnings:

> WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call.