### PR TITLE
Remove JRuby from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Capistrano is designed to deploy using a single, non-privileged SSH user, using 
 
 ### Requirements
 
-* Ruby version 2.0 or higher on your local machine (MRI, JRuby, or Rubinius)
+* Ruby version 2.0 or higher on your local machine (MRI or Rubinius)
 * A project that uses source control (Git, Mercurial, and Subversion support is built-in)
 * The SCM binaries (e.g. `git`, `hg`) needed to check out your project must be installed on the server(s) you are deploying to
 * [Bundler](http://bundler.io), along with a Gemfile for your project, are recommended


### PR DESCRIPTION
Although JRuby might work, we don't officially support it (i.e. not tested by Travis), so best take it out of the official docs.