### PR TITLE
Rubocop housekeeping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.1
   - 2.0
   - rbx-2
-script: bundle exec rake spec lint
+script: bundle exec rake spec rubocop
 install: bundle install --jobs=1
 cache: bundler
 branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ default of Capistrano 3.4.0 and earlier.
 
 Other changes:
 
+* Internal Rubocop cleanups.
 * `remove` DSL method for removing values like from arrays like `linked_dirs`
 * `append` DSL method for pushing values like `linked_dirs`
   [#1447](https://github.com/capistrano/capistrano/pull/1447),

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -55,11 +55,11 @@ Currently, the Capistrano Travis build does *not* run the Cucumber suite. This m
 
 ## Coding guidelines
 
-This project uses [RuboCop](https://github.com/bbatsov/rubocop) to enforce standard Ruby coding guidelines. Currently we run RuboCop's lint rules only, which check for readability issues like indentation, ambiguity, and useless/unreachable code.
+This project uses [RuboCop](https://github.com/bbatsov/rubocop) to enforce standard Ruby coding guidelines.
 
-* Test that your contributions pass with `rake lint`
-* The linter is also run as part of the full test suite with `rake`
-* Note the Travis build will fail and your PR cannot be merged if the linter finds errors
+* Test that your contributions pass with `rake rubocop`
+* Rubocop is also run as part of the full test suite with `rake`
+* Note the Travis build will fail and your PR cannot be merged if Rubocop finds errors
 
 ## Submitting a pull request
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,12 +3,10 @@ require "cucumber/rake/task"
 require "rspec/core/rake_task"
 require "rubocop/rake_task"
 
-task :default => [:spec, :lint]
+task :default => [:spec, :rubocop]
 RSpec::Core::RakeTask.new
 
 Cucumber::Rake::Task.new(:features)
 
-desc "Run RuboCop lint checks"
-RuboCop::RakeTask.new(:lint) do |task|
-  task.options = ["--lint"]
-end
+desc "Run RuboCop checks"
+RuboCop::RakeTask.new


### PR DESCRIPTION
Followup to https://github.com/capistrano/capistrano/pull/1594.

* Updates TravisCI to use full Rubocop suite
* Updates docs to reflect change