### PR TITLE
Upgrade airbrussh dependency to 1.0.0 final

### DIFF
--- a/capistrano.gemspec
+++ b/capistrano.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.licenses      = ["MIT"]
 
   gem.required_ruby_version = ">= 1.9.3"
-  gem.add_dependency "airbrussh", ">= 1.0.0.beta1"
+  gem.add_dependency "airbrussh", ">= 1.0.0"
   gem.add_dependency "i18n"
   gem.add_dependency "rake", ">= 10.0.0"
   gem.add_dependency "sshkit", ">= 1.9.0.rc1"


### PR DESCRIPTION
Airbrussh 1.0.0 is now released, so we no longer need to point to the beta version.