### PR TITLE
Allow more than one value to be sent to `append`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Reverse Chronological Order:
 https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
 
 * `append` DSL method for pushing values like `linked_dirs`
+  [#1447](https://github.com/capistrano/capistrano/pull/1447),
+  [#1586](https://github.com/capistrano/capistrano/pull/1586)
 * Added support for git shallow clone
 * Remove 'vendor/bundle' from default :linked_dirs (@ojab)
 * Removed the post-install message (@Kriechi)

--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -38,8 +38,8 @@ module Capistrano
       set(key, value, &block) unless config.has_key? key
     end
 
-    def append(key, value)
-      set(key, Array(fetch(key)) << value)
+    def append(key, *values)
+      set(key, Array(fetch(key)).concat(values))
     end
 
     def delete(key)

--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -160,10 +160,10 @@ module Capistrano
       end
 
       context 'appending' do
-        subject { config.append(:linked_dirs, 'vendor/bundle') }
+        subject { config.append(:linked_dirs, 'vendor/bundle', 'tmp') }
 
         it "returns appended value" do
-          expect(subject).to eq ['vendor/bundle']
+          expect(subject).to eq ['vendor/bundle', 'tmp']
         end
 
         context "on non-array variable" do


### PR DESCRIPTION
I was about to write documentation for the new `append` DSL method, when I realized that in practice you would very likely want to append more than one value at a time. For example:

```ruby
append :linked_dirs, ".bundle", "tmp"
```

/cc @kirs 