### PR TITLE
Prune old tracking branches from the git repository on each host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
 * Drop support for Ruby 1.9.3 (Capistrano may still work with 1.9.3, but it is
   no longer officially supported)
 * Added new runtime option `--print-config-variables` that inspect all defined config variables in order to assist development of new capistrano tasks (@gerardo-navarro)
+* Prune dead tracking branches from git repositories while updating
+  * Git version 1.6.3 or greater is now required
 
 * Minor changes
   * Fix filtering behaviour when using literal hostnames in on() block (@townsen)

--- a/lib/capistrano/git.rb
+++ b/lib/capistrano/git.rb
@@ -34,7 +34,7 @@ class Capistrano::Git < Capistrano::SCM
       if (depth = fetch(:git_shallow_clone))
         git :fetch, '--depth', depth, 'origin', fetch(:branch)
       else
-        git :remote, :update
+        git :remote, :update, '--prune'
       end
     end
 

--- a/spec/lib/capistrano/git_spec.rb
+++ b/spec/lib/capistrano/git_spec.rb
@@ -61,7 +61,7 @@ module Capistrano
     describe "#update" do
       it "should run git update" do
         context.expects(:fetch).with(:git_shallow_clone).returns(nil)
-        context.expects(:execute).with(:git, :remote, :update)
+        context.expects(:execute).with(:git, :remote, :update, '--prune')
 
         subject.update
       end


### PR DESCRIPTION
This change runs a git prune operation prior to running the repository update operation in order to remove old tracking branches.  Updates for projects that have a large branch turnover rate grind to a fairly sudden halt without regular pruning as the server side of the repository becomes bogged down trying to resolve branch refs that no longer exist.