### PR TITLE
Add `rubocop --lint` to default rake task and Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.1
   - 2.0
   - rbx-2
-script: bundle exec rake spec
+script: bundle exec rake spec lint
 install: bundle install --jobs=1
 cache: bundler
 branches:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,6 +2,7 @@ Thanks for helping build Capistrano! Here are the development practices followed
 
 * [Who can help](#who-can-help)
 * [Setting up your development environment](#setting-up-your-development-environment)
+* [Coding guidelines](#coding-guidelines)
 * [Submitting a pull request](#submitting-a-pull-request)
 * [Managing GitHub issues](#managing-github-issues)
 * [Reviewing and merging pull requests](#reviewing-and-merging-pull-requests)
@@ -52,6 +53,13 @@ Currently, the Capistrano Travis build does *not* run the Cucumber suite. This m
 
 **If you come across a failing Cucumber feature, this is a bug.** Please report it by opening a GitHub issue. Or even better: do your best to fix the feature and submit a pull request!
 
+## Coding guidelines
+
+This project uses [RuboCop](https://github.com/bbatsov/rubocop) to enforce standard Ruby coding guidelines. Currently we run RuboCop's lint rules only, which check for readability issues like indentation, ambiguity, and useless/unreachable code.
+
+* Test that your contributions pass with `rake lint`
+* The linter is also run as part of the full test suite with `rake`
+* Note the Travis build will fail and your PR cannot be merged if the linter finds errors
 
 ## Submitting a pull request
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,14 @@
 require "bundler/gem_tasks"
 require "cucumber/rake/task"
 require "rspec/core/rake_task"
+require "rubocop/rake_task"
 
-task :default => :spec
+task :default => [:spec, :lint]
 RSpec::Core::RakeTask.new
 
 Cucumber::Rake::Task.new(:features)
 
+desc "Run RuboCop lint checks"
+RuboCop::RakeTask.new(:lint) do |task|
+  task.options = ["--lint"]
+end

--- a/capistrano.gemspec
+++ b/capistrano.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'mocha'
+  gem.add_development_dependency 'rubocop'
 end

--- a/lib/capistrano/configuration/server.rb
+++ b/lib/capistrano/configuration/server.rb
@@ -27,14 +27,15 @@ module Capistrano
       def select?(options)
         options.each do |k,v|
           callable = v.respond_to?(:call) ? v: ->(server){server.fetch(v)}
-          result = case k
-          when :filter, :select
-            callable.call(self)
-          when :exclude
-            !callable.call(self)
-          else
-            self.fetch(k) == v
-          end
+          result = \
+            case k
+            when :filter, :select
+              callable.call(self)
+            when :exclude
+              !callable.call(self)
+            else
+              self.fetch(k) == v
+            end
           return false unless result
         end
         return true

--- a/spec/lib/capistrano/application_spec.rb
+++ b/spec/lib/capistrano/application_spec.rb
@@ -51,7 +51,7 @@ describe Capistrano::Application do
 
   def command_line(*options)
     options.each { |opt| ARGV << opt }
-    def subject.exit(*_args)
+    subject.define_singleton_method(:exit) do |*_args|
       throw(:system_exit, :exit)
     end
     subject.run


### PR DESCRIPTION
This PR is pretty much identical to the one that was merged for SSHKit: https://github.com/capistrano/sshkit/pull/313

* Fixes all warnings reported by `rubocop --lint` (there were only a few)
* Explains our usage of RuboCop in DEVELOPMENT.md
* Adds a `lint` rake task for executing `rubocop --lint`
* Makes linting part of the default rake task
* Adds linting to the Travis build