### PR TITLE
Implementation of remove.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Reverse Chronological Order:
 
 https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
 
+* `remove` DSL method for removing values like from arrays like `linked_dirs`
 * `append` DSL method for pushing values like `linked_dirs`
   [#1447](https://github.com/capistrano/capistrano/pull/1447),
   [#1586](https://github.com/capistrano/capistrano/pull/1586)

--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -28,7 +28,7 @@ module Capistrano
     def set(key, value=nil, &block)
       invoke_validations(key, value, &block)
       config[key] = block || value
-      
+
       puts "Config variable set: #{key.inspect} => #{config[key].inspect}" if fetch(:print_config_variables, false)
 
       config[key]
@@ -40,6 +40,10 @@ module Capistrano
 
     def append(key, *values)
       set(key, Array(fetch(key)).concat(values))
+    end
+
+    def remove(key, *values)
+      set(key, Array(fetch(key)) - values)
     end
 
     def delete(key)

--- a/lib/capistrano/dsl/env.rb
+++ b/lib/capistrano/dsl/env.rb
@@ -6,7 +6,7 @@ module Capistrano
       extend Forwardable
       def_delegators :env,
                      :configure_backend, :fetch, :set, :set_if_empty, :delete,
-                     :ask, :role, :server, :primary, :validate, :append
+                     :ask, :role, :server, :primary, :validate, :append, :remove
 
       def is_question?(key)
         env.is_question?(key)

--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -175,6 +175,38 @@ module Capistrano
           end
         end
       end
+
+      context 'removing' do
+        before :each do
+          config.set(:linked_dirs, ['vendor/bundle', 'tmp'])
+        end
+
+        subject { config.remove(:linked_dirs, 'vendor/bundle') }
+
+        it 'returns without removed value' do
+          expect(subject).to eq ['tmp']
+        end
+
+        context 'on non-array variable' do
+          before { config.set(:linked_dirs, 'string') }
+
+          context 'when removing same value' do
+            subject { config.remove(:linked_dirs, 'string') }
+
+            it 'returns without removed value' do
+              expect(subject).to eq []
+            end
+          end
+
+          context 'when removing different value' do
+            subject { config.remove(:linked_dirs, 'othervalue') }
+
+            it 'returns without removed value' do
+              expect(subject).to eq ['string']
+            end
+          end
+        end
+      end
     end
 
     describe 'keys' do


### PR DESCRIPTION
I just saw https://github.com/capistrano/capistrano/pull/1447 and realized how useful this is, especially when paired with the ability to remove. This PR adds that ability.

My use case is that I've built an internal Gem for my company which sets a pile of defaults. Sometimes, I don't need all of the default linked_dirs or such, at which point I have some messy code to remove them from the array.