### PR TITLE
Use default Rubocop recommended syntax for string literals.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,8 +11,6 @@ Style/DoubleNegation:
   Enabled: false
 Style/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: no_space
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
 Style/TrivialAccessors:
   AllowPredicates: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in capistrano.gemspec
 gemspec
 
 group :cucumber do
-  gem "cucumber"
-  gem "rspec"
-  gem "rspec-core", "~> 3.4.4"
+  gem 'cucumber'
+  gem 'rspec'
+  gem 'rspec-core', '~> 3.4.4'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,12 @@
-require "bundler/gem_tasks"
-require "cucumber/rake/task"
-require "rspec/core/rake_task"
-require "rubocop/rake_task"
+require 'bundler/gem_tasks'
+require 'cucumber/rake/task'
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
 task default: [:spec, :rubocop]
 RSpec::Core::RakeTask.new
 
 Cucumber::Rake::Task.new(:features)
 
-desc "Run RuboCop checks"
+desc 'Run RuboCop checks'
 RuboCop::RakeTask.new

--- a/bin/cap
+++ b/bin/cap
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-require "capistrano/all"
+require 'capistrano/all'
 Capistrano::Application.new.run

--- a/bin/capify
+++ b/bin/capify
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
-puts "-" * 80
-puts "Capistrano 3.x is incompatible with Capistrano 2.x. "
+puts '-' * 80
+puts 'Capistrano 3.x is incompatible with Capistrano 2.x. '
 puts
-puts "This command has become `cap install` in Capistrano 3.x"
+puts 'This command has become `cap install` in Capistrano 3.x'
 puts
-puts "For more information see http://www.capistranorb.com/"
-puts "-" * 80
+puts 'For more information see http://www.capistranorb.com/'
+puts '-' * 80

--- a/capistrano.gemspec
+++ b/capistrano.gemspec
@@ -1,31 +1,31 @@
 # -*- encoding: utf-8 -*-
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "capistrano/version"
+require 'capistrano/version'
 
 Gem::Specification.new do |gem|
-  gem.name          = "capistrano"
+  gem.name          = 'capistrano'
   gem.version       = Capistrano::VERSION
-  gem.authors       = ["Tom Clements", "Lee Hambley"]
-  gem.email         = ["seenmyfate@gmail.com", "lee.hambley@gmail.com"]
-  gem.description   = "Capistrano is a utility and framework for executing commands in parallel on multiple remote machines, via SSH."
-  gem.summary       = "Capistrano - Welcome to easy deployment with Ruby over SSH"
-  gem.homepage      = "http://capistranorb.com/"
+  gem.authors       = ['Tom Clements', 'Lee Hambley']
+  gem.email         = ['seenmyfate@gmail.com', 'lee.hambley@gmail.com']
+  gem.description   = 'Capistrano is a utility and framework for executing commands in parallel on multiple remote machines, via SSH.'
+  gem.summary       = 'Capistrano - Welcome to easy deployment with Ruby over SSH'
+  gem.homepage      = 'http://capistranorb.com/'
 
   gem.files         = `git ls-files -z`.split("\x0")
   gem.executables   = %w(cap capify)
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.require_paths = ["lib"]
+  gem.require_paths = ['lib']
 
-  gem.licenses      = ["MIT"]
+  gem.licenses      = ['MIT']
 
-  gem.required_ruby_version = ">= 1.9.3"
-  gem.add_dependency "airbrussh", ">= 1.0.0"
-  gem.add_dependency "i18n"
-  gem.add_dependency "rake", ">= 10.0.0"
-  gem.add_dependency "sshkit", ">= 1.9.0"
+  gem.required_ruby_version = '>= 1.9.3'
+  gem.add_dependency 'airbrussh', '>= 1.0.0'
+  gem.add_dependency 'i18n'
+  gem.add_dependency 'rake', '>= 10.0.0'
+  gem.add_dependency 'sshkit', '>= 1.9.0.rc1'
 
-  gem.add_development_dependency "rspec"
-  gem.add_development_dependency "mocha"
-  gem.add_development_dependency "rubocop"
+  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'mocha'
+  gem.add_development_dependency 'rubocop'
 end

--- a/features/step_definitions/assertions.rb
+++ b/features/step_definitions/assertions.rb
@@ -1,5 +1,5 @@
 Then(/^references in the remote repo are listed$/) do
-  expect(@output).to include("refs/heads/master")
+  expect(@output).to include('refs/heads/master')
 end
 
 Then(/^the shared path is created$/) do
@@ -49,25 +49,25 @@ Then(/^the current directory will be a symlink to the release$/) do
 end
 
 Then(/^the deploy\.rb file is created$/) do
-  file = TestApp.test_app_path.join("config/deploy.rb")
+  file = TestApp.test_app_path.join('config/deploy.rb')
   expect(File.exist?(file)).to be true
 end
 
 Then(/^the default stage files are created$/) do
-  staging = TestApp.test_app_path.join("config/deploy/staging.rb")
-  production = TestApp.test_app_path.join("config/deploy/production.rb")
+  staging = TestApp.test_app_path.join('config/deploy/staging.rb')
+  production = TestApp.test_app_path.join('config/deploy/production.rb')
   expect(File.exist?(staging)).to be true
   expect(File.exist?(production)).to be true
 end
 
 Then(/^the tasks folder is created$/) do
-  path = TestApp.test_app_path.join("lib/capistrano/tasks")
+  path = TestApp.test_app_path.join('lib/capistrano/tasks')
   expect(Dir.exist?(path)).to be true
 end
 
 Then(/^the specified stage files are created$/) do
-  qa = TestApp.test_app_path.join("config/deploy/qa.rb")
-  production = TestApp.test_app_path.join("config/deploy/production.rb")
+  qa = TestApp.test_app_path.join('config/deploy/qa.rb')
+  production = TestApp.test_app_path.join('config/deploy/production.rb')
   expect(File.exist?(qa)).to be true
   expect(File.exist?(production)).to be true
 end
@@ -91,18 +91,18 @@ Then(/^the task fails$/) do
 end
 
 Then(/^the failure task will run$/) do
-  failed = TestApp.shared_path.join("failed")
+  failed = TestApp.shared_path.join('failed')
   run_vagrant_command(test_file_exists(failed))
 end
 
 Then(/^the failure task will not run$/) do
-  failed = TestApp.shared_path.join("failed")
+  failed = TestApp.shared_path.join('failed')
   expect { run_vagrant_command(test_file_exists(failed)) }
     .to raise_error(VagrantHelpers::VagrantSSHCommandError)
 end
 
 When(/^an error is raised$/) do
-  error = TestApp.shared_path.join("fail")
+  error = TestApp.shared_path.join('fail')
   run_vagrant_command(test_file_exists(error))
 end
 

--- a/features/step_definitions/setup.rb
+++ b/features/step_definitions/setup.rb
@@ -4,7 +4,7 @@ end
 
 Given(/^servers with the roles app and web$/) do
   begin
-    vagrant_cli_command("up")
+    vagrant_cli_command('up')
   rescue
     nil
   end
@@ -28,11 +28,11 @@ Given(/^file "(.*?)" does not exist in shared path$/) do |file|
 end
 
 Given(/^a custom task to generate a file$/) do
-  TestApp.copy_task_to_test_app("spec/support/tasks/database.rake")
+  TestApp.copy_task_to_test_app('spec/support/tasks/database.rake')
 end
 
 Given(/^a task which executes as root$/) do
-  TestApp.copy_task_to_test_app("spec/support/tasks/root.rake")
+  TestApp.copy_task_to_test_app('spec/support/tasks/root.rake')
 end
 
 Given(/config stage file has line "(.*?)"/) do |line|
@@ -40,15 +40,15 @@ Given(/config stage file has line "(.*?)"/) do |line|
 end
 
 Given(/^the configuration is in a custom location$/) do
-  TestApp.move_configuration_to_custom_location("app")
+  TestApp.move_configuration_to_custom_location('app')
 end
 
 Given(/^a custom task that will simulate a failure$/) do
-  safely_remove_file(TestApp.shared_path.join("failed"))
-  TestApp.copy_task_to_test_app("spec/support/tasks/fail.rake")
+  safely_remove_file(TestApp.shared_path.join('failed'))
+  TestApp.copy_task_to_test_app('spec/support/tasks/fail.rake')
 end
 
 Given(/^a custom task to run in the event of a failure$/) do
-  safely_remove_file(TestApp.shared_path.join("failed"))
-  TestApp.copy_task_to_test_app("spec/support/tasks/failed.rake")
+  safely_remove_file(TestApp.shared_path.join('failed'))
+  TestApp.copy_task_to_test_app('spec/support/tasks/failed.rake')
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,11 +1,11 @@
-PROJECT_ROOT = File.expand_path("../../../", __FILE__)
-VAGRANT_ROOT = File.join(PROJECT_ROOT, "spec/support")
-VAGRANT_BIN = ENV["VAGRANT_BIN"] || "vagrant"
+PROJECT_ROOT = File.expand_path('../../../', __FILE__)
+VAGRANT_ROOT = File.join(PROJECT_ROOT, 'spec/support')
+VAGRANT_BIN = ENV['VAGRANT_BIN'] || 'vagrant'
 
 at_exit do
-  if ENV["KEEP_RUNNING"]
-    VagrantHelpers.run_vagrant_command("rm -rf /home/vagrant/var")
+  if ENV['KEEP_RUNNING']
+    VagrantHelpers.run_vagrant_command('rm -rf /home/vagrant/var')
   end
 end
 
-require_relative "../../spec/support/test_app"
+require_relative '../../spec/support/test_app'

--- a/features/support/remote_command_helpers.rb
+++ b/features/support/remote_command_helpers.rb
@@ -1,14 +1,14 @@
 module RemoteCommandHelpers
   def test_dir_exists(path)
-    exists?("d", path)
+    exists?('d', path)
   end
 
   def test_symlink_exists(path)
-    exists?("L", path)
+    exists?('L', path)
   end
 
   def test_file_exists(path)
-    exists?("f", path)
+    exists?('f', path)
   end
 
   def exists?(type, path)

--- a/features/support/vagrant_helpers.rb
+++ b/features/support/vagrant_helpers.rb
@@ -1,4 +1,4 @@
-require "English"
+require 'English'
 
 module VagrantHelpers
   extend self
@@ -6,11 +6,11 @@ module VagrantHelpers
   class VagrantSSHCommandError < RuntimeError; end
 
   at_exit do
-    if ENV["KEEP_RUNNING"]
-      puts "Vagrant vm will be left up because KEEP_RUNNING is set."
-      puts "Rerun without KEEP_RUNNING set to cleanup the vm."
+    if ENV['KEEP_RUNNING']
+      puts 'Vagrant vm will be left up because KEEP_RUNNING is set.'
+      puts 'Rerun without KEEP_RUNNING set to cleanup the vm.'
     else
-      vagrant_cli_command("destroy -f")
+      vagrant_cli_command('destroy -f')
     end
   end
 

--- a/lib/Capfile
+++ b/lib/Capfile
@@ -1,3 +1,3 @@
 #!/usr/bin/env cap
 include Capistrano::DSL
-require "capistrano/install"
+require 'capistrano/install'

--- a/lib/capistrano/all.rb
+++ b/lib/capistrano/all.rb
@@ -1,16 +1,16 @@
-require "rake"
-require "sshkit"
+require 'rake'
+require 'sshkit'
 
-require "io/console"
+require 'io/console'
 
 Rake.application.options.trace = true
 
-require "capistrano/version"
-require "capistrano/version_validator"
-require "capistrano/i18n"
-require "capistrano/dsl"
-require "capistrano/application"
-require "capistrano/configuration"
+require 'capistrano/version'
+require 'capistrano/version_validator'
+require 'capistrano/i18n'
+require 'capistrano/dsl'
+require 'capistrano/application'
+require 'capistrano/configuration'
 
 module Capistrano
 end

--- a/lib/capistrano/application.rb
+++ b/lib/capistrano/application.rb
@@ -6,7 +6,7 @@ module Capistrano
     end
 
     def name
-      "cap"
+      'cap'
     end
 
     def run
@@ -24,30 +24,30 @@ module Capistrano
     end
 
     def handle_options
-      options.rakelib = ["rakelib"]
+      options.rakelib = ['rakelib']
       options.trace_output = $stderr
 
       OptionParser.new do |opts|
-        opts.banner = "See full documentation at http://capistranorb.com/."
-        opts.separator ""
-        opts.separator "Install capistrano in a project:"
-        opts.separator "    bundle exec cap install [STAGES=qa,staging,production,...]"
-        opts.separator ""
-        opts.separator "Show available tasks:"
-        opts.separator "    bundle exec cap -T"
-        opts.separator ""
-        opts.separator "Invoke (or simulate invoking) a task:"
-        opts.separator "    bundle exec cap [--dry-run] STAGE TASK"
-        opts.separator ""
-        opts.separator "Advanced options:"
+        opts.banner = 'See full documentation at http://capistranorb.com/.'
+        opts.separator ''
+        opts.separator 'Install capistrano in a project:'
+        opts.separator '    bundle exec cap install [STAGES=qa,staging,production,...]'
+        opts.separator ''
+        opts.separator 'Show available tasks:'
+        opts.separator '    bundle exec cap -T'
+        opts.separator ''
+        opts.separator 'Invoke (or simulate invoking) a task:'
+        opts.separator '    bundle exec cap [--dry-run] STAGE TASK'
+        opts.separator ''
+        opts.separator 'Advanced options:'
 
-        opts.on_tail("-h", "--help", "-H", "Display this help message.") do
+        opts.on_tail('-h', '--help', '-H', 'Display this help message.') do
           puts opts
           exit
         end
 
         standard_rake_options.each { |args| opts.on(*args) }
-        opts.environment("RAKEOPT")
+        opts.environment('RAKEOPT')
       end.parse!
     end
 
@@ -62,7 +62,7 @@ module Capistrano
     def display_error_message(ex)
       unless options.backtrace
         Rake.application.options.suppress_backtrace_pattern = backtrace_pattern if backtrace_pattern
-        trace "(Backtrace restricted to imported tasks)"
+        trace '(Backtrace restricted to imported tasks)'
       end
 
       super
@@ -88,8 +88,8 @@ module Capistrano
 
     def load_imports
       if options.show_tasks
-        invoke "load:defaults"
-        set(:stage, "")
+        invoke 'load:defaults'
+        set(:stage, '')
         Dir[deploy_config_path].each { |f| add_import f }
       end
 
@@ -98,12 +98,12 @@ module Capistrano
 
     # allows the `cap install` task to load without a capfile
     def capfile
-      File.expand_path(File.join(File.dirname(__FILE__), "..", "Capfile"))
+      File.expand_path(File.join(File.dirname(__FILE__), '..', 'Capfile'))
     end
 
     def version
-      ["--version", "-V",
-       "Display the program version.",
+      ['--version', '-V',
+       'Display the program version.',
        lambda do |_value|
          puts "Capistrano Version: #{Capistrano::VERSION} (Rake Version: #{Rake::VERSION})"
          exit
@@ -112,8 +112,8 @@ module Capistrano
     end
 
     def dry_run
-      ["--dry-run", "-n",
-       "Do a dry run without executing actions",
+      ['--dry-run', '-n',
+       'Do a dry run without executing actions',
        lambda do |_value|
          Configuration.env.set(:sshkit_backend, SSHKit::Backend::Printer)
        end
@@ -121,8 +121,8 @@ module Capistrano
     end
 
     def roles
-      ["--roles ROLES", "-r",
-       "Run SSH commands only on hosts matching these roles",
+      ['--roles ROLES', '-r',
+       'Run SSH commands only on hosts matching these roles',
        lambda do |value|
          Configuration.env.add_cmdline_filter(:role, value)
        end
@@ -130,8 +130,8 @@ module Capistrano
     end
 
     def hostfilter
-      ["--hosts HOSTS", "-z",
-       "Run SSH commands only on matching hosts",
+      ['--hosts HOSTS', '-z',
+       'Run SSH commands only on matching hosts',
        lambda do |value|
          Configuration.env.add_cmdline_filter(:host, value)
        end
@@ -139,8 +139,8 @@ module Capistrano
     end
 
     def print_config_variables
-      ["--print-config-variables", "-p",
-       "Display the defined config variables before starting the deployment tasks.",
+      ['--print-config-variables', '-p',
+       'Display the defined config variables before starting the deployment tasks.',
        lambda do |_value|
          Configuration.env.set(:print_config_variables, true)
        end

--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -1,7 +1,7 @@
-require_relative "configuration/filter"
-require_relative "configuration/question"
-require_relative "configuration/server"
-require_relative "configuration/servers"
+require_relative 'configuration/filter'
+require_relative 'configuration/question'
+require_relative 'configuration/server'
+require_relative 'configuration/servers'
 
 module Capistrano
   class ValidationError < Exception; end
@@ -129,8 +129,8 @@ module Capistrano
 
     def setup_filters
       @filters = cmdline_filters.clone
-      @filters << Filter.new(:role, ENV["ROLES"]) if ENV["ROLES"]
-      @filters << Filter.new(:host, ENV["HOSTS"]) if ENV["HOSTS"]
+      @filters << Filter.new(:role, ENV['ROLES']) if ENV['ROLES']
+      @filters << Filter.new(:host, ENV['HOSTS']) if ENV['HOSTS']
       fh = fetch_for(:filter, {}) || {}
       @filters << Filter.new(:host, fh[:hosts]) if fh[:hosts]
       @filters << Filter.new(:role, fh[:roles]) if fh[:roles]
@@ -179,7 +179,7 @@ module Capistrano
 
     def invoke_validations(key, value, &block)
       unless value.nil? || block.nil?
-        raise Capistrano::ValidationError, "Value and block both passed to Configuration#set"
+        raise Capistrano::ValidationError, 'Value and block both passed to Configuration#set'
       end
 
       return unless validators.key? key

--- a/lib/capistrano/configuration/filter.rb
+++ b/lib/capistrano/configuration/filter.rb
@@ -1,8 +1,8 @@
-require "capistrano/configuration"
-require "capistrano/configuration/empty_filter"
-require "capistrano/configuration/host_filter"
-require "capistrano/configuration/null_filter"
-require "capistrano/configuration/role_filter"
+require 'capistrano/configuration'
+require 'capistrano/configuration/empty_filter'
+require 'capistrano/configuration/host_filter'
+require 'capistrano/configuration/null_filter'
+require 'capistrano/configuration/role_filter'
 
 module Capistrano
   class Configuration
@@ -12,7 +12,7 @@ module Capistrano
         av = Array(values)
         @strategy = case
                     when av.empty? then EmptyFilter.new
-                    when av.include?(:all), av.include?("all") then NullFilter.new
+                    when av.include?(:all), av.include?('all') then NullFilter.new
                     when type == :host then HostFilter.new(values)
                     when type == :role then RoleFilter.new(values)
                     else NullFilter.new

--- a/lib/capistrano/configuration/host_filter.rb
+++ b/lib/capistrano/configuration/host_filter.rb
@@ -3,7 +3,7 @@ module Capistrano
     class HostFilter
       def initialize(values)
         av = Array(values).dup
-        av.map! { |v| (v.is_a?(String) && v =~ /^(?<name>[-A-Za-z0-9.]+)(,\g<name>)*$/) ? v.split(",") : v }
+        av.map! { |v| (v.is_a?(String) && v =~ /^(?<name>[-A-Za-z0-9.]+)(,\g<name>)*$/) ? v.split(',') : v }
         av.flatten!
         @rex = regex_matcher(av)
       end

--- a/lib/capistrano/configuration/question.rb
+++ b/lib/capistrano/configuration/question.rb
@@ -31,7 +31,7 @@ module Capistrano
       def response
         return @response if defined? @response
 
-        @response = (gets || "").chomp
+        @response = (gets || '').chomp
       end
 
       def gets

--- a/lib/capistrano/configuration/role_filter.rb
+++ b/lib/capistrano/configuration/role_filter.rb
@@ -3,7 +3,7 @@ module Capistrano
     class RoleFilter
       def initialize(values)
         av = Array(values).dup
-        av.map! { |v| v.is_a?(String) ? v.split(",") : v }
+        av.map! { |v| v.is_a?(String) ? v.split(',') : v }
         av.flatten!
         @rex = regex_matcher(av)
       end

--- a/lib/capistrano/configuration/server.rb
+++ b/lib/capistrano/configuration/server.rb
@@ -1,4 +1,4 @@
-require "set"
+require 'set'
 module Capistrano
   class Configuration
     class Server < SSHKit::Host
@@ -122,7 +122,7 @@ module Capistrano
         private
 
         def lvalue(key)
-          key.to_s.chomp("=").to_sym
+          key.to_s.chomp('=').to_sym
         end
       end
     end

--- a/lib/capistrano/configuration/servers.rb
+++ b/lib/capistrano/configuration/servers.rb
@@ -1,6 +1,6 @@
-require "set"
-require "capistrano/configuration"
-require "capistrano/configuration/filter"
+require 'set'
+require 'capistrano/configuration'
+require 'capistrano/configuration/filter'
 
 module Capistrano
   class Configuration

--- a/lib/capistrano/console.rb
+++ b/lib/capistrano/console.rb
@@ -1,1 +1,1 @@
-load File.expand_path("../tasks/console.rake", __FILE__)
+load File.expand_path('../tasks/console.rake', __FILE__)

--- a/lib/capistrano/defaults.rb
+++ b/lib/capistrano/defaults.rb
@@ -1,17 +1,17 @@
 validate :application do |_key, value|
-  changed_value = value.gsub(/[^A-Z0-9\.\-]/i, "_")
+  changed_value = value.gsub(/[^A-Z0-9\.\-]/i, '_')
   if value != changed_value
     warn %Q(The :application value "#{value}" is invalid!)
-    warn "Use only letters, numbers, hyphens, dots, and underscores. For example:"
+    warn 'Use only letters, numbers, hyphens, dots, and underscores. For example:'
     warn "  set :application, '#{changed_value}'"
     raise Capistrano::ValidationError
   end
 end
 
 set_if_empty :scm, :git
-set_if_empty :branch, "master"
+set_if_empty :branch, 'master'
 set_if_empty :deploy_to, -> { "/var/www/#{fetch(:application)}" }
-set_if_empty :tmp_dir, "/tmp"
+set_if_empty :tmp_dir, '/tmp'
 
 set_if_empty :default_env, {}
 set_if_empty :keep_releases, 5
@@ -21,4 +21,4 @@ set_if_empty :log_level, :debug
 
 set_if_empty :pty, false
 
-set_if_empty :local_user, -> { ENV["USER"] || ENV["LOGNAME"] || ENV["USERNAME"] }
+set_if_empty :local_user, -> { ENV['USER'] || ENV['LOGNAME'] || ENV['USERNAME'] }

--- a/lib/capistrano/deploy.rb
+++ b/lib/capistrano/deploy.rb
@@ -1,3 +1,3 @@
-require "capistrano/framework"
+require 'capistrano/framework'
 
-load File.expand_path("../tasks/deploy.rake", __FILE__)
+load File.expand_path('../tasks/deploy.rake', __FILE__)

--- a/lib/capistrano/dotfile.rb
+++ b/lib/capistrano/dotfile.rb
@@ -1,2 +1,2 @@
-dotfile = Pathname.new(File.join(Dir.home, ".capfile"))
+dotfile = Pathname.new(File.join(Dir.home, '.capfile'))
 load dotfile if dotfile.file?

--- a/lib/capistrano/dsl.rb
+++ b/lib/capistrano/dsl.rb
@@ -1,8 +1,8 @@
-require "capistrano/dsl/task_enhancements"
-require "capistrano/dsl/paths"
-require "capistrano/dsl/stages"
-require "capistrano/dsl/env"
-require "capistrano/configuration/filter"
+require 'capistrano/dsl/task_enhancements'
+require 'capistrano/dsl/paths'
+require 'capistrano/dsl/stages'
+require 'capistrano/dsl/env'
+require 'capistrano/configuration/filter'
 
 module Capistrano
   module DSL

--- a/lib/capistrano/dsl/env.rb
+++ b/lib/capistrano/dsl/env.rb
@@ -1,4 +1,4 @@
-require "forwardable"
+require 'forwardable'
 
 module Capistrano
   module DSL
@@ -38,11 +38,11 @@ module Capistrano
       end
 
       def release_timestamp
-        env.timestamp.strftime("%Y%m%d%H%M%S")
+        env.timestamp.strftime('%Y%m%d%H%M%S')
       end
 
       def asset_timestamp
-        env.timestamp.strftime("%Y%m%d%H%M.%S")
+        env.timestamp.strftime('%Y%m%d%H%M.%S')
       end
     end
   end

--- a/lib/capistrano/dsl/paths.rb
+++ b/lib/capistrano/dsl/paths.rb
@@ -1,4 +1,4 @@
-require "pathname"
+require 'pathname'
 module Capistrano
   module DSL
     module Paths
@@ -11,11 +11,11 @@ module Capistrano
       end
 
       def current_path
-        deploy_path.join("current")
+        deploy_path.join('current')
       end
 
       def releases_path
-        deploy_path.join("releases")
+        deploy_path.join('releases')
       end
 
       def release_path
@@ -28,16 +28,16 @@ module Capistrano
       end
 
       def stage_config_path
-        Pathname.new fetch(:stage_config_path, "config/deploy")
+        Pathname.new fetch(:stage_config_path, 'config/deploy')
       end
 
       def deploy_config_path
-        Pathname.new fetch(:deploy_config_path, "config/deploy.rb")
+        Pathname.new fetch(:deploy_config_path, 'config/deploy.rb')
       end
 
       def repo_url
-        require "cgi"
-        require "uri"
+        require 'cgi'
+        require 'uri'
         if fetch(:git_http_username) && fetch(:git_http_password)
           URI.parse(fetch(:repo_url)).tap do |repo_uri|
             repo_uri.user     = fetch(:git_http_username)
@@ -53,23 +53,23 @@ module Capistrano
       end
 
       def repo_path
-        Pathname.new(fetch(:repo_path, ->() { deploy_path.join("repo") }))
+        Pathname.new(fetch(:repo_path, ->() { deploy_path.join('repo') }))
       end
 
       def shared_path
-        deploy_path.join("shared")
+        deploy_path.join('shared')
       end
 
       def revision_log
-        deploy_path.join("revisions.log")
+        deploy_path.join('revisions.log')
       end
 
       def now
-        env.timestamp.strftime("%Y%m%d%H%M%S")
+        env.timestamp.strftime('%Y%m%d%H%M%S')
       end
 
       def asset_timestamp
-        env.timestamp.strftime("%Y%m%d%H%M.%S")
+        env.timestamp.strftime('%Y%m%d%H%M.%S')
       end
 
       def linked_dirs(parent)

--- a/lib/capistrano/dsl/stages.rb
+++ b/lib/capistrano/dsl/stages.rb
@@ -2,11 +2,11 @@ module Capistrano
   module DSL
     module Stages
       def stages
-        Dir[stage_definitions].map { |f| File.basename(f, ".rb") }
+        Dir[stage_definitions].map { |f| File.basename(f, '.rb') }
       end
 
       def stage_definitions
-        stage_config_path.join("*.rb")
+        stage_config_path.join('*.rb')
       end
 
       def stage_set?

--- a/lib/capistrano/dsl/task_enhancements.rb
+++ b/lib/capistrano/dsl/task_enhancements.rb
@@ -1,4 +1,4 @@
-require "capistrano/upload_task"
+require 'capistrano/upload_task'
 
 module Capistrano
   module TaskEnhancements
@@ -53,7 +53,7 @@ module Capistrano
 
     def exit_deploy_because_of_exception(ex)
       warn t(:deploy_failed, ex: ex.message)
-      invoke "deploy:failed"
+      invoke 'deploy:failed'
       exit(false)
     end
 

--- a/lib/capistrano/framework.rb
+++ b/lib/capistrano/framework.rb
@@ -1,2 +1,2 @@
-load File.expand_path("../tasks/framework.rake", __FILE__)
-require "capistrano/install"
+load File.expand_path('../tasks/framework.rake', __FILE__)
+require 'capistrano/install'

--- a/lib/capistrano/git.rb
+++ b/lib/capistrano/git.rb
@@ -1,6 +1,6 @@
-load File.expand_path("../tasks/git.rake", __FILE__)
+load File.expand_path('../tasks/git.rake', __FILE__)
 
-require "capistrano/scm"
+require 'capistrano/scm'
 
 class Capistrano::Git < Capistrano::SCM
   # execute git with argument in the context
@@ -22,28 +22,28 @@ class Capistrano::Git < Capistrano::SCM
 
     def clone
       if (depth = fetch(:git_shallow_clone))
-        git :clone, "--mirror", "--depth", depth, "--no-single-branch", repo_url, repo_path
+        git :clone, '--mirror', '--depth', depth, '--no-single-branch', repo_url, repo_path
       else
-        git :clone, "--mirror", repo_url, repo_path
+        git :clone, '--mirror', repo_url, repo_path
       end
     end
 
     def update
       # Note: Requires git version 1.9 or greater
       if (depth = fetch(:git_shallow_clone))
-        git :fetch, "--depth", depth, "origin", fetch(:branch)
+        git :fetch, '--depth', depth, 'origin', fetch(:branch)
       else
-        git :remote, :update, "--prune"
+        git :remote, :update, '--prune'
       end
     end
 
     def release
       if (tree = fetch(:repo_tree))
         tree = tree.slice %r#^/?(.*?)/?$#, 1
-        components = tree.split("/").size
+        components = tree.split('/').size
         git :archive, fetch(:branch), tree, "| tar -x --strip-components #{components} -f - -C", release_path
       else
-        git :archive, fetch(:branch), "| tar -x -f - -C", release_path
+        git :archive, fetch(:branch), '| tar -x -f - -C', release_path
       end
     end
 

--- a/lib/capistrano/hg.rb
+++ b/lib/capistrano/hg.rb
@@ -1,6 +1,6 @@
-load File.expand_path("../tasks/hg.rake", __FILE__)
+load File.expand_path('../tasks/hg.rake', __FILE__)
 
-require "capistrano/scm"
+require 'capistrano/scm'
 
 class Capistrano::Hg < Capistrano::SCM
   # execute hg in context with arguments
@@ -15,24 +15,24 @@ class Capistrano::Hg < Capistrano::SCM
     end
 
     def check
-      hg "id", repo_url
+      hg 'id', repo_url
     end
 
     def clone
-      hg "clone", "--noupdate", repo_url, repo_path
+      hg 'clone', '--noupdate', repo_url, repo_path
     end
 
     def update
-      hg "pull"
+      hg 'pull'
     end
 
     def release
       if (tree = fetch(:repo_tree))
         tree = tree.slice %r#^/?(.*?)/?$#, 1
-        components = tree.split("/").size
-        hg "archive --type tgz -p . -I", tree, "--rev", fetch(:branch), "| tar -x --strip-components #{components} -f - -C", release_path
+        components = tree.split('/').size
+        hg 'archive --type tgz -p . -I', tree, '--rev', fetch(:branch), "| tar -x --strip-components #{components} -f - -C", release_path
       else
-        hg "archive", release_path, "--rev", fetch(:branch)
+        hg 'archive', release_path, '--rev', fetch(:branch)
       end
     end
 

--- a/lib/capistrano/i18n.rb
+++ b/lib/capistrano/i18n.rb
@@ -1,32 +1,32 @@
-require "i18n"
+require 'i18n'
 
 en = {
-  starting: "Starting",
-  capified: "Capified",
-  start: "Start",
-  update: "Update",
-  finalize: "Finalise",
-  finishing: "Finishing",
-  finished: "Finished",
-  stage_not_set: "Stage not set, please call something such as `cap production deploy`, where production is a stage you have defined.",
-  written_file: "create %{file}",
-  question: "Please enter %{key} (%{default_value}): ",
-  keeping_releases: "Keeping %{keep_releases} of %{releases} deployed releases on %{host}",
-  no_old_releases: "No old releases (keeping newest %{keep_releases}) on %{host}",
-  linked_file_does_not_exist: "linked file %{file} does not exist on %{host}",
-  cannot_rollback: "There are no older releases to rollback to",
-  mirror_exists: "The repository mirror is at %{at}",
-  revision_log_message: "Branch %{branch} (at %{sha}) deployed as release %{release} by %{user}",
-  rollback_log_message: "%{user} rolled back to release %{release}",
-  deploy_failed: "The deploy has failed with an error: %{ex}",
+  starting: 'Starting',
+  capified: 'Capified',
+  start: 'Start',
+  update: 'Update',
+  finalize: 'Finalise',
+  finishing: 'Finishing',
+  finished: 'Finished',
+  stage_not_set: 'Stage not set, please call something such as `cap production deploy`, where production is a stage you have defined.',
+  written_file: 'create %{file}',
+  question: 'Please enter %{key} (%{default_value}): ',
+  keeping_releases: 'Keeping %{keep_releases} of %{releases} deployed releases on %{host}',
+  no_old_releases: 'No old releases (keeping newest %{keep_releases}) on %{host}',
+  linked_file_does_not_exist: 'linked file %{file} does not exist on %{host}',
+  cannot_rollback: 'There are no older releases to rollback to',
+  mirror_exists: 'The repository mirror is at %{at}',
+  revision_log_message: 'Branch %{branch} (at %{sha}) deployed as release %{release} by %{user}',
+  rollback_log_message: '%{user} rolled back to release %{release}',
+  deploy_failed: 'The deploy has failed with an error: %{ex}',
   console: {
-    welcome: "capistrano console - enter command to execute on %{stage}",
-    bye: "bye"
+    welcome: 'capistrano console - enter command to execute on %{stage}',
+    bye: 'bye'
   },
   error: {
     user: {
-      does_not_exist: "User %{user} does not exists",
-      cannot_switch: "Cannot switch to user %{user}"
+      does_not_exist: 'User %{user} does not exists',
+      cannot_switch: 'Cannot switch to user %{user}'
     }
   }
 }

--- a/lib/capistrano/install.rb
+++ b/lib/capistrano/install.rb
@@ -1,1 +1,1 @@
-load File.expand_path(File.join(File.dirname(__FILE__), "tasks/install.rake"))
+load File.expand_path(File.join(File.dirname(__FILE__), 'tasks/install.rake'))

--- a/lib/capistrano/plugin.rb
+++ b/lib/capistrano/plugin.rb
@@ -1,5 +1,5 @@
-require "capistrano/all"
-require "rake/tasklib"
+require 'capistrano/all'
+require 'rake/tasklib'
 
 # IMPORTANT: The Capistrano::Plugin system is not yet considered a stable,
 # public API, and is subject to change without notice. Eventually it will be
@@ -44,7 +44,7 @@ class Capistrano::Plugin < Rake::TaskLib
   def initialize(hooks: true)
     define_tasks
     register_hooks if hooks
-    task "load:defaults" do
+    task 'load:defaults' do
       set_defaults
     end
   end

--- a/lib/capistrano/scm.rb
+++ b/lib/capistrano/scm.rb
@@ -58,7 +58,7 @@ module Capistrano
     # @return [Boolean]
     #
     def test
-      raise NotImplementedError, "Your SCM strategy module should provide a #test method"
+      raise NotImplementedError, 'Your SCM strategy module should provide a #test method'
     end
 
     # @abstract
@@ -69,7 +69,7 @@ module Capistrano
     # @return [Boolean]
     #
     def check
-      raise NotImplementedError, "Your SCM strategy module should provide a #check method"
+      raise NotImplementedError, 'Your SCM strategy module should provide a #check method'
     end
 
     # @abstract
@@ -79,7 +79,7 @@ module Capistrano
     # @return void
     #
     def clone
-      raise NotImplementedError, "Your SCM strategy module should provide a #clone method"
+      raise NotImplementedError, 'Your SCM strategy module should provide a #clone method'
     end
 
     # @abstract
@@ -89,7 +89,7 @@ module Capistrano
     # @return void
     #
     def update
-      raise NotImplementedError, "Your SCM strategy module should provide a #update method"
+      raise NotImplementedError, 'Your SCM strategy module should provide a #update method'
     end
 
     # @abstract
@@ -99,7 +99,7 @@ module Capistrano
     # @return void
     #
     def release
-      raise NotImplementedError, "Your SCM strategy module should provide a #release method"
+      raise NotImplementedError, 'Your SCM strategy module should provide a #release method'
     end
 
     # @abstract
@@ -109,7 +109,7 @@ module Capistrano
     # @return void
     #
     def fetch_revision
-      raise NotImplementedError, "Your SCM strategy module should provide a #fetch_revision method"
+      raise NotImplementedError, 'Your SCM strategy module should provide a #fetch_revision method'
     end
   end
 end

--- a/lib/capistrano/setup.rb
+++ b/lib/capistrano/setup.rb
@@ -1,13 +1,13 @@
-require "capistrano/immutable_task"
+require 'capistrano/immutable_task'
 include Capistrano::DSL
 
 namespace :load do
   task :defaults do
-    load "capistrano/defaults.rb"
+    load 'capistrano/defaults.rb'
   end
 end
 
-require "airbrussh/capistrano"
+require 'airbrussh/capistrano'
 # We don't need to show the "using Airbrussh" banner announcement since
 # Airbrussh is now the built-in formatter. Also enable command output by
 # default; hiding the output might be confusing to users new to Capistrano.
@@ -20,8 +20,8 @@ stages.each do |stage|
   Rake::Task.define_task(stage) do
     set(:stage, stage.to_sym)
 
-    invoke "load:defaults"
-    Rake.application["load:defaults"].extend(Capistrano::ImmutableTask)
+    invoke 'load:defaults'
+    Rake.application['load:defaults'].extend(Capistrano::ImmutableTask)
     load deploy_config_path
     load stage_config_path.join("#{stage}.rb")
     load "capistrano/#{fetch(:scm)}.rb"
@@ -30,4 +30,4 @@ stages.each do |stage|
   end
 end
 
-require "capistrano/dotfile"
+require 'capistrano/dotfile'

--- a/lib/capistrano/svn.rb
+++ b/lib/capistrano/svn.rb
@@ -1,6 +1,6 @@
-load File.expand_path("../tasks/svn.rake", __FILE__)
+load File.expand_path('../tasks/svn.rake', __FILE__)
 
-require "capistrano/scm"
+require 'capistrano/scm'
 
 class Capistrano::Svn < Capistrano::SCM
   # execute svn in context with arguments
@@ -18,8 +18,8 @@ class Capistrano::Svn < Capistrano::SCM
     end
 
     def check
-      svn_username = fetch(:svn_username) ? "--username #{fetch(:svn_username)}" : ""
-      svn_password = fetch(:svn_password) ? "--password #{fetch(:svn_password)}" : ""
+      svn_username = fetch(:svn_username) ? "--username #{fetch(:svn_username)}" : ''
+      svn_password = fetch(:svn_password) ? "--password #{fetch(:svn_password)}" : ''
       test! :svn, :info, repo_url, svn_username, svn_password
     end
 
@@ -32,7 +32,7 @@ class Capistrano::Svn < Capistrano::SCM
     end
 
     def release
-      svn :export, "--force", ".", release_path
+      svn :export, '--force', '.', release_path
     end
 
     def fetch_revision

--- a/lib/capistrano/tasks/console.rake
+++ b/lib/capistrano/tasks/console.rake
@@ -1,16 +1,20 @@
-desc "Execute remote commands"
+desc 'Execute remote commands'
 task :console do
   stage = fetch(:stage)
-  puts I18n.t("console.welcome", scope: :capistrano, stage: stage)
+  puts I18n.t('console.welcome', scope: :capistrano, stage: stage)
   loop do
     print "#{stage}> "
 
-    command = (input = $stdin.gets) ? input.chomp : "exit"
+    command = if (input = $stdin.gets)
+                input.chomp
+              else
+                'exit'
+              end
 
     next if command.empty?
 
     if %w{quit exit q}.include? command
-      puts t("console.bye")
+      puts t('console.bye')
       break
     else
       begin

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -1,13 +1,13 @@
 namespace :deploy do
   task :starting do
-    invoke "deploy:print_config_variables" if fetch(:print_config_variables, false)
-    invoke "deploy:check"
-    invoke "deploy:set_previous_revision"
+    invoke 'deploy:print_config_variables' if fetch(:print_config_variables, false)
+    invoke 'deploy:check'
+    invoke 'deploy:set_previous_revision'
   end
 
   task :print_config_variables do
     puts
-    puts "------- Printing current config variables -------"
+    puts '------- Printing current config variables -------'
     env.keys.each do |config_variable_key|
       if is_question?(config_variable_key)
         puts "#{config_variable_key.inspect} => Question (awaits user input on next fetch(#{config_variable_key.inspect}))"
@@ -17,7 +17,7 @@ namespace :deploy do
     end
 
     puts
-    puts "------- Printing current config variables of SSHKit mechanism -------"
+    puts '------- Printing current config variables of SSHKit mechanism -------'
     puts env.backend.config.inspect
     # puts env.backend.config.backend.config.ssh_options.inspect
     # puts env.backend.config.command_map.defaults.inspect
@@ -27,64 +27,64 @@ namespace :deploy do
 
   task updating: :new_release_path do
     invoke "#{scm}:create_release"
-    invoke "deploy:set_current_revision"
-    invoke "deploy:symlink:shared"
+    invoke 'deploy:set_current_revision'
+    invoke 'deploy:symlink:shared'
   end
 
   task :reverting do
-    invoke "deploy:revert_release"
+    invoke 'deploy:revert_release'
   end
 
   task :publishing do
-    invoke "deploy:symlink:release"
+    invoke 'deploy:symlink:release'
   end
 
   task :finishing do
-    invoke "deploy:cleanup"
+    invoke 'deploy:cleanup'
   end
 
   task :finishing_rollback do
-    invoke "deploy:cleanup_rollback"
+    invoke 'deploy:cleanup_rollback'
   end
 
   task :finished do
-    invoke "deploy:log_revision"
+    invoke 'deploy:log_revision'
   end
 
-  desc "Check required files and directories exist"
+  desc 'Check required files and directories exist'
   task :check do
     invoke "#{scm}:check"
-    invoke "deploy:check:directories"
-    invoke "deploy:check:linked_dirs"
-    invoke "deploy:check:make_linked_dirs"
-    invoke "deploy:check:linked_files"
+    invoke 'deploy:check:directories'
+    invoke 'deploy:check:linked_dirs'
+    invoke 'deploy:check:make_linked_dirs'
+    invoke 'deploy:check:linked_files'
   end
 
   namespace :check do
-    desc "Check shared and release directories exist"
+    desc 'Check shared and release directories exist'
     task :directories do
       on release_roles :all do
-        execute :mkdir, "-p", shared_path, releases_path
+        execute :mkdir, '-p', shared_path, releases_path
       end
     end
 
-    desc "Check directories to be linked exist in shared"
+    desc 'Check directories to be linked exist in shared'
     task :linked_dirs do
       next unless any? :linked_dirs
       on release_roles :all do
-        execute :mkdir, "-p", linked_dirs(shared_path)
+        execute :mkdir, '-p', linked_dirs(shared_path)
       end
     end
 
-    desc "Check directories of files to be linked exist in shared"
+    desc 'Check directories of files to be linked exist in shared'
     task :make_linked_dirs do
       next unless any? :linked_files
       on release_roles :all do |_host|
-        execute :mkdir, "-p", linked_file_dirs(shared_path)
+        execute :mkdir, '-p', linked_file_dirs(shared_path)
       end
     end
 
-    desc "Check files to be linked exist in shared"
+    desc 'Check files to be linked exist in shared'
     task :linked_files do
       next unless any? :linked_files
       on release_roles :all do |host|
@@ -99,66 +99,66 @@ namespace :deploy do
   end
 
   namespace :symlink do
-    desc "Symlink release to current"
+    desc 'Symlink release to current'
     task :release do
       on release_roles :all do
         tmp_current_path = release_path.parent.join(current_path.basename)
-        execute :ln, "-s", release_path, tmp_current_path
+        execute :ln, '-s', release_path, tmp_current_path
         execute :mv, tmp_current_path, current_path.parent
       end
     end
 
-    desc "Symlink files and directories from shared to release"
+    desc 'Symlink files and directories from shared to release'
     task :shared do
-      invoke "deploy:symlink:linked_files"
-      invoke "deploy:symlink:linked_dirs"
+      invoke 'deploy:symlink:linked_files'
+      invoke 'deploy:symlink:linked_dirs'
     end
 
-    desc "Symlink linked directories"
+    desc 'Symlink linked directories'
     task :linked_dirs do
       next unless any? :linked_dirs
       on release_roles :all do
-        execute :mkdir, "-p", linked_dir_parents(release_path)
+        execute :mkdir, '-p', linked_dir_parents(release_path)
 
         fetch(:linked_dirs).each do |dir|
           target = release_path.join(dir)
           source = shared_path.join(dir)
           next if test "[ -L #{target} ]"
-          execute :rm, "-rf", target if test "[ -d #{target} ]"
-          execute :ln, "-s", source, target
+          execute :rm, '-rf', target if test "[ -d #{target} ]"
+          execute :ln, '-s', source, target
         end
       end
     end
 
-    desc "Symlink linked files"
+    desc 'Symlink linked files'
     task :linked_files do
       next unless any? :linked_files
       on release_roles :all do
-        execute :mkdir, "-p", linked_file_dirs(release_path)
+        execute :mkdir, '-p', linked_file_dirs(release_path)
 
         fetch(:linked_files).each do |file|
           target = release_path.join(file)
           source = shared_path.join(file)
           next if test "[ -L #{target} ]"
           execute :rm, target if test "[ -f #{target} ]"
-          execute :ln, "-s", source, target
+          execute :ln, '-s', source, target
         end
       end
     end
   end
 
-  desc "Clean up old releases"
+  desc 'Clean up old releases'
   task :cleanup do
     on release_roles :all do |host|
-      releases = capture(:ls, "-xtr", releases_path).split
+      releases = capture(:ls, '-xtr', releases_path).split
       if releases.count >= fetch(:keep_releases)
         info t(:keeping_releases, host: host.to_s, keep_releases: fetch(:keep_releases), releases: releases.count)
         directories = (releases - releases.last(fetch(:keep_releases)))
         if directories.any?
           directories_str = directories.map do |release|
             releases_path.join(release)
-          end.join(" ")
-          execute :rm, "-rf", directories_str
+          end.join(' ')
+          execute :rm, '-rf', directories_str
         else
           info t(:no_old_releases, host: host.to_s, keep_releases: fetch(:keep_releases))
         end
@@ -166,23 +166,23 @@ namespace :deploy do
     end
   end
 
-  desc "Remove and archive rolled-back release."
+  desc 'Remove and archive rolled-back release.'
   task :cleanup_rollback do
     on release_roles(:all) do
-      last_release = capture(:ls, "-xt", releases_path).split.first
+      last_release = capture(:ls, '-xt', releases_path).split.first
       last_release_path = releases_path.join(last_release)
       if test "[ `readlink #{current_path}` != #{last_release_path} ]"
-        execute :tar, "-czf",
+        execute :tar, '-czf',
                 deploy_path.join("rolled-back-release-#{last_release}.tar.gz"),
                 last_release_path
-        execute :rm, "-rf", last_release_path
+        execute :rm, '-rf', last_release_path
       else
-        debug "Last release is the current release, skip cleanup_rollback."
+        debug 'Last release is the current release, skip cleanup_rollback.'
       end
     end
   end
 
-  desc "Log details of the deploy"
+  desc 'Log details of the deploy'
   task :log_revision do
     on release_roles(:all) do
       within releases_path do
@@ -191,7 +191,7 @@ namespace :deploy do
     end
   end
 
-  desc "Revert to previous release timestamp"
+  desc 'Revert to previous release timestamp'
   task revert_release: :rollback_release_path do
     on release_roles(:all) do
       set(:revision_log_message, rollback_log_message)
@@ -204,7 +204,7 @@ namespace :deploy do
 
   task :rollback_release_path do
     on release_roles(:all) do
-      releases = capture(:ls, "-xt", releases_path).split
+      releases = capture(:ls, '-xt', releases_path).split
       if releases.count < 2
         error t(:cannot_rollback)
         exit 1
@@ -215,7 +215,7 @@ namespace :deploy do
     end
   end
 
-  desc "Place a REVISION file with the current revision SHA in the current release path"
+  desc 'Place a REVISION file with the current revision SHA in the current release path'
   task :set_current_revision  do
     invoke "#{scm}:set_current_revision"
     on release_roles(:all) do
@@ -227,9 +227,9 @@ namespace :deploy do
 
   task :set_previous_revision do
     on release_roles(:all) do
-      target = release_path.join("REVISION")
+      target = release_path.join('REVISION')
       if test "[ -f #{target} ]"
-        set(:previous_revision, capture(:cat, target, "2>/dev/null"))
+        set(:previous_revision, capture(:cat, target, '2>/dev/null'))
       end
     end
   end

--- a/lib/capistrano/tasks/framework.rake
+++ b/lib/capistrano/tasks/framework.rake
@@ -1,49 +1,49 @@
 namespace :deploy do
-  desc "Start a deployment, make sure server(s) ready."
+  desc 'Start a deployment, make sure server(s) ready.'
   task :starting do
   end
 
-  desc "Started"
+  desc 'Started'
   task :started do
   end
 
-  desc "Update server(s) by setting up a new release."
+  desc 'Update server(s) by setting up a new release.'
   task :updating do
   end
 
-  desc "Updated"
+  desc 'Updated'
   task :updated do
   end
 
-  desc "Revert server(s) to previous release."
+  desc 'Revert server(s) to previous release.'
   task :reverting do
   end
 
-  desc "Reverted"
+  desc 'Reverted'
   task :reverted do
   end
 
-  desc "Publish the release."
+  desc 'Publish the release.'
   task :publishing do
   end
 
-  desc "Published"
+  desc 'Published'
   task :published do
   end
 
-  desc "Finish the deployment, clean up server(s)."
+  desc 'Finish the deployment, clean up server(s).'
   task :finishing do
   end
 
-  desc "Finish the rollback, clean up server(s)."
+  desc 'Finish the rollback, clean up server(s).'
   task :finishing_rollback do
   end
 
-  desc "Finished"
+  desc 'Finished'
   task :finished do
   end
 
-  desc "Rollback to previous release."
+  desc 'Rollback to previous release.'
   task :rollback do
     %w{ starting started
         reverting reverted
@@ -54,7 +54,7 @@ namespace :deploy do
   end
 end
 
-desc "Deploy a new release."
+desc 'Deploy a new release.'
 task :deploy do
   set(:deploying, true)
   %w{ starting started

--- a/lib/capistrano/tasks/git.rake
+++ b/lib/capistrano/tasks/git.rake
@@ -3,23 +3,23 @@ namespace :git do
     @strategy ||= Capistrano::Git.new(self, fetch(:git_strategy, Capistrano::Git::DefaultStrategy))
   end
 
-  set :git_environmental_variables, lambda {
+  set :git_environmental_variables, ->() {
     {
-      git_askpass: "/bin/echo",
+      git_askpass: '/bin/echo',
       git_ssh: "#{fetch(:tmp_dir)}/#{fetch(:application)}/git-ssh.sh"
     }
   }
 
-  desc "Upload the git wrapper script, this script guarantees that we can script git without getting an interactive prompt"
+  desc 'Upload the git wrapper script, this script guarantees that we can script git without getting an interactive prompt'
   task :wrapper do
     on release_roles :all do
-      execute :mkdir, "-p", "#{fetch(:tmp_dir)}/#{fetch(:application)}/"
+      execute :mkdir, '-p', "#{fetch(:tmp_dir)}/#{fetch(:application)}/"
       upload! StringIO.new("#!/bin/sh -e\nexec /usr/bin/ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no \"$@\"\n"), "#{fetch(:tmp_dir)}/#{fetch(:application)}/git-ssh.sh"
-      execute :chmod, "+rx", "#{fetch(:tmp_dir)}/#{fetch(:application)}/git-ssh.sh"
+      execute :chmod, '+rx', "#{fetch(:tmp_dir)}/#{fetch(:application)}/git-ssh.sh"
     end
   end
 
-  desc "Check that the repository is reachable"
+  desc 'Check that the repository is reachable'
   task check: :'git:wrapper' do
     fetch(:branch)
     on release_roles :all do
@@ -29,7 +29,7 @@ namespace :git do
     end
   end
 
-  desc "Clone the repo to the cache"
+  desc 'Clone the repo to the cache'
   task clone: :'git:wrapper' do
     on release_roles :all do
       if strategy.test
@@ -44,7 +44,7 @@ namespace :git do
     end
   end
 
-  desc "Update the repo mirror to reflect the origin state"
+  desc 'Update the repo mirror to reflect the origin state'
   task update: :'git:clone' do
     on release_roles :all do
       within repo_path do
@@ -55,19 +55,19 @@ namespace :git do
     end
   end
 
-  desc "Copy repo to releases"
+  desc 'Copy repo to releases'
   task create_release: :'git:update' do
     on release_roles :all do
       with fetch(:git_environmental_variables) do
         within repo_path do
-          execute :mkdir, "-p", release_path
+          execute :mkdir, '-p', release_path
           strategy.release
         end
       end
     end
   end
 
-  desc "Determine the revision that will be deployed"
+  desc 'Determine the revision that will be deployed'
   task :set_current_revision do
     on release_roles :all do
       within repo_path do

--- a/lib/capistrano/tasks/git.rake
+++ b/lib/capistrano/tasks/git.rake
@@ -3,12 +3,12 @@ namespace :git do
     @strategy ||= Capistrano::Git.new(self, fetch(:git_strategy, Capistrano::Git::DefaultStrategy))
   end
 
-  set :git_environmental_variables, ->() {
+  set :git_environmental_variables, lambda do
     {
       git_askpass: '/bin/echo',
       git_ssh: "#{fetch(:tmp_dir)}/#{fetch(:application)}/git-ssh.sh"
     }
-  }
+  end
 
   desc 'Upload the git wrapper script, this script guarantees that we can script git without getting an interactive prompt'
   task :wrapper do

--- a/lib/capistrano/tasks/hg.rake
+++ b/lib/capistrano/tasks/hg.rake
@@ -3,14 +3,14 @@ namespace :hg do
     @strategy ||= Capistrano::Hg.new(self, fetch(:hg_strategy, Capistrano::Hg::DefaultStrategy))
   end
 
-  desc "Check that the repo is reachable"
+  desc 'Check that the repo is reachable'
   task :check do
     on release_roles :all do
       strategy.check
     end
   end
 
-  desc "Clone the repo to the cache"
+  desc 'Clone the repo to the cache'
   task :clone do
     on release_roles :all do
       if strategy.test
@@ -23,7 +23,7 @@ namespace :hg do
     end
   end
 
-  desc "Pull changes from the remote repo"
+  desc 'Pull changes from the remote repo'
   task update: :'hg:clone' do
     on release_roles :all do
       within repo_path do
@@ -32,7 +32,7 @@ namespace :hg do
     end
   end
 
-  desc "Copy repo to releases"
+  desc 'Copy repo to releases'
   task create_release: :'hg:update' do
     on release_roles :all do
       within repo_path do
@@ -41,7 +41,7 @@ namespace :hg do
     end
   end
 
-  desc "Determine the revision that will be deployed"
+  desc 'Determine the revision that will be deployed'
   task :set_current_revision do
     on release_roles :all do
       within repo_path do

--- a/lib/capistrano/tasks/install.rake
+++ b/lib/capistrano/tasks/install.rake
@@ -1,27 +1,27 @@
-require "erb"
-require "pathname"
-desc "Install Capistrano, cap install STAGES=staging,production"
+require 'erb'
+require 'pathname'
+desc 'Install Capistrano, cap install STAGES=staging,production'
 task :install do
-  envs = ENV["STAGES"] || "staging,production"
+  envs = ENV['STAGES'] || 'staging,production'
 
-  tasks_dir = Pathname.new("lib/capistrano/tasks")
-  config_dir = Pathname.new("config")
-  deploy_dir = config_dir.join("deploy")
+  tasks_dir = Pathname.new('lib/capistrano/tasks')
+  config_dir = Pathname.new('config')
+  deploy_dir = config_dir.join('deploy')
 
-  deploy_rb = File.expand_path("../../templates/deploy.rb.erb", __FILE__)
-  stage_rb = File.expand_path("../../templates/stage.rb.erb", __FILE__)
-  capfile = File.expand_path("../../templates/Capfile", __FILE__)
+  deploy_rb = File.expand_path('../../templates/deploy.rb.erb', __FILE__)
+  stage_rb = File.expand_path('../../templates/stage.rb.erb', __FILE__)
+  capfile = File.expand_path('../../templates/Capfile', __FILE__)
 
   mkdir_p deploy_dir
 
-  entries = [{ template: deploy_rb, file: config_dir.join("deploy.rb") }]
-  entries += envs.split(",").map { |stage| { template: stage_rb, file: deploy_dir.join("#{stage}.rb") } }
+  entries = [{ template: deploy_rb, file: config_dir.join('deploy.rb') }]
+  entries += envs.split(',').map { |stage| { template: stage_rb, file: deploy_dir.join("#{stage}.rb") } }
 
   entries.each do |entry|
     if File.exist?(entry[:file])
       warn "[skip] #{entry[:file]} already exists"
     else
-      File.open(entry[:file], "w+") do |f|
+      File.open(entry[:file], 'w+') do |f|
         f.write(ERB.new(File.read(entry[:template])).result(binding))
         puts I18n.t(:written_file, scope: :capistrano, file: entry[:file])
       end
@@ -30,11 +30,11 @@ task :install do
 
   mkdir_p tasks_dir
 
-  if File.exist?("Capfile")
-    warn "[skip] Capfile already exists"
+  if File.exist?('Capfile')
+    warn '[skip] Capfile already exists'
   else
-    FileUtils.cp(capfile, "Capfile")
-    puts I18n.t(:written_file, scope: :capistrano, file: "Capfile")
+    FileUtils.cp(capfile, 'Capfile')
+    puts I18n.t(:written_file, scope: :capistrano, file: 'Capfile')
   end
 
   puts I18n.t :capified, scope: :capistrano

--- a/lib/capistrano/tasks/svn.rake
+++ b/lib/capistrano/tasks/svn.rake
@@ -3,14 +3,14 @@ namespace :svn do
     @strategy ||= Capistrano::Svn.new(self, fetch(:svn_strategy, Capistrano::Svn::DefaultStrategy))
   end
 
-  desc "Check that the repo is reachable"
+  desc 'Check that the repo is reachable'
   task :check do
     on release_roles :all do
       strategy.check
     end
   end
 
-  desc "Clone the repo to the cache"
+  desc 'Clone the repo to the cache'
   task :clone do
     on release_roles :all do
       if strategy.test
@@ -23,7 +23,7 @@ namespace :svn do
     end
   end
 
-  desc "Pull changes from the remote repo"
+  desc 'Pull changes from the remote repo'
   task update: :'svn:clone' do
     on release_roles :all do
       within repo_path do
@@ -32,7 +32,7 @@ namespace :svn do
     end
   end
 
-  desc "Copy repo to releases"
+  desc 'Copy repo to releases'
   task create_release: :'svn:update' do
     on release_roles :all do
       within repo_path do
@@ -41,7 +41,7 @@ namespace :svn do
     end
   end
 
-  desc "Determine the revision that will be deployed"
+  desc 'Determine the revision that will be deployed'
   task :set_current_revision do
     on release_roles :all do
       within repo_path do

--- a/lib/capistrano/templates/Capfile
+++ b/lib/capistrano/templates/Capfile
@@ -1,8 +1,8 @@
 # Load DSL and set up stages
-require "capistrano/setup"
+require 'capistrano/setup'
 
 # Include default deployment tasks
-require "capistrano/deploy"
+require 'capistrano/deploy'
 
 # Include tasks from other gems included in your Gemfile
 #
@@ -24,4 +24,4 @@ require "capistrano/deploy"
 # require 'capistrano/passenger'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
-Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }
+Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/lib/capistrano/upload_task.rb
+++ b/lib/capistrano/upload_task.rb
@@ -1,4 +1,4 @@
-require "rake/file_creation_task"
+require 'rake/file_creation_task'
 
 module Capistrano
   class UploadTask < Rake::FileCreationTask

--- a/lib/capistrano/version.rb
+++ b/lib/capistrano/version.rb
@@ -1,3 +1,3 @@
 module Capistrano
-  VERSION = "3.4.0".freeze
+  VERSION = '3.4.0'.freeze
 end

--- a/lib/capistrano/version_validator.rb
+++ b/lib/capistrano/version_validator.rb
@@ -25,11 +25,11 @@ module Capistrano
     end
 
     def available
-      Gem::Dependency.new("cap", version)
+      Gem::Dependency.new('cap', version)
     end
 
     def requested
-      Gem::Dependency.new("cap", current_version)
+      Gem::Dependency.new('cap', current_version)
     end
   end
 end

--- a/spec/integration/dsl_spec.rb
+++ b/spec/integration/dsl_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe Capistrano::DSL do
   let(:dsl) { Class.new.extend Capistrano::DSL }
@@ -7,171 +7,171 @@ describe Capistrano::DSL do
     Capistrano::Configuration.reset!
   end
 
-  describe "setting and fetching hosts" do
-    describe "when defining a host using the `server` syntax" do
+  describe 'setting and fetching hosts' do
+    describe 'when defining a host using the `server` syntax' do
       before do
-        dsl.server "example1.com", roles: %w{web}, active: true
-        dsl.server "example2.com", roles: %w{web}
-        dsl.server "example3.com", roles: %w{app web}, active: true
-        dsl.server "example4.com", roles: %w{app}, primary: true
-        dsl.server "example5.com", roles: %w{db}, no_release: true, active: true
+        dsl.server 'example1.com', roles: %w{web}, active: true
+        dsl.server 'example2.com', roles: %w{web}
+        dsl.server 'example3.com', roles: %w{app web}, active: true
+        dsl.server 'example4.com', roles: %w{app}, primary: true
+        dsl.server 'example5.com', roles: %w{db}, no_release: true, active: true
       end
 
-      describe "fetching all servers" do
+      describe 'fetching all servers' do
         subject { dsl.roles(:all) }
 
-        it "returns all servers" do
+        it 'returns all servers' do
           expect(subject.map(&:hostname)).to eq %w{example1.com example2.com example3.com example4.com example5.com}
         end
       end
 
-      describe "fetching all release servers" do
-        context "with no additional options" do
+      describe 'fetching all release servers' do
+        context 'with no additional options' do
           subject { dsl.release_roles(:all) }
 
-          it "returns all release servers" do
+          it 'returns all release servers' do
             expect(subject.map(&:hostname)).to eq %w{example1.com example2.com example3.com example4.com}
           end
         end
 
-        context "with property filter options" do
+        context 'with property filter options' do
           subject { dsl.release_roles(:all, filter: :active) }
 
-          it "returns all release servers that match the property filter" do
+          it 'returns all release servers that match the property filter' do
             expect(subject.map(&:hostname)).to eq %w{example1.com example3.com}
           end
         end
       end
 
-      describe "fetching servers by multiple roles" do
-        it "does not confuse the last role with options" do
+      describe 'fetching servers by multiple roles' do
+        it 'does not confuse the last role with options' do
           expect(dsl.roles(:app, :web).count).to eq 4
           expect(dsl.roles(:app, :web, filter: :active).count).to eq 2
         end
       end
 
-      describe "fetching servers by role" do
+      describe 'fetching servers by role' do
         subject { dsl.roles(:app) }
 
-        it "returns the servers" do
+        it 'returns the servers' do
           expect(subject.map(&:hostname)).to eq %w{example3.com example4.com}
         end
       end
 
-      describe "fetching servers by an array of roles" do
+      describe 'fetching servers by an array of roles' do
         subject { dsl.roles([:app]) }
 
-        it "returns the servers" do
+        it 'returns the servers' do
           expect(subject.map(&:hostname)).to eq %w{example3.com example4.com}
         end
       end
 
-      describe "fetching filtered servers by role" do
+      describe 'fetching filtered servers by role' do
         subject { dsl.roles(:app, filter: :active) }
 
-        it "returns the servers" do
+        it 'returns the servers' do
           expect(subject.map(&:hostname)).to eq %w{example3.com}
         end
       end
 
-      describe "fetching selected servers by role" do
+      describe 'fetching selected servers by role' do
         subject { dsl.roles(:app, select: :active) }
 
-        it "returns the servers" do
+        it 'returns the servers' do
           expect(subject.map(&:hostname)).to eq %w{example3.com}
         end
       end
 
-      describe "fetching the primary server by role" do
-        context "when inferring primary status based on order" do
+      describe 'fetching the primary server by role' do
+        context 'when inferring primary status based on order' do
           subject { dsl.primary(:web) }
-          it "returns the servers" do
-            expect(subject.hostname).to eq "example1.com"
+          it 'returns the servers' do
+            expect(subject.hostname).to eq 'example1.com'
           end
         end
 
-        context "when the attribute `primary` is explicitly set" do
+        context 'when the attribute `primary` is explicitly set' do
           subject { dsl.primary(:app) }
-          it "returns the servers" do
-            expect(subject.hostname).to eq "example4.com"
+          it 'returns the servers' do
+            expect(subject.hostname).to eq 'example4.com'
           end
         end
       end
 
-      describe "setting an internal host filter" do
+      describe 'setting an internal host filter' do
         subject { dsl.roles(:app) }
-        it "is ignored" do
-          dsl.set :filter, host: "example3.com"
-          expect(subject.map(&:hostname)).to eq(["example3.com", "example4.com"])
+        it 'is ignored' do
+          dsl.set :filter, host: 'example3.com'
+          expect(subject.map(&:hostname)).to eq(['example3.com', 'example4.com'])
         end
       end
 
-      describe "setting an internal role filter" do
+      describe 'setting an internal role filter' do
         subject { dsl.roles(:app) }
-        it "ignores it" do
+        it 'ignores it' do
           dsl.set :filter, role: :web
-          expect(subject.map(&:hostname)).to eq(["example3.com", "example4.com"])
+          expect(subject.map(&:hostname)).to eq(['example3.com', 'example4.com'])
         end
       end
 
-      describe "setting an internal host and role filter" do
+      describe 'setting an internal host and role filter' do
         subject { dsl.roles(:app) }
-        it "ignores it" do
-          dsl.set :filter, role: :web, host: "example1.com"
-          expect(subject.map(&:hostname)).to eq(["example3.com", "example4.com"])
+        it 'ignores it' do
+          dsl.set :filter, role: :web, host: 'example1.com'
+          expect(subject.map(&:hostname)).to eq(['example3.com', 'example4.com'])
         end
       end
 
-      describe "setting an internal regexp host filter" do
+      describe 'setting an internal regexp host filter' do
         subject { dsl.roles(:all) }
-        it "is ignored" do
+        it 'is ignored' do
           dsl.set :filter, host: /1/
           expect(subject.map(&:hostname)).to eq(%w{example1.com example2.com example3.com example4.com example5.com})
         end
       end
 
-      describe "setting an internal hosts filter" do
+      describe 'setting an internal hosts filter' do
         subject { dsl.roles(:app) }
-        it "is ignored" do
-          dsl.set :filter, hosts: "example3.com"
-          expect(subject.map(&:hostname)).to eq(["example3.com", "example4.com"])
+        it 'is ignored' do
+          dsl.set :filter, hosts: 'example3.com'
+          expect(subject.map(&:hostname)).to eq(['example3.com', 'example4.com'])
         end
       end
 
-      describe "setting an internal roles filter" do
+      describe 'setting an internal roles filter' do
         subject { dsl.roles(:app) }
-        it "ignores it" do
+        it 'ignores it' do
           dsl.set :filter, roles: :web
-          expect(subject.map(&:hostname)).to eq(["example3.com", "example4.com"])
+          expect(subject.map(&:hostname)).to eq(['example3.com', 'example4.com'])
         end
       end
 
-      describe "setting an internal hosts and roles filter" do
+      describe 'setting an internal hosts and roles filter' do
         subject { dsl.roles(:app) }
-        it "ignores it" do
-          dsl.set :filter, roles: :web, hosts: "example1.com"
-          expect(subject.map(&:hostname)).to eq(["example3.com", "example4.com"])
+        it 'ignores it' do
+          dsl.set :filter, roles: :web, hosts: 'example1.com'
+          expect(subject.map(&:hostname)).to eq(['example3.com', 'example4.com'])
         end
       end
 
-      describe "setting an internal regexp hosts filter" do
+      describe 'setting an internal regexp hosts filter' do
         subject { dsl.roles(:all) }
-        it "is ignored" do
+        it 'is ignored' do
           dsl.set :filter, hosts: /1/
           expect(subject.map(&:hostname)).to eq(%w{example1.com example2.com example3.com example4.com example5.com})
         end
       end
     end
 
-    describe "when defining role with reserved name" do
-      it "fails with ArgumentError" do
+    describe 'when defining role with reserved name' do
+      it 'fails with ArgumentError' do
         expect do
           dsl.role :all, %w{example1.com}
-        end.to raise_error(ArgumentError, "all reserved name for role. Please choose another name")
+        end.to raise_error(ArgumentError, 'all reserved name for role. Please choose another name')
       end
     end
 
-    describe "when defining hosts using the `role` syntax" do
+    describe 'when defining hosts using the `role` syntax' do
       before do
         dsl.role :web, %w{example1.com example2.com example3.com}
         dsl.role :web, %w{example1.com}, active: true
@@ -181,237 +181,237 @@ describe Capistrano::DSL do
         dsl.role :db, %w{example5.com}, no_release: true
       end
 
-      describe "fetching all servers" do
+      describe 'fetching all servers' do
         subject { dsl.roles(:all) }
 
-        it "returns all servers" do
+        it 'returns all servers' do
           expect(subject.map(&:hostname)).to eq %w{example1.com example2.com example3.com example4.com example5.com}
         end
       end
 
-      describe "fetching all release servers" do
-        context "with no additional options" do
+      describe 'fetching all release servers' do
+        context 'with no additional options' do
           subject { dsl.release_roles(:all) }
 
-          it "returns all release servers" do
+          it 'returns all release servers' do
             expect(subject.map(&:hostname)).to eq %w{example1.com example2.com example3.com example4.com}
           end
         end
 
-        context "with filter options" do
+        context 'with filter options' do
           subject { dsl.release_roles(:all, filter: :active) }
 
-          it "returns all release servers that match the filter" do
+          it 'returns all release servers that match the filter' do
             expect(subject.map(&:hostname)).to eq %w{example1.com example3.com}
           end
         end
       end
 
-      describe "fetching servers by role" do
+      describe 'fetching servers by role' do
         subject { dsl.roles(:app) }
 
-        it "returns the servers" do
+        it 'returns the servers' do
           expect(subject.map(&:hostname)).to eq %w{example3.com example4.com}
         end
       end
 
-      describe "fetching servers by an array of roles" do
+      describe 'fetching servers by an array of roles' do
         subject { dsl.roles([:app]) }
 
-        it "returns the servers" do
+        it 'returns the servers' do
           expect(subject.map(&:hostname)).to eq %w{example3.com example4.com}
         end
       end
 
-      describe "fetching filtered servers by role" do
+      describe 'fetching filtered servers by role' do
         subject { dsl.roles(:app, filter: :active) }
 
-        it "returns the servers" do
+        it 'returns the servers' do
           expect(subject.map(&:hostname)).to eq %w{example3.com}
         end
       end
 
-      describe "fetching selected servers by role" do
+      describe 'fetching selected servers by role' do
         subject { dsl.roles(:app, select: :active) }
 
-        it "returns the servers" do
+        it 'returns the servers' do
           expect(subject.map(&:hostname)).to eq %w{example3.com}
         end
       end
 
-      describe "fetching the primary server by role" do
-        context "when inferring primary status based on order" do
+      describe 'fetching the primary server by role' do
+        context 'when inferring primary status based on order' do
           subject { dsl.primary(:web) }
-          it "returns the servers" do
-            expect(subject.hostname).to eq "example1.com"
+          it 'returns the servers' do
+            expect(subject.hostname).to eq 'example1.com'
           end
         end
 
-        context "when the attribute `primary` is explicity set" do
+        context 'when the attribute `primary` is explicity set' do
           subject { dsl.primary(:app) }
-          it "returns the servers" do
-            expect(subject.hostname).to eq "example4.com"
+          it 'returns the servers' do
+            expect(subject.hostname).to eq 'example4.com'
           end
         end
       end
     end
 
-    describe "when defining a host using a combination of the `server` and `role` syntax" do
+    describe 'when defining a host using a combination of the `server` and `role` syntax' do
       before do
-        dsl.server "db@example1.com:1234", roles: %w{db}, active: true
-        dsl.server "root@example1.com:1234", roles: %w{web}, active: true
-        dsl.server "example1.com:5678", roles: %w{web}, active: true
+        dsl.server 'db@example1.com:1234', roles: %w{db}, active: true
+        dsl.server 'root@example1.com:1234', roles: %w{web}, active: true
+        dsl.server 'example1.com:5678', roles: %w{web}, active: true
         dsl.role :app, %w{deployer@example1.com:1234}
         dsl.role :app, %w{example1.com:5678}
       end
 
-      describe "fetching all servers" do
-        it "creates one server per hostname, ignoring user combinations" do
+      describe 'fetching all servers' do
+        it 'creates one server per hostname, ignoring user combinations' do
           expect(dsl.roles(:all).size).to eq(2)
         end
       end
 
-      describe "fetching servers for a role" do
-        it "roles defined using the `server` syntax are included" do
+      describe 'fetching servers for a role' do
+        it 'roles defined using the `server` syntax are included' do
           as = dsl.roles(:web).map { |server| "#{server.user}@#{server.hostname}:#{server.port}" }
           expect(as.size).to eq(2)
-          expect(as[0]).to eq("deployer@example1.com:1234")
-          expect(as[1]).to eq("@example1.com:5678")
+          expect(as[0]).to eq('deployer@example1.com:1234')
+          expect(as[1]).to eq('@example1.com:5678')
         end
 
-        it "roles defined using the `role` syntax are included" do
+        it 'roles defined using the `role` syntax are included' do
           as = dsl.roles(:app).map { |server| "#{server.user}@#{server.hostname}:#{server.port}" }
           expect(as.size).to eq(2)
-          expect(as[0]).to eq("deployer@example1.com:1234")
-          expect(as[1]).to eq("@example1.com:5678")
+          expect(as[0]).to eq('deployer@example1.com:1234')
+          expect(as[1]).to eq('@example1.com:5678')
         end
       end
     end
 
-    describe "when setting user and port" do
+    describe 'when setting user and port' do
       subject { dsl.roles(:all).map { |server| "#{server.user}@#{server.hostname}:#{server.port}" }.first }
 
-      describe "using the :user property" do
-        it "takes precedence over in the host string" do
-          dsl.server "db@example1.com:1234", roles: %w{db}, active: true, user: "brian"
-          expect(subject).to eq("brian@example1.com:1234")
+      describe 'using the :user property' do
+        it 'takes precedence over in the host string' do
+          dsl.server 'db@example1.com:1234', roles: %w{db}, active: true, user: 'brian'
+          expect(subject).to eq('brian@example1.com:1234')
         end
       end
 
-      describe "using the :port property" do
-        it "takes precedence over in the host string" do
-          dsl.server "db@example1.com:9090", roles: %w{db}, active: true, port: 1234
-          expect(subject).to eq("db@example1.com:1234")
+      describe 'using the :port property' do
+        it 'takes precedence over in the host string' do
+          dsl.server 'db@example1.com:9090', roles: %w{db}, active: true, port: 1234
+          expect(subject).to eq('db@example1.com:1234')
         end
       end
     end
   end
 
-  describe "setting and fetching variables" do
+  describe 'setting and fetching variables' do
     before do
       dsl.set :scm, :git
     end
 
-    context "without a default" do
-      context "when the variables is defined" do
-        it "returns the variable" do
+    context 'without a default' do
+      context 'when the variables is defined' do
+        it 'returns the variable' do
           expect(dsl.fetch(:scm)).to eq :git
         end
       end
 
-      context "when the variables is undefined" do
-        it "returns nil" do
+      context 'when the variables is undefined' do
+        it 'returns nil' do
           expect(dsl.fetch(:source_control)).to be_nil
         end
       end
     end
 
-    context "with a default" do
-      context "when the variables is defined" do
-        it "returns the variable" do
+    context 'with a default' do
+      context 'when the variables is defined' do
+        it 'returns the variable' do
           expect(dsl.fetch(:scm, :svn)).to eq :git
         end
       end
 
-      context "when the variables is undefined" do
-        it "returns the default" do
+      context 'when the variables is undefined' do
+        it 'returns the default' do
           expect(dsl.fetch(:source_control, :svn)).to eq :svn
         end
       end
     end
 
-    context "with a block" do
-      context "when the variables is defined" do
-        it "returns the variable" do
+    context 'with a block' do
+      context 'when the variables is defined' do
+        it 'returns the variable' do
           expect(dsl.fetch(:scm) { :svn }).to eq :git
         end
       end
 
-      context "when the variables is undefined" do
-        it "calls the block" do
+      context 'when the variables is undefined' do
+        it 'calls the block' do
           expect(dsl.fetch(:source_control) { :svn }).to eq :svn
         end
       end
     end
   end
 
-  describe "asking for a variable" do
+  describe 'asking for a variable' do
     before do
       dsl.ask(:scm, :svn)
       $stdout.stubs(:print)
     end
 
-    context "variable is provided" do
+    context 'variable is provided' do
       before do
-        $stdin.expects(:gets).returns("git")
+        $stdin.expects(:gets).returns('git')
       end
 
-      it "sets the input as the variable" do
-        expect(dsl.fetch(:scm)).to eq "git"
+      it 'sets the input as the variable' do
+        expect(dsl.fetch(:scm)).to eq 'git'
       end
     end
 
-    context "variable is not provided" do
+    context 'variable is not provided' do
       before do
-        $stdin.expects(:gets).returns("")
+        $stdin.expects(:gets).returns('')
       end
 
-      it "sets the variable as the default" do
+      it 'sets the variable as the default' do
         expect(dsl.fetch(:scm)).to eq :svn
       end
     end
   end
 
-  describe "checking for presence" do
+  describe 'checking for presence' do
     subject { dsl.any? :linked_files }
 
     before do
       dsl.set(:linked_files, linked_files)
     end
 
-    context "variable is an non-empty array" do
+    context 'variable is an non-empty array' do
       let(:linked_files) { %w{1} }
 
       it { expect(subject).to be_truthy }
     end
 
-    context "variable is an empty array" do
+    context 'variable is an empty array' do
       let(:linked_files) { [] }
       it { expect(subject).to be_falsey }
     end
 
-    context "variable exists, is not an array" do
+    context 'variable exists, is not an array' do
       let(:linked_files) { stub }
       it { expect(subject).to be_truthy }
     end
 
-    context "variable is nil" do
+    context 'variable is nil' do
       let(:linked_files) { nil }
       it { expect(subject).to be_falsey }
     end
   end
 
-  describe "configuration SSHKit" do
+  describe 'configuration SSHKit' do
     let(:config) { SSHKit.config }
     let(:backend) { SSHKit.config.backend.config }
     let(:default_env) { { rails_env: :production } }
@@ -428,200 +428,200 @@ describe Capistrano::DSL do
       dsl.configure_backend
     end
 
-    it "sets the output" do
+    it 'sets the output' do
       expect(config.output).to be_a SSHKit::Formatter::Dot
     end
 
-    it "sets the output verbosity" do
+    it 'sets the output verbosity' do
       expect(config.output_verbosity).to eq 0
     end
 
-    it "sets the default env" do
+    it 'sets the default env' do
       expect(config.default_env).to eq default_env
     end
 
-    it "sets the backend pty" do
+    it 'sets the backend pty' do
       expect(backend.pty).to be_truthy
     end
 
-    it "sets the backend connection timeout" do
+    it 'sets the backend connection timeout' do
       expect(backend.connection_timeout).to eq 10
     end
 
-    it "sets the backend ssh_options" do
+    it 'sets the backend ssh_options' do
       expect(backend.ssh_options[:keys]).to eq %w(/home/user/.ssh/id_rsa)
       expect(backend.ssh_options[:forward_agent]).to eq false
       expect(backend.ssh_options[:auth_methods]).to eq %w(publickey password)
     end
   end
 
-  describe "on()" do
-    describe "when passed server objects" do
+  describe 'on()' do
+    describe 'when passed server objects' do
       before do
-        dsl.server "example1.com", roles: %w{web}, active: true
-        dsl.server "example2.com", roles: %w{web}
-        dsl.server "example3.com", roles: %w{app web}, active: true
-        dsl.server "example4.com", roles: %w{app}, primary: true
-        dsl.server "example5.com", roles: %w{db}, no_release: true
-        @coordinator = mock("coordinator")
+        dsl.server 'example1.com', roles: %w{web}, active: true
+        dsl.server 'example2.com', roles: %w{web}
+        dsl.server 'example3.com', roles: %w{app web}, active: true
+        dsl.server 'example4.com', roles: %w{app}, primary: true
+        dsl.server 'example5.com', roles: %w{db}, no_release: true
+        @coordinator = mock('coordinator')
         @coordinator.expects(:each).returns(nil)
-        ENV.delete "ROLES"
-        ENV.delete "HOSTS"
+        ENV.delete 'ROLES'
+        ENV.delete 'HOSTS'
       end
 
-      it "filters by role from the :filter variable" do
+      it 'filters by role from the :filter variable' do
         hosts = dsl.roles(:web)
         all = dsl.roles(:all)
         SSHKit::Coordinator.expects(:new).with(hosts).returns(@coordinator)
-        dsl.set :filter, role: "web"
+        dsl.set :filter, role: 'web'
         dsl.on(all)
       end
 
-      it "filters by host and role from the :filter variable" do
+      it 'filters by host and role from the :filter variable' do
         all = dsl.roles(:all)
         SSHKit::Coordinator.expects(:new).with([]).returns(@coordinator)
-        dsl.set :filter, role: "db", host: "example3.com"
+        dsl.set :filter, role: 'db', host: 'example3.com'
         dsl.on(all)
       end
 
-      it "filters by roles from the :filter variable" do
+      it 'filters by roles from the :filter variable' do
         hosts = dsl.roles(:web)
         all = dsl.roles(:all)
         SSHKit::Coordinator.expects(:new).with(hosts).returns(@coordinator)
-        dsl.set :filter, roles: "web"
+        dsl.set :filter, roles: 'web'
         dsl.on(all)
       end
 
-      it "filters by hosts and roles from the :filter variable" do
+      it 'filters by hosts and roles from the :filter variable' do
         all = dsl.roles(:all)
         SSHKit::Coordinator.expects(:new).with([]).returns(@coordinator)
-        dsl.set :filter, roles: "db", hosts: "example3.com"
+        dsl.set :filter, roles: 'db', hosts: 'example3.com'
         dsl.on(all)
       end
 
-      it "filters from ENV[ROLES]" do
+      it 'filters from ENV[ROLES]' do
         hosts = dsl.roles(:db)
         all = dsl.roles(:all)
         SSHKit::Coordinator.expects(:new).with(hosts).returns(@coordinator)
-        ENV["ROLES"] = "db"
+        ENV['ROLES'] = 'db'
         dsl.on(all)
       end
 
-      it "filters from ENV[HOSTS]" do
+      it 'filters from ENV[HOSTS]' do
         hosts = dsl.roles(:db)
         all = dsl.roles(:all)
         SSHKit::Coordinator.expects(:new).with(hosts).returns(@coordinator)
-        ENV["HOSTS"] = "example5.com"
+        ENV['HOSTS'] = 'example5.com'
         dsl.on(all)
       end
 
-      it "filters by ENV[HOSTS] && ENV[ROLES]" do
+      it 'filters by ENV[HOSTS] && ENV[ROLES]' do
         all = dsl.roles(:all)
         SSHKit::Coordinator.expects(:new).with([]).returns(@coordinator)
-        ENV["HOSTS"] = "example5.com"
-        ENV["ROLES"] = "web"
+        ENV['HOSTS'] = 'example5.com'
+        ENV['ROLES'] = 'web'
         dsl.on(all)
       end
     end
 
-    describe "when passed server literal names" do
+    describe 'when passed server literal names' do
       before do
-        ENV.delete "ROLES"
-        ENV.delete "HOSTS"
-        @coordinator = mock("coordinator")
+        ENV.delete 'ROLES'
+        ENV.delete 'HOSTS'
+        @coordinator = mock('coordinator')
         @coordinator.expects(:each).returns(nil)
       end
 
-      it "selects nothing when a role filter is present" do
-        dsl.set :filter, role: "web"
+      it 'selects nothing when a role filter is present' do
+        dsl.set :filter, role: 'web'
         SSHKit::Coordinator.expects(:new).with([]).returns(@coordinator)
-        dsl.on("my.server")
+        dsl.on('my.server')
       end
 
-      it "selects using the string when a host filter is present" do
-        dsl.set :filter, host: "server.local"
-        SSHKit::Coordinator.expects(:new).with(["server.local"]).returns(@coordinator)
-        dsl.on("server.local")
+      it 'selects using the string when a host filter is present' do
+        dsl.set :filter, host: 'server.local'
+        SSHKit::Coordinator.expects(:new).with(['server.local']).returns(@coordinator)
+        dsl.on('server.local')
       end
 
       it "doesn't select when a host filter is present that doesn't match" do
-        dsl.set :filter, host: "ruby.local"
+        dsl.set :filter, host: 'ruby.local'
         SSHKit::Coordinator.expects(:new).with([]).returns(@coordinator)
-        dsl.on("server.local")
+        dsl.on('server.local')
       end
 
-      it "selects nothing when a roles filter is present" do
-        dsl.set :filter, roles: "web"
+      it 'selects nothing when a roles filter is present' do
+        dsl.set :filter, roles: 'web'
         SSHKit::Coordinator.expects(:new).with([]).returns(@coordinator)
-        dsl.on("my.server")
+        dsl.on('my.server')
       end
 
-      it "selects using the string when a hosts filter is present" do
-        dsl.set :filter, hosts: "server.local"
-        SSHKit::Coordinator.expects(:new).with(["server.local"]).returns(@coordinator)
-        dsl.on("server.local")
+      it 'selects using the string when a hosts filter is present' do
+        dsl.set :filter, hosts: 'server.local'
+        SSHKit::Coordinator.expects(:new).with(['server.local']).returns(@coordinator)
+        dsl.on('server.local')
       end
 
       it "doesn't select when a hosts filter is present that doesn't match" do
-        dsl.set :filter, hosts: "ruby.local"
+        dsl.set :filter, hosts: 'ruby.local'
         SSHKit::Coordinator.expects(:new).with([]).returns(@coordinator)
-        dsl.on("server.local")
+        dsl.on('server.local')
       end
     end
   end
 
-  describe "role_properties()" do
+  describe 'role_properties()' do
     before do
       dsl.role :redis, %w[example1.com example2.com], redis: { port: 6379, type: :slave }
-      dsl.server "example1.com", roles: %w{web}, active: true, web: { port: 80 }
-      dsl.server "example2.com", roles: %w{web redis}, web: { port: 81 }, redis: { type: :master }
-      dsl.server "example3.com", roles: %w{app}, primary: true
+      dsl.server 'example1.com', roles: %w{web}, active: true, web: { port: 80 }
+      dsl.server 'example2.com', roles: %w{web redis}, web: { port: 81 }, redis: { type: :master }
+      dsl.server 'example3.com', roles: %w{app}, primary: true
     end
 
-    it "retrieves properties for a single role as a set" do
+    it 'retrieves properties for a single role as a set' do
       rps = dsl.role_properties(:app)
-      expect(rps).to eq(Set[{ hostname: "example3.com", role: :app }])
+      expect(rps).to eq(Set[{ hostname: 'example3.com', role: :app }])
     end
 
-    it "retrieves properties for multiple roles as a set" do
+    it 'retrieves properties for multiple roles as a set' do
       rps = dsl.role_properties(:app, :web)
-      expect(rps).to eq(Set[{ hostname: "example3.com", role: :app }, { hostname: "example1.com", role: :web, port: 80 }, { hostname: "example2.com", role: :web, port: 81 }])
+      expect(rps).to eq(Set[{ hostname: 'example3.com', role: :app }, { hostname: 'example1.com', role: :web, port: 80 }, { hostname: 'example2.com', role: :web, port: 81 }])
     end
 
-    it "yields the properties for a single role" do
-      recipient = mock("recipient")
-      recipient.expects(:doit).with("example1.com", :redis, port: 6379, type: :slave)
-      recipient.expects(:doit).with("example2.com", :redis, port: 6379, type: :master)
+    it 'yields the properties for a single role' do
+      recipient = mock('recipient')
+      recipient.expects(:doit).with('example1.com', :redis, port: 6379, type: :slave)
+      recipient.expects(:doit).with('example2.com', :redis, port: 6379, type: :master)
       dsl.role_properties(:redis) do |host, role, props|
         recipient.doit(host, role, props)
       end
     end
 
-    it "yields the properties for multiple roles" do
-      recipient = mock("recipient")
-      recipient.expects(:doit).with("example1.com", :redis, port: 6379, type: :slave)
-      recipient.expects(:doit).with("example2.com", :redis, port: 6379, type: :master)
-      recipient.expects(:doit).with("example3.com", :app, nil)
+    it 'yields the properties for multiple roles' do
+      recipient = mock('recipient')
+      recipient.expects(:doit).with('example1.com', :redis, port: 6379, type: :slave)
+      recipient.expects(:doit).with('example2.com', :redis, port: 6379, type: :master)
+      recipient.expects(:doit).with('example3.com', :app, nil)
       dsl.role_properties(:redis, :app) do |host, role, props|
         recipient.doit(host, role, props)
       end
     end
 
-    it "yields the merged properties for multiple roles" do
-      recipient = mock("recipient")
-      recipient.expects(:doit).with("example1.com", :redis, port: 6379, type: :slave)
-      recipient.expects(:doit).with("example2.com", :redis, port: 6379, type: :master)
-      recipient.expects(:doit).with("example1.com", :web, port: 80)
-      recipient.expects(:doit).with("example2.com", :web, port: 81)
+    it 'yields the merged properties for multiple roles' do
+      recipient = mock('recipient')
+      recipient.expects(:doit).with('example1.com', :redis, port: 6379, type: :slave)
+      recipient.expects(:doit).with('example2.com', :redis, port: 6379, type: :master)
+      recipient.expects(:doit).with('example1.com', :web, port: 80)
+      recipient.expects(:doit).with('example2.com', :web, port: 81)
       dsl.role_properties(:redis, :web) do |host, role, props|
         recipient.doit(host, role, props)
       end
     end
 
-    it "honours a property filter before yielding" do
-      recipient = mock("recipient")
-      recipient.expects(:doit).with("example1.com", :redis, port: 6379, type: :slave)
-      recipient.expects(:doit).with("example1.com", :web, port: 80)
+    it 'honours a property filter before yielding' do
+      recipient = mock('recipient')
+      recipient.expects(:doit).with('example1.com', :redis, port: 6379, type: :slave)
+      recipient.expects(:doit).with('example1.com', :web, port: 80)
       dsl.role_properties(:redis, :web, select: :active) do |host, role, props|
         recipient.doit(host, role, props)
       end

--- a/spec/integration_spec_helper.rb
+++ b/spec/integration_spec_helper.rb
@@ -1,5 +1,5 @@
-require "spec_helper"
-require "support/test_app"
-require "support/matchers"
+require 'spec_helper'
+require 'support/test_app'
+require 'support/matchers'
 
 include TestApp

--- a/spec/lib/capistrano/application_spec.rb
+++ b/spec/lib/capistrano/application_spec.rb
@@ -1,18 +1,18 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe Capistrano::Application do
-  it "provides a --trace option which enables SSHKit/NetSSH trace output"
+  it 'provides a --trace option which enables SSHKit/NetSSH trace output'
 
-  it "provides a --format option which enables the choice of output formatting"
+  it 'provides a --format option which enables the choice of output formatting'
 
   let(:help_output) do
     out, _err = capture_io do
-      flags "--help", "-h"
+      flags '--help', '-h'
     end
     out
   end
 
-  it "displays documentation URL as help banner" do
+  it 'displays documentation URL as help banner' do
     expect(help_output.lines.first).to match(/capistranorb.com/)
   end
 
@@ -22,9 +22,9 @@ describe Capistrano::Application do
     end
   end
 
-  it "overrides the rake method, but still prints the rake version" do
+  it 'overrides the rake method, but still prints the rake version' do
     out, _err = capture_io do
-      flags "--version", "-V"
+      flags '--version', '-V'
     end
     expect(out).to match(/\bCapistrano Version\b/)
     expect(out).to match(/\b#{Capistrano::VERSION}\b/)
@@ -32,17 +32,17 @@ describe Capistrano::Application do
     expect(out).to match(/\b#{Rake::VERSION}\b/)
   end
 
-  it "overrides the rake method, and sets the sshkit_backend to SSHKit::Backend::Printer" do
+  it 'overrides the rake method, and sets the sshkit_backend to SSHKit::Backend::Printer' do
     capture_io do
-      flags "--dry-run", "-n"
+      flags '--dry-run', '-n'
     end
     sshkit_backend = Capistrano::Configuration.fetch(:sshkit_backend)
     expect(sshkit_backend).to eq(SSHKit::Backend::Printer)
   end
 
-  it "enables printing all config variables on command line parameter" do
+  it 'enables printing all config variables on command line parameter' do
     capture_io do
-      flags "--print-config-variables", "-p"
+      flags '--print-config-variables', '-p'
     end
     expect(Capistrano::Configuration.fetch(:print_config_variables)).to be true
   end
@@ -65,7 +65,7 @@ describe Capistrano::Application do
   end
 
   def capture_io
-    require "stringio"
+    require 'stringio'
 
     orig_stdout = $stdout
     orig_stderr = $stderr

--- a/spec/lib/capistrano/configuration/empty_filter_spec.rb
+++ b/spec/lib/capistrano/configuration/empty_filter_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 module Capistrano
   class Configuration
@@ -6,9 +6,9 @@ module Capistrano
       subject(:empty_filter) { EmptyFilter.new }
 
       describe '#filter' do
-        let(:servers) { mock("servers") }
+        let(:servers) { mock('servers') }
 
-        it "returns an empty array" do
+        it 'returns an empty array' do
           expect(empty_filter.filter(servers)).to eq([])
         end
       end

--- a/spec/lib/capistrano/configuration/filter_spec.rb
+++ b/spec/lib/capistrano/configuration/filter_spec.rb
@@ -1,16 +1,14 @@
-require "spec_helper"
+require 'spec_helper'
 
 module Capistrano
   class Configuration
     describe Filter do
       let(:available) do
-        [
-          Server.new("server1").add_roles([:web, :db]),
-          Server.new("server2").add_role(:web),
-          Server.new("server3").add_role(:redis),
-          Server.new("server4").add_role(:db),
-          Server.new("server5").add_role(:stageweb)
-        ]
+        [Server.new('server1').add_roles([:web, :db]),
+         Server.new('server2').add_role(:web),
+         Server.new('server3').add_role(:redis),
+         Server.new('server4').add_role(:db),
+         Server.new('server5').add_role(:stageweb)]
       end
 
       describe '#new' do
@@ -20,54 +18,54 @@ module Capistrano
           end.to raise_error RuntimeError
         end
 
-        context "with type :host" do
-          context "and no values" do
-            it "creates an EmptyFilter strategy" do
+        context 'with type :host' do
+          context 'and no values' do
+            it 'creates an EmptyFilter strategy' do
               expect(Filter.new(:host).instance_variable_get(:@strategy)).to be_a(EmptyFilter)
             end
           end
 
-          context "and :all" do
-            it "creates an NullFilter strategy" do
+          context 'and :all' do
+            it 'creates an NullFilter strategy' do
               expect(Filter.new(:host, :all).instance_variable_get(:@strategy)).to be_a(NullFilter)
             end
           end
 
-          context "and [:all]" do
-            it "creates an NullFilter strategy" do
+          context 'and [:all]' do
+            it 'creates an NullFilter strategy' do
               expect(Filter.new(:host, [:all]).instance_variable_get(:@strategy)).to be_a(NullFilter)
             end
           end
 
-          context "and [:all]" do
-            it "creates an NullFilter strategy" do
-              expect(Filter.new(:host, "all").instance_variable_get(:@strategy)).to be_a(NullFilter)
+          context 'and [:all]' do
+            it 'creates an NullFilter strategy' do
+              expect(Filter.new(:host, 'all').instance_variable_get(:@strategy)).to be_a(NullFilter)
             end
           end
         end
 
-        context "with type :role" do
-          context "and no values" do
-            it "creates an EmptyFilter strategy" do
+        context 'with type :role' do
+          context 'and no values' do
+            it 'creates an EmptyFilter strategy' do
               expect(Filter.new(:role).instance_variable_get(:@strategy)).to be_a(EmptyFilter)
             end
           end
 
-          context "and :all" do
-            it "creates an NullFilter strategy" do
+          context 'and :all' do
+            it 'creates an NullFilter strategy' do
               expect(Filter.new(:role, :all).instance_variable_get(:@strategy)).to be_a(NullFilter)
             end
           end
 
-          context "and [:all]" do
-            it "creates an NullFilter strategy" do
+          context 'and [:all]' do
+            it 'creates an NullFilter strategy' do
               expect(Filter.new(:role, [:all]).instance_variable_get(:@strategy)).to be_a(NullFilter)
             end
           end
 
-          context "and [:all]" do
-            it "creates an NullFilter strategy" do
-              expect(Filter.new(:role, "all").instance_variable_get(:@strategy)).to be_a(NullFilter)
+          context 'and [:all]' do
+            it 'creates an NullFilter strategy' do
+              expect(Filter.new(:role, 'all').instance_variable_get(:@strategy)).to be_a(NullFilter)
             end
           end
         end
@@ -75,7 +73,7 @@ module Capistrano
 
       describe '#filter' do
         let(:strategy) { filter.instance_variable_get(:@strategy) }
-        let(:results) { mock("result") }
+        let(:results) { mock('result') }
 
         shared_examples 'it calls #filter on its strategy' do
           it 'calls #filter on its strategy' do
@@ -84,23 +82,23 @@ module Capistrano
           end
         end
 
-        context "for an empty filter" do
+        context 'for an empty filter' do
           let(:filter) { Filter.new(:role) }
           it_behaves_like 'it calls #filter on its strategy'
         end
 
-        context "for a null filter" do
+        context 'for a null filter' do
           let(:filter) { Filter.new(:role, :all) }
           it_behaves_like 'it calls #filter on its strategy'
         end
 
-        context "for a role filter" do
-          let(:filter) { Filter.new(:role, "web") }
+        context 'for a role filter' do
+          let(:filter) { Filter.new(:role, 'web') }
           it_behaves_like 'it calls #filter on its strategy'
         end
 
-        context "for a host filter" do
-          let(:filter) { Filter.new(:host, "server1") }
+        context 'for a host filter' do
+          let(:filter) { Filter.new(:host, 'server1') }
           it_behaves_like 'it calls #filter on its strategy'
         end
       end

--- a/spec/lib/capistrano/configuration/host_filter_spec.rb
+++ b/spec/lib/capistrano/configuration/host_filter_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 module Capistrano
   class Configuration
@@ -6,54 +6,54 @@ module Capistrano
       subject(:host_filter) { HostFilter.new(values) }
 
       let(:available) do
-        [Server.new("server1"),
-         Server.new("server2"),
-         Server.new("server3"),
-         Server.new("server4"),
-         Server.new("server5")]
+        [Server.new('server1'),
+         Server.new('server2'),
+         Server.new('server3'),
+         Server.new('server4'),
+         Server.new('server5')]
       end
 
-      shared_examples "it filters hosts correctly" do |expected|
-        it "filters correctly" do
+      shared_examples 'it filters hosts correctly' do |expected|
+        it 'filters correctly' do
           set = host_filter.filter(available)
           expect(set.map(&:hostname)).to eq(expected)
         end
       end
 
       describe '#filter' do
-        context "with a string" do
-          let(:values) { "server1" }
-          it_behaves_like "it filters hosts correctly", %w{server1}
+        context 'with a string' do
+          let(:values) { 'server1' }
+          it_behaves_like 'it filters hosts correctly', %w{server1}
 
-          context "and a single server" do
-            let(:available) { Server.new("server1") }
-            it_behaves_like "it filters hosts correctly", %w{server1}
+          context 'and a single server' do
+            let(:available) { Server.new('server1') }
+            it_behaves_like 'it filters hosts correctly', %w{server1}
           end
         end
 
-        context "with a comma separated string" do
-          let(:values) { "server1,server3" }
-          it_behaves_like "it filters hosts correctly", %w{server1 server3}
+        context 'with a comma separated string' do
+          let(:values) { 'server1,server3' }
+          it_behaves_like 'it filters hosts correctly', %w{server1 server3}
         end
 
-        context "with an array of strings" do
+        context 'with an array of strings' do
           let(:values) { %w{server1 server3} }
-          it_behaves_like "it filters hosts correctly", %w{server1 server3}
+          it_behaves_like 'it filters hosts correctly', %w{server1 server3}
         end
 
-        context "with a regexp" do
-          let(:values) { "server[13]$" }
-          it_behaves_like "it filters hosts correctly", %w{server1 server3}
+        context 'with a regexp' do
+          let(:values) { 'server[13]$' }
+          it_behaves_like 'it filters hosts correctly', %w{server1 server3}
         end
 
-        context "with a regexp with line boundaries" do
-          let(:values) { "^server" }
-          it_behaves_like "it filters hosts correctly", %w{server1 server2 server3 server4 server5}
+        context 'with a regexp with line boundaries' do
+          let(:values) { '^server' }
+          it_behaves_like 'it filters hosts correctly', %w{server1 server2 server3 server4 server5}
         end
 
-        context "with a regexp with a comma" do
+        context 'with a regexp with a comma' do
           let(:values) { 'server\d{1,3}$' }
-          it_behaves_like "it filters hosts correctly", %w{server1 server2 server3 server4 server5}
+          it_behaves_like 'it filters hosts correctly', %w{server1 server2 server3 server4 server5}
         end
       end
     end

--- a/spec/lib/capistrano/configuration/null_filter_spec.rb
+++ b/spec/lib/capistrano/configuration/null_filter_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 module Capistrano
   class Configuration
@@ -6,9 +6,9 @@ module Capistrano
       subject(:null_filter) { NullFilter.new }
 
       describe '#filter' do
-        let(:servers) { mock("servers") }
+        let(:servers) { mock('servers') }
 
-        it "returns the servers passed in as arguments" do
+        it 'returns the servers passed in as arguments' do
           expect(null_filter.filter(servers)).to eq(servers)
         end
       end

--- a/spec/lib/capistrano/configuration/question_spec.rb
+++ b/spec/lib/capistrano/configuration/question_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 module Capistrano
   class Configuration
@@ -9,28 +9,28 @@ module Capistrano
       let(:key) { :branch }
       let(:options) { nil }
 
-      describe ".new" do
-        it "takes a key, default, options" do
+      describe '.new' do
+        it 'takes a key, default, options' do
           question
         end
       end
 
       describe '#call' do
-        context "value is entered" do
-          let(:branch) { "branch" }
+        context 'value is entered' do
+          let(:branch) { 'branch' }
 
           before do
-            $stdout.expects(:print).with("Please enter branch (default): ")
+            $stdout.expects(:print).with('Please enter branch (default): ')
           end
 
-          it "returns the echoed value" do
+          it 'returns the echoed value' do
             $stdin.expects(:gets).returns(branch)
             $stdin.expects(:noecho).never
 
             expect(question.call).to eq(branch)
           end
 
-          it "returns the value but does not echo it" do
+          it 'returns the value but does not echo it' do
             $stdin.expects(:noecho).returns(branch)
             $stdout.expects(:print).with("\n")
 
@@ -38,15 +38,15 @@ module Capistrano
           end
         end
 
-        context "value is not entered" do
+        context 'value is not entered' do
           let(:branch) { default }
 
           before do
-            $stdout.expects(:print).with("Please enter branch (default): ")
-            $stdin.expects(:gets).returns("")
+            $stdout.expects(:print).with('Please enter branch (default): ')
+            $stdin.expects(:gets).returns('')
           end
 
-          it "returns the default as the value" do
+          it 'returns the default as the value' do
             expect(question.call).to eq(branch)
           end
         end

--- a/spec/lib/capistrano/configuration/role_filter_spec.rb
+++ b/spec/lib/capistrano/configuration/role_filter_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 module Capistrano
   class Configuration
@@ -6,17 +6,15 @@ module Capistrano
       subject(:role_filter) { RoleFilter.new(values) }
 
       let(:available) do
-        [
-          Server.new("server1").add_roles([:web, :db]),
-          Server.new("server2").add_role(:web),
-          Server.new("server3").add_role(:redis),
-          Server.new("server4").add_role(:db),
-          Server.new("server5").add_role(:stageweb)
-        ]
+        [Server.new('server1').add_roles([:web, :db]),
+         Server.new('server2').add_role(:web),
+         Server.new('server3').add_role(:redis),
+         Server.new('server4').add_role(:db),
+         Server.new('server5').add_role(:stageweb)]
       end
 
-      shared_examples "it filters roles correctly" do |expected_size, expected|
-        it "filters correctly" do
+      shared_examples 'it filters roles correctly' do |expected_size, expected|
+        it 'filters correctly' do
           set = role_filter.filter(available)
           expect(set.size).to eq(expected_size)
           expect(set.map(&:hostname)).to eq(expected)
@@ -24,39 +22,39 @@ module Capistrano
       end
 
       describe '#filter' do
-        context "with a single role string" do
-          let(:values) { "web" }
-          it_behaves_like "it filters roles correctly", 2, %w{server1 server2}
+        context 'with a single role string' do
+          let(:values) { 'web' }
+          it_behaves_like 'it filters roles correctly', 2, %w{server1 server2}
         end
 
-        context "with a single role" do
+        context 'with a single role' do
           let(:values) { [:web] }
-          it_behaves_like "it filters roles correctly", 2, %w{server1 server2}
+          it_behaves_like 'it filters roles correctly', 2, %w{server1 server2}
         end
 
-        context "with multiple roles in a string" do
-          let(:values) { "web,db" }
-          it_behaves_like "it filters roles correctly", 3, %w{server1 server2 server4}
+        context 'with multiple roles in a string' do
+          let(:values) { 'web,db' }
+          it_behaves_like 'it filters roles correctly', 3, %w{server1 server2 server4}
         end
 
-        context "with multiple roles" do
+        context 'with multiple roles' do
           let(:values) { [:web, :db] }
-          it_behaves_like "it filters roles correctly", 3, %w{server1 server2 server4}
+          it_behaves_like 'it filters roles correctly', 3, %w{server1 server2 server4}
         end
 
-        context "with a regex" do
+        context 'with a regex' do
           let(:values) { /red/ }
-          it_behaves_like "it filters roles correctly", 1, %w{server3}
+          it_behaves_like 'it filters roles correctly', 1, %w{server3}
         end
 
-        context "with a regex string" do
-          let(:values) { "/red|web/" }
-          it_behaves_like "it filters roles correctly", 4, %w{server1 server2 server3 server5}
+        context 'with a regex string' do
+          let(:values) { '/red|web/' }
+          it_behaves_like 'it filters roles correctly', 4, %w{server1 server2 server3 server5}
         end
 
-        context "with both a string and regex" do
-          let(:values) { "db,/red/" }
-          it_behaves_like "it filters roles correctly", 3, %w{server1 server3 server4}
+        context 'with both a string and regex' do
+          let(:values) { 'db,/red/' }
+          it_behaves_like 'it filters roles correctly', 3, %w{server1 server3 server4}
         end
       end
     end

--- a/spec/lib/capistrano/configuration/server_spec.rb
+++ b/spec/lib/capistrano/configuration/server_spec.rb
@@ -1,139 +1,139 @@
-require "spec_helper"
+require 'spec_helper'
 
 module Capistrano
   class Configuration
     describe Server do
-      let(:server) { Server.new("root@hostname:1234") }
+      let(:server) { Server.new('root@hostname:1234') }
 
-      describe "adding a role" do
+      describe 'adding a role' do
         subject { server.add_role(:test) }
-        it "adds the role" do
+        it 'adds the role' do
           expect { subject }.to change { server.roles.size }.from(0).to(1)
         end
       end
 
-      describe "adding roles" do
+      describe 'adding roles' do
         subject { server.add_roles([:things, :stuff]) }
-        it "adds the roles" do
+        it 'adds the roles' do
           expect { subject }.to change { server.roles.size }.from(0).to(2)
         end
       end
 
-      describe "checking roles" do
+      describe 'checking roles' do
         subject { server.has_role?(:test) }
 
         before do
           server.add_role(:test)
         end
 
-        it "adds the role" do
+        it 'adds the role' do
           expect(subject).to be_truthy
         end
       end
 
-      describe "comparing identity" do
+      describe 'comparing identity' do
         subject { server.hostname == Server[hostname].hostname }
 
-        context "with the same user, hostname and port" do
-          let(:hostname) { "root@hostname:1234" }
+        context 'with the same user, hostname and port' do
+          let(:hostname) { 'root@hostname:1234' }
           it { expect(subject).to be_truthy }
         end
 
-        context "with a different user" do
-          let(:hostname) { "deployer@hostname:1234" }
+        context 'with a different user' do
+          let(:hostname) { 'deployer@hostname:1234' }
           it { expect(subject).to be_truthy }
         end
 
-        context "with a different port" do
-          let(:hostname) { "root@hostname:5678" }
+        context 'with a different port' do
+          let(:hostname) { 'root@hostname:5678' }
           it { expect(subject).to be_truthy }
         end
 
-        context "with a different hostname" do
-          let(:hostname) { "root@otherserver:1234" }
+        context 'with a different hostname' do
+          let(:hostname) { 'root@otherserver:1234' }
           it { expect(subject).to be_falsey }
         end
       end
 
-      describe "identifying as primary" do
+      describe 'identifying as primary' do
         subject { server.primary }
-        context "server is primary" do
+        context 'server is primary' do
           before do
             server.set(:primary, true)
           end
-          it "returns self" do
+          it 'returns self' do
             expect(subject).to eq server
           end
         end
 
-        context "server is not primary" do
-          it "is falesy" do
+        context 'server is not primary' do
+          it 'is falesy' do
             expect(subject).to be_falsey
           end
         end
       end
 
-      describe "assigning properties" do
+      describe 'assigning properties' do
         before do
           server.with(properties)
         end
 
-        context "properties contains roles" do
+        context 'properties contains roles' do
           let(:properties) { { roles: [:clouds] } }
 
-          it "adds the roles" do
+          it 'adds the roles' do
             expect(server.roles.first).to eq :clouds
           end
         end
 
-        context "properties contains user" do
-          let(:properties) { { user: "tomc" } }
+        context 'properties contains user' do
+          let(:properties) { { user: 'tomc' } }
 
-          it "sets the user" do
-            expect(server.user).to eq "tomc"
+          it 'sets the user' do
+            expect(server.user).to eq 'tomc'
           end
 
-          it "sets the netssh_options user" do
-            expect(server.netssh_options[:user]).to eq "tomc"
+          it 'sets the netssh_options user' do
+            expect(server.netssh_options[:user]).to eq 'tomc'
           end
         end
 
-        context "properties contains port" do
+        context 'properties contains port' do
           let(:properties) { { port: 2222 } }
 
-          it "sets the port" do
+          it 'sets the port' do
             expect(server.port).to eq 2222
           end
         end
 
-        context "properties contains key" do
-          let(:properties) { { key: "/key" } }
+        context 'properties contains key' do
+          let(:properties) { { key: '/key' } }
 
-          it "adds the key" do
-            expect(server.keys).to include "/key"
+          it 'adds the key' do
+            expect(server.keys).to include '/key'
           end
         end
 
-        context "properties contains password" do
-          let(:properties) { { password: "supersecret" } }
+        context 'properties contains password' do
+          let(:properties) { { password: 'supersecret' } }
 
-          it "adds the key" do
-            expect(server.password).to eq "supersecret"
+          it 'adds the key' do
+            expect(server.password).to eq 'supersecret'
           end
         end
 
-        context "new properties" do
+        context 'new properties' do
           let(:properties) { { webscales: 5 } }
 
-          it "adds the properties" do
+          it 'adds the properties' do
             expect(server.properties.webscales).to eq 5
           end
         end
 
-        context "existing properties" do
+        context 'existing properties' do
           let(:properties) { { webscales: 6 } }
 
-          it "keeps the existing properties" do
+          it 'keeps the existing properties' do
             expect(server.properties.webscales).to eq 6
             server.properties.webscales = 5
             expect(server.properties.webscales).to eq 5
@@ -150,100 +150,100 @@ module Capistrano
           server.properties.active = true
         end
 
-        context "options are empty" do
+        context 'options are empty' do
           it { expect(subject).to be_truthy }
         end
 
-        context "value is a symbol" do
-          context "value matches server property" do
-            context "with :filter" do
+        context 'value is a symbol' do
+          context 'value matches server property' do
+            context 'with :filter' do
               let(:options) { { filter: :active } }
               it { expect(subject).to be_truthy }
             end
 
-            context "with :select" do
+            context 'with :select' do
               let(:options) { { select: :active } }
               it { expect(subject).to be_truthy }
             end
 
-            context "with :exclude" do
+            context 'with :exclude' do
               let(:options) { { exclude: :active } }
               it { expect(subject).to be_falsey }
             end
           end
 
-          context "value does not match server properly" do
-            context "with :active true" do
+          context 'value does not match server properly' do
+            context 'with :active true' do
               let(:options) { { active: true } }
               it { expect(subject).to be_truthy }
             end
 
-            context "with :active false" do
+            context 'with :active false' do
               let(:options) { { active: false } }
               it { expect(subject).to be_falsey }
             end
           end
 
-          context "value does not match server properly" do
-            context "with :filter" do
+          context 'value does not match server properly' do
+            context 'with :filter' do
               let(:options) { { filter: :inactive } }
               it { expect(subject).to be_falsey }
             end
 
-            context "with :select" do
+            context 'with :select' do
               let(:options) { { select: :inactive } }
               it { expect(subject).to be_falsey }
             end
 
-            context "with :exclude" do
+            context 'with :exclude' do
               let(:options) { { exclude: :inactive } }
               it { expect(subject).to be_truthy }
             end
           end
         end
 
-        context "key is a property" do
-          context "with :active true" do
+        context 'key is a property' do
+          context 'with :active true' do
             let(:options) { { active: true } }
             it { expect(subject).to be_truthy }
           end
 
-          context "with :active false" do
+          context 'with :active false' do
             let(:options) { { active: false } }
             it { expect(subject).to be_falsey }
           end
         end
 
-        context "value is a proc" do
-          context "value matches server property" do
-            context "with :filter" do
+        context 'value is a proc' do
+          context 'value matches server property' do
+            context 'with :filter' do
               let(:options) { { filter: ->(s) { s.properties.active } } }
               it { expect(subject).to be_truthy }
             end
 
-            context "with :select" do
+            context 'with :select' do
               let(:options) { { select: ->(s) { s.properties.active } } }
               it { expect(subject).to be_truthy }
             end
 
-            context "with :exclude" do
+            context 'with :exclude' do
               let(:options) { { exclude: ->(s) { s.properties.active } } }
               it { expect(subject).to be_falsey }
             end
           end
 
-          context "value does not match server properly" do
-            context "with :filter" do
+          context 'value does not match server properly' do
+            context 'with :filter' do
               let(:options) { { filter: ->(s) { s.properties.inactive } } }
               it { expect(subject).to be_falsey }
             end
 
-            context "with :select" do
+            context 'with :select' do
               let(:options) { { select: ->(s) { s.properties.inactive } } }
               it { expect(subject).to be_falsey }
             end
 
-            context "with :exclude" do
+            context 'with :exclude' do
               let(:options) { { exclude: ->(s) { s.properties.inactive } } }
               it { expect(subject).to be_truthy }
             end
@@ -251,22 +251,22 @@ module Capistrano
         end
       end
 
-      describe "assign ssh_options" do
-        let(:server) { Server.new("user_name@hostname") }
+      describe 'assign ssh_options' do
+        let(:server) { Server.new('user_name@hostname') }
 
-        context "defaults" do
-          it "forward agent" do
+        context 'defaults' do
+          it 'forward agent' do
             expect(server.netssh_options[:forward_agent]).to eq true
           end
-          it "contains user" do
-            expect(server.netssh_options[:user]).to eq "user_name"
+          it 'contains user' do
+            expect(server.netssh_options[:user]).to eq 'user_name'
           end
         end
 
-        context "custom" do
+        context 'custom' do
           let(:properties) do
             { ssh_options: {
-              user: "another_user",
+              user: 'another_user',
               keys: %w(/home/another_user/.ssh/id_rsa),
               forward_agent: false,
               auth_methods: %w(publickey password) } }
@@ -276,30 +276,30 @@ module Capistrano
             server.with(properties)
           end
 
-          it "not forward agent" do
+          it 'not forward agent' do
             expect(server.netssh_options[:forward_agent]).to eq false
           end
-          it "contains correct user" do
-            expect(server.netssh_options[:user]).to eq "another_user"
+          it 'contains correct user' do
+            expect(server.netssh_options[:user]).to eq 'another_user'
           end
-          it "does not affect server user in host" do
-            expect(server.user).to eq "user_name"
+          it 'does not affect server user in host' do
+            expect(server.user).to eq 'user_name'
           end
-          it "contains keys" do
+          it 'contains keys' do
             expect(server.netssh_options[:keys]).to eq %w(/home/another_user/.ssh/id_rsa)
           end
-          it "contains auth_methods" do
+          it 'contains auth_methods' do
             expect(server.netssh_options[:auth_methods]).to eq %w(publickey password)
           end
         end
       end
 
-      describe ".[]" do
-        it "creates a server if its argument is not already a server" do
-          expect(Server["hostname:1234"]).to be_a Server
+      describe '.[]' do
+        it 'creates a server if its argument is not already a server' do
+          expect(Server['hostname:1234']).to be_a Server
         end
 
-        it "returns its argument if it is already a server" do
+        it 'returns its argument if it is already a server' do
           expect(Server[server]).to be server
         end
       end

--- a/spec/lib/capistrano/configuration/servers_spec.rb
+++ b/spec/lib/capistrano/configuration/servers_spec.rb
@@ -1,60 +1,60 @@
-require "spec_helper"
+require 'spec_helper'
 
 module Capistrano
   class Configuration
     describe Servers do
       let(:servers) { Servers.new }
 
-      describe "adding a role" do
-        it "adds two new server instances" do
+      describe 'adding a role' do
+        it 'adds two new server instances' do
           expect { servers.add_role(:app, %w{1 2}) }
             .to change { servers.count }.from(0).to(2)
         end
 
-        it "handles de-duplification within roles" do
+        it 'handles de-duplification within roles' do
           servers.add_role(:app, %w{1})
           servers.add_role(:app, %w{1})
           expect(servers.count).to eq 1
         end
 
-        it "handles de-duplification within roles with users" do
-          servers.add_role(:app, %w{1}, user: "nick")
-          servers.add_role(:app, %w{1}, user: "fred")
+        it 'handles de-duplification within roles with users' do
+          servers.add_role(:app, %w{1}, user: 'nick')
+          servers.add_role(:app, %w{1}, user: 'fred')
           expect(servers.count).to eq 1
         end
 
-        it "accepts instances of server objects" do
-          servers.add_role(:app, [Capistrano::Configuration::Server.new("example.net"), "example.com"])
+        it 'accepts instances of server objects' do
+          servers.add_role(:app, [Capistrano::Configuration::Server.new('example.net'), 'example.com'])
           expect(servers.roles_for([:app]).length).to eq 2
         end
 
-        it "accepts non-enumerable types" do
-          servers.add_role(:app, "1")
+        it 'accepts non-enumerable types' do
+          servers.add_role(:app, '1')
           expect(servers.roles_for([:app]).count).to eq 1
         end
 
-        it "creates distinct server properties" do
+        it 'creates distinct server properties' do
           servers.add_role(:db, %w{1 2}, db: { port: 1234 })
-          servers.add_host("1", db: { master: true })
+          servers.add_host('1', db: { master: true })
           expect(servers.count).to eq(2)
           expect(servers.roles_for([:db]).count).to eq 2
-          expect(servers.find { |s| s.hostname == "1" }.properties.db).to eq(port: 1234, master: true)
-          expect(servers.find { |s| s.hostname == "2" }.properties.db).to eq(port: 1234)
+          expect(servers.find { |s| s.hostname == '1' }.properties.db).to eq(port: 1234, master: true)
+          expect(servers.find { |s| s.hostname == '2' }.properties.db).to eq(port: 1234)
         end
       end
 
-      describe "adding a role to an existing server" do
+      describe 'adding a role to an existing server' do
         before do
           servers.add_role(:web, %w{1 2})
           servers.add_role(:app, %w{1 2})
         end
 
-        it "adds new roles to existing servers" do
+        it 'adds new roles to existing servers' do
           expect(servers.count).to eq 2
         end
       end
 
-      describe "collecting server roles" do
+      describe 'collecting server roles' do
         let(:app) { Set.new([:app]) }
         let(:web_app) { Set.new([:web, :app]) }
         let(:web) { Set.new([:web]) }
@@ -64,262 +64,262 @@ module Capistrano
           servers.add_role(:web, %w{2 3 4})
         end
 
-        it "returns an array of the roles" do
+        it 'returns an array of the roles' do
           expect(servers.roles_for([:app]).collect(&:roles)).to eq [app, web_app, web_app]
           expect(servers.roles_for([:web]).collect(&:roles)).to eq [web_app, web_app, web]
         end
       end
 
-      describe "finding the primary server" do
+      describe 'finding the primary server' do
         after do
           Configuration.reset!
         end
-        it "takes the first server if none have the primary property" do
+        it 'takes the first server if none have the primary property' do
           servers.add_role(:app, %w{1 2})
-          expect(servers.fetch_primary(:app).hostname).to eq("1")
+          expect(servers.fetch_primary(:app).hostname).to eq('1')
         end
 
-        it "takes the first server with the primary have the primary flag" do
+        it 'takes the first server with the primary have the primary flag' do
           servers.add_role(:app, %w{1 2})
-          servers.add_host("2", primary: true)
-          expect(servers.fetch_primary(:app).hostname).to eq("2")
+          servers.add_host('2', primary: true)
+          expect(servers.fetch_primary(:app).hostname).to eq('2')
         end
 
-        it "ignores any on_filters" do
-          Configuration.env.set :filter, host: "1"
+        it 'ignores any on_filters' do
+          Configuration.env.set :filter, host: '1'
           servers.add_role(:app, %w{1 2})
-          servers.add_host("2", primary: true)
-          expect(servers.fetch_primary(:app).hostname).to eq("2")
+          servers.add_host('2', primary: true)
+          expect(servers.fetch_primary(:app).hostname).to eq('2')
         end
       end
 
-      describe "fetching servers" do
+      describe 'fetching servers' do
         before do
           servers.add_role(:app, %w{1 2})
           servers.add_role(:web, %w{2 3})
         end
 
-        it "returns the correct app servers" do
+        it 'returns the correct app servers' do
           expect(servers.roles_for([:app]).map(&:hostname)).to eq %w{1 2}
         end
 
-        it "returns the correct web servers" do
+        it 'returns the correct web servers' do
           expect(servers.roles_for([:web]).map(&:hostname)).to eq %w{2 3}
         end
 
-        it "returns the correct app and web servers" do
+        it 'returns the correct app and web servers' do
           expect(servers.roles_for([:app, :web]).map(&:hostname)).to eq %w{1 2 3}
         end
 
-        it "returns all servers" do
+        it 'returns all servers' do
           expect(servers.roles_for([:all]).map(&:hostname)).to eq %w{1 2 3}
         end
       end
 
-      describe "adding a server" do
+      describe 'adding a server' do
         before do
-          servers.add_host("1", roles: [:app, "web"], test: :value)
+          servers.add_host('1', roles: [:app, 'web'], test: :value)
         end
 
-        it "can create a server with properties" do
-          expect(servers.roles_for([:app]).first.hostname).to eq "1"
-          expect(servers.roles_for([:web]).first.hostname).to eq "1"
+        it 'can create a server with properties' do
+          expect(servers.roles_for([:app]).first.hostname).to eq '1'
+          expect(servers.roles_for([:web]).first.hostname).to eq '1'
           expect(servers.roles_for([:all]).first.properties.test).to eq :value
           expect(servers.roles_for([:all]).first.properties.keys).to eq [:test]
         end
 
-        it "can accept multiple servers with the same hostname but different ports or users" do
-          servers.add_host("1", roles: [:app, "web"], test: :value, port: 12)
-          servers.add_host("1", roles: [:app, "web"], test: :value, port: 34)
-          servers.add_host("1", roles: [:app, "web"], test: :value, user: "root")
-          servers.add_host("1", roles: [:app, "web"], test: :value, user: "deployer")
-          servers.add_host("1", roles: [:app, "web"], test: :value, user: "root", port: 34)
-          servers.add_host("1", roles: [:app, "web"], test: :value, user: "deployer", port: 34)
-          servers.add_host("1", roles: [:app, "web"], test: :value, user: "deployer", port: 56)
+        it 'can accept multiple servers with the same hostname but different ports or users' do
+          servers.add_host('1', roles: [:app, 'web'], test: :value, port: 12)
+          servers.add_host('1', roles: [:app, 'web'], test: :value, port: 34)
+          servers.add_host('1', roles: [:app, 'web'], test: :value, user: 'root')
+          servers.add_host('1', roles: [:app, 'web'], test: :value, user: 'deployer')
+          servers.add_host('1', roles: [:app, 'web'], test: :value, user: 'root', port: 34)
+          servers.add_host('1', roles: [:app, 'web'], test: :value, user: 'deployer', port: 34)
+          servers.add_host('1', roles: [:app, 'web'], test: :value, user: 'deployer', port: 56)
           expect(servers.count).to eq(5)
         end
 
-        describe "with a :user property" do
-          it "sets the server ssh username" do
-            servers.add_host("1", roles: [:app, "web"], user: "nick")
+        describe 'with a :user property' do
+          it 'sets the server ssh username' do
+            servers.add_host('1', roles: [:app, 'web'], user: 'nick')
             expect(servers.count).to eq(1)
-            expect(servers.roles_for([:all]).first.user).to eq "nick"
+            expect(servers.roles_for([:all]).first.user).to eq 'nick'
           end
 
-          it "overwrites the value of a user specified in the hostname" do
-            servers.add_host("brian@1", roles: [:app, "web"], user: "nick")
+          it 'overwrites the value of a user specified in the hostname' do
+            servers.add_host('brian@1', roles: [:app, 'web'], user: 'nick')
             expect(servers.count).to eq(1)
-            expect(servers.roles_for([:all]).first.user).to eq "nick"
+            expect(servers.roles_for([:all]).first.user).to eq 'nick'
           end
         end
 
-        it "overwrites the value of a previously defined scalar property" do
-          servers.add_host("1", roles: [:app, "web"], test: :volatile)
+        it 'overwrites the value of a previously defined scalar property' do
+          servers.add_host('1', roles: [:app, 'web'], test: :volatile)
           expect(servers.count).to eq(1)
           expect(servers.roles_for([:all]).first.properties.test).to eq :volatile
         end
 
-        it "merges previously defined hash properties" do
-          servers.add_host("1", roles: [:b], db: { port: 1234 })
-          servers.add_host("1", roles: [:b], db: { master: true })
+        it 'merges previously defined hash properties' do
+          servers.add_host('1', roles: [:b], db: { port: 1234 })
+          servers.add_host('1', roles: [:b], db: { master: true })
           expect(servers.count).to eq(1)
           expect(servers.roles_for([:b]).first.properties.db).to eq(port: 1234, master: true)
         end
 
-        it "concatenates previously defined array properties" do
-          servers.add_host("1", roles: [:b], steps: [1, 3, 5])
-          servers.add_host("1", roles: [:b], steps: [1, 9])
+        it 'concatenates previously defined array properties' do
+          servers.add_host('1', roles: [:b], steps: [1, 3, 5])
+          servers.add_host('1', roles: [:b], steps: [1, 9])
           expect(servers.count).to eq(1)
           expect(servers.roles_for([:b]).first.properties.steps).to eq([1, 3, 5, 1, 9])
         end
 
-        it "merges previously defined set properties" do
-          servers.add_host("1", roles: [:b], endpoints: Set[123, 333])
-          servers.add_host("1", roles: [:b], endpoints: Set[222, 333])
+        it 'merges previously defined set properties' do
+          servers.add_host('1', roles: [:b], endpoints: Set[123, 333])
+          servers.add_host('1', roles: [:b], endpoints: Set[222, 333])
           expect(servers.count).to eq(1)
           expect(servers.roles_for([:b]).first.properties.endpoints).to eq(Set[123, 222, 333])
         end
 
-        it "adds array property value only ones for a new host" do
-          servers.add_host("2", roles: [:array_test], array_property: [1, 2])
+        it 'adds array property value only ones for a new host' do
+          servers.add_host('2', roles: [:array_test], array_property: [1, 2])
           expect(servers.roles_for([:array_test]).first.properties.array_property).to eq [1, 2]
         end
 
-        it "updates roles when custom user defined" do
-          servers.add_host("1", roles: ["foo"], user: "custom")
-          servers.add_host("1", roles: ["bar"], user: "custom")
-          expect(servers.roles_for([:foo]).first.hostname).to eq "1"
-          expect(servers.roles_for([:bar]).first.hostname).to eq "1"
+        it 'updates roles when custom user defined' do
+          servers.add_host('1', roles: ['foo'], user: 'custom')
+          servers.add_host('1', roles: ['bar'], user: 'custom')
+          expect(servers.roles_for([:foo]).first.hostname).to eq '1'
+          expect(servers.roles_for([:bar]).first.hostname).to eq '1'
         end
 
-        it "updates roles when custom port defined" do
-          servers.add_host("1", roles: ["foo"], port: 1234)
-          servers.add_host("1", roles: ["bar"], port: 1234)
-          expect(servers.roles_for([:foo]).first.hostname).to eq "1"
-          expect(servers.roles_for([:bar]).first.hostname).to eq "1"
+        it 'updates roles when custom port defined' do
+          servers.add_host('1', roles: ['foo'], port: 1234)
+          servers.add_host('1', roles: ['bar'], port: 1234)
+          expect(servers.roles_for([:foo]).first.hostname).to eq '1'
+          expect(servers.roles_for([:bar]).first.hostname).to eq '1'
         end
       end
 
-      describe "selecting roles" do
+      describe 'selecting roles' do
         before do
-          servers.add_host("1", roles: :app, active: true)
-          servers.add_host("2", roles: :app)
+          servers.add_host('1', roles: :app, active: true)
+          servers.add_host('2', roles: :app)
         end
 
-        it "is empty if the filter would remove all matching hosts" do
+        it 'is empty if the filter would remove all matching hosts' do
           expect(servers.roles_for([:app, select: :inactive])).to be_empty
         end
 
-        it "can filter hosts by properties on the host object using symbol as shorthand" do
+        it 'can filter hosts by properties on the host object using symbol as shorthand' do
           expect(servers.roles_for([:app, filter: :active]).length).to eq 1
         end
 
-        it "can select hosts by properties on the host object using symbol as shorthand" do
+        it 'can select hosts by properties on the host object using symbol as shorthand' do
           expect(servers.roles_for([:app, select: :active]).length).to eq 1
         end
 
-        it "can filter hosts by properties on the host using a regular proc" do
+        it 'can filter hosts by properties on the host using a regular proc' do
           expect(servers.roles_for([:app, filter: ->(h) { h.properties.active }]).length).to eq 1
         end
 
-        it "can select hosts by properties on the host using a regular proc" do
+        it 'can select hosts by properties on the host using a regular proc' do
           expect(servers.roles_for([:app, select: ->(h) { h.properties.active }]).length).to eq 1
         end
 
-        it "is empty if the regular proc filter would remove all matching hosts" do
+        it 'is empty if the regular proc filter would remove all matching hosts' do
           expect(servers.roles_for([:app, select: ->(h) { h.properties.inactive }])).to be_empty
         end
       end
 
-      describe "excluding by property" do
+      describe 'excluding by property' do
         before do
-          servers.add_host("1", roles: :app, active: true)
-          servers.add_host("2", roles: :app, active: true, no_release: true)
+          servers.add_host('1', roles: :app, active: true)
+          servers.add_host('2', roles: :app, active: true, no_release: true)
         end
 
-        it "is empty if the filter would remove all matching hosts" do
+        it 'is empty if the filter would remove all matching hosts' do
           hosts = servers.roles_for([:app, exclude: :active])
           expect(hosts.map(&:hostname)).to be_empty
         end
 
-        it "returns the servers without the attributes specified" do
+        it 'returns the servers without the attributes specified' do
           hosts = servers.roles_for([:app, exclude: :no_release])
           expect(hosts.map(&:hostname)).to eq %w{1}
         end
 
-        it "can exclude hosts by properties on the host using a regular proc" do
+        it 'can exclude hosts by properties on the host using a regular proc' do
           hosts = servers.roles_for([:app, exclude: ->(h) { h.properties.no_release }])
           expect(hosts.map(&:hostname)).to eq %w{1}
         end
 
-        it "is empty if the regular proc filter would remove all matching hosts" do
+        it 'is empty if the regular proc filter would remove all matching hosts' do
           hosts = servers.roles_for([:app, exclude: ->(h) { h.properties.active }])
           expect(hosts.map(&:hostname)).to be_empty
         end
       end
 
-      describe "filtering roles internally" do
+      describe 'filtering roles internally' do
         before do
-          servers.add_host("1", roles: :app, active: true)
-          servers.add_host("2", roles: :app)
-          servers.add_host("3", roles: :web)
-          servers.add_host("4", roles: :web)
-          servers.add_host("5", roles: :db)
+          servers.add_host('1', roles: :app, active: true)
+          servers.add_host('2', roles: :app)
+          servers.add_host('3', roles: :web)
+          servers.add_host('4', roles: :web)
+          servers.add_host('5', roles: :db)
         end
 
         subject { servers.roles_for(roles).map(&:hostname) }
 
-        context "with the ROLES environment variable set" do
+        context 'with the ROLES environment variable set' do
           before do
-            ENV.stubs(:[]).with("ROLES").returns("web,db")
-            ENV.stubs(:[]).with("HOSTS").returns(nil)
+            ENV.stubs(:[]).with('ROLES').returns('web,db')
+            ENV.stubs(:[]).with('HOSTS').returns(nil)
           end
 
-          context "when selecting all roles" do
+          context 'when selecting all roles' do
             let(:roles) { [:all] }
-            it "ignores it" do
+            it 'ignores it' do
               expect(subject).to eq %w{1 2 3 4 5}
             end
           end
 
-          context "when selecting specific roles" do
+          context 'when selecting specific roles' do
             let(:roles) { [:app, :web] }
-            it "ignores it" do
+            it 'ignores it' do
               expect(subject).to eq %w{1 2 3 4}
             end
           end
 
-          context "when selecting roles not included in ROLE" do
+          context 'when selecting roles not included in ROLE' do
             let(:roles) { [:app] }
-            it "ignores it" do
+            it 'ignores it' do
               expect(subject).to eq %w{1 2}
             end
           end
         end
 
-        context "with the HOSTS environment variable set" do
+        context 'with the HOSTS environment variable set' do
           before do
-            ENV.stubs(:[]).with("ROLES").returns(nil)
-            ENV.stubs(:[]).with("HOSTS").returns("3,5")
+            ENV.stubs(:[]).with('ROLES').returns(nil)
+            ENV.stubs(:[]).with('HOSTS').returns('3,5')
           end
 
-          context "when selecting all roles" do
+          context 'when selecting all roles' do
             let(:roles) { [:all] }
-            it "ignores it" do
+            it 'ignores it' do
               expect(subject).to eq %w{1 2 3 4 5}
             end
           end
 
-          context "when selecting specific roles" do
+          context 'when selecting specific roles' do
             let(:roles) { [:app, :web] }
-            it "ignores it" do
+            it 'ignores it' do
               expect(subject).to eq %w{1 2 3 4}
             end
           end
 
-          context "when selecting no roles" do
+          context 'when selecting no roles' do
             let(:roles) { [] }
-            it "ignores it" do
+            it 'ignores it' do
               expect(subject).to be_empty
             end
           end

--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -1,34 +1,34 @@
-require "spec_helper"
+require 'spec_helper'
 
 module Capistrano
   describe Configuration do
     let(:config) { Configuration.new }
     let(:servers) { stub }
 
-    describe ".new" do
-      it "accepts initial hash" do
-        configuration = described_class.new(custom: "value")
-        expect(configuration.fetch(:custom)).to eq("value")
+    describe '.new' do
+      it 'accepts initial hash' do
+        configuration = described_class.new(custom: 'value')
+        expect(configuration.fetch(:custom)).to eq('value')
       end
     end
 
-    describe ".env" do
-      it "is a global accessor to a single instance" do
+    describe '.env' do
+      it 'is a global accessor to a single instance' do
         Configuration.env.set(:test, true)
         expect(Configuration.env.fetch(:test)).to be_truthy
       end
     end
 
-    describe ".reset!" do
-      it "blows away the existing `env` and creates a new one" do
+    describe '.reset!' do
+      it 'blows away the existing `env` and creates a new one' do
         old_env = Configuration.env
         Configuration.reset!
         expect(Configuration.env).not_to be old_env
       end
     end
 
-    describe "roles" do
-      context "adding a role" do
+    describe 'roles' do
+      context 'adding a role' do
         subject { config.role(:app, %w{server1 server2}) }
 
         before do
@@ -36,43 +36,43 @@ module Capistrano
           servers.expects(:add_role).with(:app, %w{server1 server2}, {})
         end
 
-        it "adds the role" do
+        it 'adds the role' do
           expect(subject)
         end
       end
     end
 
-    describe "setting and fetching" do
+    describe 'setting and fetching' do
       subject { config.fetch(:key, :default) }
 
-      context "set" do
-        it "sets by value" do
+      context 'set' do
+        it 'sets by value' do
           config.set(:key, :value)
           expect(subject).to eq :value
         end
 
-        it "sets by block" do
+        it 'sets by block' do
           config.set(:key) { :value }
           expect(subject).to eq :value
         end
 
-        it "raises an exception when given both a value and block" do
+        it 'raises an exception when given both a value and block' do
           expect { config.set(:key, :value) { :value } }.to raise_error(Capistrano::ValidationError)
         end
       end
 
-      context "set_if_empty" do
-        it "sets by value when none is present" do
+      context 'set_if_empty' do
+        it 'sets by value when none is present' do
           config.set_if_empty(:key, :value)
           expect(subject).to eq :value
         end
 
-        it "sets by block when none is present" do
+        it 'sets by block when none is present' do
           config.set_if_empty(:key) { :value }
           expect(subject).to eq :value
         end
 
-        it "does not overwrite existing values" do
+        it 'does not overwrite existing values' do
           config.set(:key, :value)
           config.set_if_empty(:key, :update)
           config.set_if_empty(:key) { :update }
@@ -80,136 +80,136 @@ module Capistrano
         end
       end
 
-      context "value is not set" do
-        it "returns the default value" do
+      context 'value is not set' do
+        it 'returns the default value' do
           expect(subject).to eq :default
         end
       end
 
-      context "value is a proc" do
+      context 'value is a proc' do
         subject { config.fetch(:key, proc { :proc }) }
-        it "calls the proc" do
+        it 'calls the proc' do
           expect(subject).to eq :proc
         end
       end
 
-      context "value is a lambda" do
+      context 'value is a lambda' do
         subject { config.fetch(:key, -> { :lambda }) }
-        it "calls the lambda" do
+        it 'calls the lambda' do
           expect(subject).to eq :lambda
         end
       end
 
-      context "value inside proc inside a proc" do
-        subject { config.fetch(:key, proc { proc { "some value" } }) }
-        it "calls all procs and lambdas" do
-          expect(subject).to eq "some value"
+      context 'value inside proc inside a proc' do
+        subject { config.fetch(:key, proc { proc { 'some value' } }) }
+        it 'calls all procs and lambdas' do
+          expect(subject).to eq 'some value'
         end
       end
 
-      context "value inside lambda inside a lambda" do
-        subject { config.fetch(:key, -> { -> { "some value" } }) }
-        it "calls all procs and lambdas" do
-          expect(subject).to eq "some value"
+      context 'value inside lambda inside a lambda' do
+        subject { config.fetch(:key, -> { -> { 'some value' } }) }
+        it 'calls all procs and lambdas' do
+          expect(subject).to eq 'some value'
         end
       end
 
-      context "value inside lambda inside a proc" do
-        subject { config.fetch(:key, proc { -> { "some value" } }) }
-        it "calls all procs and lambdas" do
-          expect(subject).to eq "some value"
+      context 'value inside lambda inside a proc' do
+        subject { config.fetch(:key, proc { -> { 'some value' } }) }
+        it 'calls all procs and lambdas' do
+          expect(subject).to eq 'some value'
         end
       end
 
-      context "value inside proc inside a lambda" do
-        subject { config.fetch(:key, -> { proc { "some value" } }) }
-        it "calls all procs and lambdas" do
-          expect(subject).to eq "some value"
+      context 'value inside proc inside a lambda' do
+        subject { config.fetch(:key, -> { proc { 'some value' } }) }
+        it 'calls all procs and lambdas' do
+          expect(subject).to eq 'some value'
         end
       end
 
-      context "lambda with parameters" do
+      context 'lambda with parameters' do
         subject { config.fetch(:key, ->(c) { c }).call(42) }
-        it "is returned as a lambda" do
+        it 'is returned as a lambda' do
           expect(subject).to eq 42
         end
       end
 
-      context "block is passed to fetch" do
-        subject { config.fetch(:key, :default) { raise "we need this!" } }
+      context 'block is passed to fetch' do
+        subject { config.fetch(:key, :default) { raise 'we need this!' } }
 
-        it "returns the block value" do
+        it 'returns the block value' do
           expect { subject }.to raise_error(RuntimeError)
         end
       end
 
-      context "validations" do
+      context 'validations' do
         before do
           config.validate :key do |_, value|
             raise Capistrano::ValidationError unless value.length > 3
           end
         end
 
-        it "validates without error" do
-          config.set(:key, "longer_value")
+        it 'validates without error' do
+          config.set(:key, 'longer_value')
         end
 
-        it "raises an exception" do
-          expect { config.set(:key, "sho") }.to raise_error(Capistrano::ValidationError)
+        it 'raises an exception' do
+          expect { config.set(:key, 'sho') }.to raise_error(Capistrano::ValidationError)
         end
       end
 
-      context "appending" do
-        subject { config.append(:linked_dirs, "vendor/bundle", "tmp") }
+      context 'appending' do
+        subject { config.append(:linked_dirs, 'vendor/bundle', 'tmp') }
 
-        it "returns appended value" do
-          expect(subject).to eq ["vendor/bundle", "tmp"]
+        it 'returns appended value' do
+          expect(subject).to eq ['vendor/bundle', 'tmp']
         end
 
-        context "on non-array variable" do
-          before { config.set(:linked_dirs, "string") }
-          subject { config.append(:linked_dirs, "vendor/bundle") }
+        context 'on non-array variable' do
+          before { config.set(:linked_dirs, 'string') }
+          subject { config.append(:linked_dirs, 'vendor/bundle') }
 
-          it "returns appended value" do
-            expect(subject).to eq ["string", "vendor/bundle"]
+          it 'returns appended value' do
+            expect(subject).to eq ['string', 'vendor/bundle']
           end
         end
       end
 
-      context "removing" do
+      context 'removing' do
         before :each do
-          config.set(:linked_dirs, ["vendor/bundle", "tmp"])
+          config.set(:linked_dirs, ['vendor/bundle', 'tmp'])
         end
 
-        subject { config.remove(:linked_dirs, "vendor/bundle") }
+        subject { config.remove(:linked_dirs, 'vendor/bundle') }
 
-        it "returns without removed value" do
-          expect(subject).to eq ["tmp"]
+        it 'returns without removed value' do
+          expect(subject).to eq ['tmp']
         end
 
-        context "on non-array variable" do
-          before { config.set(:linked_dirs, "string") }
+        context 'on non-array variable' do
+          before { config.set(:linked_dirs, 'string') }
 
-          context "when removing same value" do
-            subject { config.remove(:linked_dirs, "string") }
+          context 'when removing same value' do
+            subject { config.remove(:linked_dirs, 'string') }
 
-            it "returns without removed value" do
+            it 'returns without removed value' do
               expect(subject).to eq []
             end
           end
 
-          context "when removing different value" do
-            subject { config.remove(:linked_dirs, "othervalue") }
+          context 'when removing different value' do
+            subject { config.remove(:linked_dirs, 'othervalue') }
 
-            it "returns without removed value" do
-              expect(subject).to eq ["string"]
+            it 'returns without removed value' do
+              expect(subject).to eq ['string']
             end
           end
         end
       end
     end
 
-    describe "keys" do
+    describe 'keys' do
       subject { config.keys }
 
       before do
@@ -217,23 +217,23 @@ module Capistrano
         config.set(:key2, :value2)
       end
 
-      it "returns all set keys" do
+      it 'returns all set keys' do
         expect(subject).to match_array [:key1, :key2]
       end
     end
 
-    describe "deleting" do
+    describe 'deleting' do
       before do
         config.set(:key, :value)
       end
 
-      it "deletes the value" do
+      it 'deletes the value' do
         config.delete(:key)
         expect(config.fetch(:key)).to be_nil
       end
     end
 
-    describe "asking" do
+    describe 'asking' do
       let(:question) { stub }
       let(:options) { Hash.new }
 
@@ -242,30 +242,30 @@ module Capistrano
                                .returns(question)
       end
 
-      it "prompts for the value when fetching" do
+      it 'prompts for the value when fetching' do
         config.ask(:branch, :default, options)
         expect(config.fetch(:branch)).to eq question
       end
     end
 
-    describe "setting the backend" do
-      it "by default, is SSHKit" do
+    describe 'setting the backend' do
+      it 'by default, is SSHKit' do
         expect(config.backend).to eq SSHKit
       end
 
-      it "can be set to another class" do
+      it 'can be set to another class' do
         config.backend = :test
         expect(config.backend).to eq :test
       end
 
-      describe "ssh_options for Netssh" do
-        it "merges them with the :ssh_options variable" do
+      describe 'ssh_options for Netssh' do
+        it 'merges them with the :ssh_options variable' do
           config.set :format, :pretty
           config.set :log_level, :debug
-          config.set :ssh_options, user: "albert"
-          SSHKit::Backend::Netssh.configure { |ssh| ssh.ssh_options = { password: "einstein" } }
+          config.set :ssh_options, user: 'albert'
+          SSHKit::Backend::Netssh.configure { |ssh| ssh.ssh_options = { password: 'einstein' } }
           config.configure_backend
-          expect(config.backend.config.backend.config.ssh_options).to eq(user: "albert", password: "einstein")
+          expect(config.backend.config.backend.config.ssh_options).to eq(user: 'albert', password: 'einstein')
         end
       end
     end

--- a/spec/lib/capistrano/dsl/paths_spec.rb
+++ b/spec/lib/capistrano/dsl/paths_spec.rb
@@ -1,15 +1,15 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe Capistrano::DSL::Paths do
   let(:dsl) { Class.new.extend Capistrano::DSL }
-  let(:parent) { Pathname.new("/var/shared") }
+  let(:parent) { Pathname.new('/var/shared') }
   let(:paths) { Class.new.extend Capistrano::DSL::Paths }
 
   let(:linked_dirs) { %w{log public/system} }
   let(:linked_files) { %w{config/database.yml log/my.log log/access.log} }
 
   before do
-    dsl.set(:deploy_to, "/var/www")
+    dsl.set(:deploy_to, '/var/www')
   end
 
   describe '#linked_dirs' do
@@ -19,10 +19,10 @@ describe Capistrano::DSL::Paths do
       paths.expects(:fetch).with(:linked_dirs).returns(linked_dirs)
     end
 
-    it "returns the full pathnames" do
+    it 'returns the full pathnames' do
       expect(subject).to eq [
-        Pathname.new("/var/shared/log"),
-        Pathname.new("/var/shared/public/system")
+        Pathname.new('/var/shared/log'),
+        Pathname.new('/var/shared/public/system')
       ]
     end
   end
@@ -34,11 +34,11 @@ describe Capistrano::DSL::Paths do
       paths.expects(:fetch).with(:linked_files).returns(linked_files)
     end
 
-    it "returns the full pathnames" do
+    it 'returns the full pathnames' do
       expect(subject).to eq [
-        Pathname.new("/var/shared/config/database.yml"),
-        Pathname.new("/var/shared/log/my.log"),
-        Pathname.new("/var/shared/log/access.log")
+        Pathname.new('/var/shared/config/database.yml'),
+        Pathname.new('/var/shared/log/my.log'),
+        Pathname.new('/var/shared/log/access.log')
       ]
     end
   end
@@ -50,10 +50,10 @@ describe Capistrano::DSL::Paths do
       paths.expects(:fetch).with(:linked_files).returns(linked_files)
     end
 
-    it "returns the full paths names of the parent dirs" do
+    it 'returns the full paths names of the parent dirs' do
       expect(subject).to eq [
-        Pathname.new("/var/shared/config"),
-        Pathname.new("/var/shared/log")
+        Pathname.new('/var/shared/config'),
+        Pathname.new('/var/shared/log')
       ]
     end
   end
@@ -65,10 +65,10 @@ describe Capistrano::DSL::Paths do
       paths.expects(:fetch).with(:linked_dirs).returns(linked_dirs)
     end
 
-    it "returns the full paths names of the parent dirs" do
+    it 'returns the full paths names of the parent dirs' do
       expect(subject).to eq [
-        Pathname.new("/var/shared"),
-        Pathname.new("/var/shared/public")
+        Pathname.new('/var/shared'),
+        Pathname.new('/var/shared/public')
       ]
     end
   end
@@ -76,49 +76,49 @@ describe Capistrano::DSL::Paths do
   describe '#release path' do
     subject { dsl.release_path }
 
-    context "where no release path has been set" do
+    context 'where no release path has been set' do
       before do
         dsl.delete(:release_path)
       end
 
-      it "returns the `current_path` value" do
-        expect(subject.to_s).to eq "/var/www/current"
+      it 'returns the `current_path` value' do
+        expect(subject.to_s).to eq '/var/www/current'
       end
     end
 
-    context "where the release path has been set" do
+    context 'where the release path has been set' do
       before do
-        dsl.set(:release_path, "/var/www/release_path")
+        dsl.set(:release_path, '/var/www/release_path')
       end
 
-      it "returns the set `release_path` value" do
-        expect(subject.to_s).to eq "/var/www/release_path"
+      it 'returns the set `release_path` value' do
+        expect(subject.to_s).to eq '/var/www/release_path'
       end
     end
   end
 
   describe '#set_release_path' do
-    let(:now) { Time.parse("Oct 21 16:29:00 2015") }
+    let(:now) { Time.parse('Oct 21 16:29:00 2015') }
     subject { dsl.release_path }
 
-    context "without a timestamp" do
+    context 'without a timestamp' do
       before do
         dsl.env.expects(:timestamp).returns(now)
         dsl.set_release_path
       end
 
-      it "returns the release path with the current env timestamp" do
-        expect(subject.to_s).to eq "/var/www/releases/20151021162900"
+      it 'returns the release path with the current env timestamp' do
+        expect(subject.to_s).to eq '/var/www/releases/20151021162900'
       end
     end
 
-    context "with a timestamp" do
+    context 'with a timestamp' do
       before do
-        dsl.set_release_path("timestamp")
+        dsl.set_release_path('timestamp')
       end
 
-      it "returns the release path with the timestamp" do
-        expect(subject.to_s).to eq "/var/www/releases/timestamp"
+      it 'returns the release path with the timestamp' do
+        expect(subject.to_s).to eq '/var/www/releases/timestamp'
       end
     end
   end
@@ -126,23 +126,23 @@ describe Capistrano::DSL::Paths do
   describe '#deploy_config_path' do
     subject { dsl.deploy_config_path.to_s }
 
-    context "when not specified" do
+    context 'when not specified' do
       before do
         dsl.delete(:deploy_config_path)
       end
 
       it 'returns "config/deploy.rb"' do
-        expect(subject).to eq "config/deploy.rb"
+        expect(subject).to eq 'config/deploy.rb'
       end
     end
 
-    context "when the variable :deploy_config_path is set" do
+    context 'when the variable :deploy_config_path is set' do
       before do
-        dsl.set(:deploy_config_path, "my/custom/path.rb")
+        dsl.set(:deploy_config_path, 'my/custom/path.rb')
       end
 
-      it "returns the custom path" do
-        expect(subject).to eq "my/custom/path.rb"
+      it 'returns the custom path' do
+        expect(subject).to eq 'my/custom/path.rb'
       end
     end
   end
@@ -150,23 +150,23 @@ describe Capistrano::DSL::Paths do
   describe '#stage_config_path' do
     subject { dsl.stage_config_path.to_s }
 
-    context "when not specified" do
+    context 'when not specified' do
       before do
         dsl.delete(:stage_config_path)
       end
 
       it 'returns "config/deploy"' do
-        expect(subject).to eq "config/deploy"
+        expect(subject).to eq 'config/deploy'
       end
     end
 
-    context "when the variable :stage_config_path is set" do
+    context 'when the variable :stage_config_path is set' do
       before do
-        dsl.set(:stage_config_path, "my/custom/path")
+        dsl.set(:stage_config_path, 'my/custom/path')
       end
 
-      it "returns the custom path" do
-        expect(subject).to eq "my/custom/path"
+      it 'returns the custom path' do
+        expect(subject).to eq 'my/custom/path'
       end
     end
   end
@@ -174,24 +174,24 @@ describe Capistrano::DSL::Paths do
   describe '#repo_path' do
     subject { dsl.repo_path.to_s }
 
-    context "when not specified" do
+    context 'when not specified' do
       before do
         dsl.delete(:repo_path)
       end
 
       it 'returns the default #{deploy_to}/repo' do
-        dsl.set(:deploy_to, "/var/www")
-        expect(subject).to eq "/var/www/repo"
+        dsl.set(:deploy_to, '/var/www')
+        expect(subject).to eq '/var/www/repo'
       end
     end
 
-    context "when the variable :repo_path is set" do
+    context 'when the variable :repo_path is set' do
       before do
-        dsl.set(:repo_path, "my/custom/path")
+        dsl.set(:repo_path, 'my/custom/path')
       end
 
-      it "returns the custom path" do
-        expect(subject).to eq "my/custom/path"
+      it 'returns the custom path' do
+        expect(subject).to eq 'my/custom/path'
       end
     end
   end

--- a/spec/lib/capistrano/dsl/task_enhancements_spec.rb
+++ b/spec/lib/capistrano/dsl/task_enhancements_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 module Capistrano
   class DummyTaskEnhancements
@@ -8,7 +8,7 @@ module Capistrano
   describe TaskEnhancements do
     let(:task_enhancements) { DummyTaskEnhancements.new }
 
-    describe "ordering" do
+    describe 'ordering' do
       after do
         task.clear
         before_task.clear
@@ -18,99 +18,99 @@ module Capistrano
 
       let(:order) { [] }
       let!(:task) do
-        Rake::Task.define_task("task", [:order]) do |_t, args|
-          args["order"].push "task"
+        Rake::Task.define_task('task', [:order]) do |_t, args|
+          args['order'].push 'task'
         end
       end
 
       let!(:before_task) do
-        Rake::Task.define_task("before_task") do
-          order.push "before_task"
+        Rake::Task.define_task('before_task') do
+          order.push 'before_task'
         end
       end
 
       let!(:after_task) do
-        Rake::Task.define_task("after_task") do
-          order.push "after_task"
+        Rake::Task.define_task('after_task') do
+          order.push 'after_task'
         end
       end
 
-      it "invokes in proper order if define after than before" do
-        task_enhancements.after("task", "after_task")
-        task_enhancements.before("task", "before_task")
+      it 'invokes in proper order if define after than before' do
+        task_enhancements.after('task', 'after_task')
+        task_enhancements.before('task', 'before_task')
 
-        Rake::Task["task"].invoke order
+        Rake::Task['task'].invoke order
 
         expect(order).to eq(%w(before_task task after_task))
       end
 
-      it "invokes in proper order if define before than after" do
-        task_enhancements.before("task", "before_task")
-        task_enhancements.after("task", "after_task")
+      it 'invokes in proper order if define before than after' do
+        task_enhancements.before('task', 'before_task')
+        task_enhancements.after('task', 'after_task')
 
-        Rake::Task["task"].invoke order
+        Rake::Task['task'].invoke order
 
         expect(order).to eq(%w(before_task task after_task))
       end
 
-      it "invokes in proper order when referring to as-yet undefined tasks" do
-        task_enhancements.after("task", "not_loaded_task")
+      it 'invokes in proper order when referring to as-yet undefined tasks' do
+        task_enhancements.after('task', 'not_loaded_task')
 
-        Rake::Task.define_task("not_loaded_task") do
-          order.push "not_loaded_task"
+        Rake::Task.define_task('not_loaded_task') do
+          order.push 'not_loaded_task'
         end
 
-        Rake::Task["task"].invoke order
+        Rake::Task['task'].invoke order
 
         expect(order).to eq(%w(task not_loaded_task))
       end
 
-      it "invokes in proper order and with arguments and block" do
-        task_enhancements.after("task", "after_task_custom", :order) do |_t, _args|
-          order.push "after_task"
+      it 'invokes in proper order and with arguments and block' do
+        task_enhancements.after('task', 'after_task_custom', :order) do |_t, _args|
+          order.push 'after_task'
         end
 
-        task_enhancements.before("task", "before_task_custom", :order) do |_t, _args|
-          order.push "before_task"
+        task_enhancements.before('task', 'before_task_custom', :order) do |_t, _args|
+          order.push 'before_task'
         end
 
-        Rake::Task["task"].invoke(order)
+        Rake::Task['task'].invoke(order)
 
         expect(order).to eq(%w(before_task task after_task))
       end
 
-      it "invokes using the correct namespace when defined within a namespace" do
-        Rake.application.in_namespace("namespace") do
-          Rake::Task.define_task("task") do |t|
+      it 'invokes using the correct namespace when defined within a namespace' do
+        Rake.application.in_namespace('namespace') do
+          Rake::Task.define_task('task') do |t|
             order.push(t.name)
           end
-          task_enhancements.before("task", "before_task", :order) do |t|
+          task_enhancements.before('task', 'before_task', :order) do |t|
             order.push(t.name)
           end
-          task_enhancements.after("task", "after_task", :order) do |t|
+          task_enhancements.after('task', 'after_task', :order) do |t|
             order.push(t.name)
           end
         end
 
-        Rake::Task["namespace:task"].invoke
+        Rake::Task['namespace:task'].invoke
 
         expect(order).to eq(
-          ["namespace:before_task", "namespace:task", "namespace:after_task"]
+          ['namespace:before_task', 'namespace:task', 'namespace:after_task']
         )
       end
     end
 
-    describe "remote_file" do
-      subject(:remote_file) { task_enhancements.remote_file("source" => "destination") }
+    describe 'remote_file' do
+      subject(:remote_file) { task_enhancements.remote_file('source' => 'destination') }
 
-      it { expect(remote_file.name).to eq("source") }
+      it { expect(remote_file.name).to eq('source') }
       it { is_expected.to be_a(Capistrano::UploadTask) }
 
-      describe "namespaced" do
+      describe 'namespaced' do
         let(:app) { Rake.application }
-        around { |ex| app.in_namespace("namespace", &ex) }
+        around { |ex| app.in_namespace('namespace', &ex) }
 
-        it { expect(remote_file.name).to eq("source") }
+        it { expect(remote_file.name).to eq('source') }
         it { is_expected.to be_a(Capistrano::UploadTask) }
       end
     end

--- a/spec/lib/capistrano/dsl_spec.rb
+++ b/spec/lib/capistrano/dsl_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 module Capistrano
   class DummyDSL
@@ -14,7 +14,7 @@ module Capistrano
         I18n.expects(:t).with(:phrase, count: 2, scope: :capistrano)
       end
 
-      it "delegates to I18n" do
+      it 'delegates to I18n' do
         dsl.t(:phrase, count: 2)
       end
     end
@@ -22,14 +22,14 @@ module Capistrano
     describe '#stage_set?' do
       subject { dsl.stage_set? }
 
-      context "stage is set" do
+      context 'stage is set' do
         before do
           dsl.set(:stage, :sandbox)
         end
         it { expect(subject).to be_truthy }
       end
 
-      context "stage is not set" do
+      context 'stage is not set' do
         before do
           dsl.set(:stage, nil)
         end
@@ -42,7 +42,7 @@ module Capistrano
         dsl.expects(:execute).with(:sudo, :my, :command)
       end
 
-      it "prepends sudo, delegates to execute" do
+      it 'prepends sudo, delegates to execute' do
         dsl.sudo(:my, :command)
       end
     end

--- a/spec/lib/capistrano/git_spec.rb
+++ b/spec/lib/capistrano/git_spec.rb
@@ -1,14 +1,14 @@
-require "spec_helper"
+require 'spec_helper'
 
-require "capistrano/git"
+require 'capistrano/git'
 
 module Capistrano
   describe Git do
     let(:context) { Class.new.new }
     subject { Capistrano::Git.new(context, Capistrano::Git::DefaultStrategy) }
 
-    describe "#git" do
-      it "should call execute git in the context, with arguments" do
+    describe '#git' do
+      it 'should call execute git in the context, with arguments' do
         context.expects(:execute).with(:git, :init)
         subject.git(:init)
       end
@@ -19,17 +19,17 @@ module Capistrano
     let(:context) { Class.new.new }
     subject { Capistrano::Git.new(context, Capistrano::Git::DefaultStrategy) }
 
-    describe "#test" do
-      it "should call test for repo HEAD" do
-        context.expects(:repo_path).returns("/path/to/repo")
-        context.expects(:test).with " [ -f /path/to/repo/HEAD ] "
+    describe '#test' do
+      it 'should call test for repo HEAD' do
+        context.expects(:repo_path).returns('/path/to/repo')
+        context.expects(:test).with ' [ -f /path/to/repo/HEAD ] '
 
         subject.test
       end
     end
 
-    describe "#check" do
-      it "should test the repo url" do
+    describe '#check' do
+      it 'should test the repo url' do
         context.expects(:repo_url).returns(:url)
         context.expects(:execute).with(:git, :'ls-remote --heads', :url).returns(true)
 
@@ -37,72 +37,72 @@ module Capistrano
       end
     end
 
-    describe "#clone" do
-      it "should run git clone" do
+    describe '#clone' do
+      it 'should run git clone' do
         context.expects(:fetch).with(:git_shallow_clone).returns(nil)
         context.expects(:repo_url).returns(:url)
         context.expects(:repo_path).returns(:path)
-        context.expects(:execute).with(:git, :clone, "--mirror", :url, :path)
+        context.expects(:execute).with(:git, :clone, '--mirror', :url, :path)
 
         subject.clone
       end
 
-      it "should run git clone in shallow mode" do
-        context.expects(:fetch).with(:git_shallow_clone).returns("1")
+      it 'should run git clone in shallow mode' do
+        context.expects(:fetch).with(:git_shallow_clone).returns('1')
         context.expects(:repo_url).returns(:url)
         context.expects(:repo_path).returns(:path)
 
-        context.expects(:execute).with(:git, :clone, "--mirror", "--depth", "1", "--no-single-branch", :url, :path)
+        context.expects(:execute).with(:git, :clone, '--mirror', '--depth', '1', '--no-single-branch', :url, :path)
 
         subject.clone
       end
     end
 
-    describe "#update" do
-      it "should run git update" do
+    describe '#update' do
+      it 'should run git update' do
         context.expects(:fetch).with(:git_shallow_clone).returns(nil)
-        context.expects(:execute).with(:git, :remote, :update, "--prune")
+        context.expects(:execute).with(:git, :remote, :update, '--prune')
 
         subject.update
       end
 
-      it "should run git update in shallow mode" do
-        context.expects(:fetch).with(:git_shallow_clone).returns("1")
+      it 'should run git update in shallow mode' do
+        context.expects(:fetch).with(:git_shallow_clone).returns('1')
         context.expects(:fetch).with(:branch).returns(:branch)
-        context.expects(:execute).with(:git, :fetch, "--depth", "1", "origin", :branch)
+        context.expects(:execute).with(:git, :fetch, '--depth', '1', 'origin', :branch)
 
         subject.update
       end
     end
 
-    describe "#release" do
-      it "should run git archive without a subtree" do
+    describe '#release' do
+      it 'should run git archive without a subtree' do
         context.expects(:fetch).with(:repo_tree).returns(nil)
         context.expects(:fetch).with(:branch).returns(:branch)
         context.expects(:release_path).returns(:path)
 
-        context.expects(:execute).with(:git, :archive, :branch, "| tar -x -f - -C", :path)
+        context.expects(:execute).with(:git, :archive, :branch, '| tar -x -f - -C', :path)
 
         subject.release
       end
 
-      it "should run git archive with a subtree" do
-        context.expects(:fetch).with(:repo_tree).returns("tree")
+      it 'should run git archive with a subtree' do
+        context.expects(:fetch).with(:repo_tree).returns('tree')
         context.expects(:fetch).with(:branch).returns(:branch)
         context.expects(:release_path).returns(:path)
 
-        context.expects(:execute).with(:git, :archive, :branch, "tree", "| tar -x --strip-components 1 -f - -C", :path)
+        context.expects(:execute).with(:git, :archive, :branch, 'tree', '| tar -x --strip-components 1 -f - -C', :path)
 
         subject.release
       end
     end
 
-    describe "#fetch_revision" do
-      it "should capture git rev-list" do
+    describe '#fetch_revision' do
+      it 'should capture git rev-list' do
         context.expects(:fetch).with(:branch).returns(:branch)
-        context.expects(:capture).with(:git, "rev-list --max-count=1 --abbrev-commit --abbrev=12 branch").returns("01abcde")
+        context.expects(:capture).with(:git, 'rev-list --max-count=1 --abbrev-commit --abbrev=12 branch').returns('01abcde')
         revision = subject.fetch_revision
-        expect(revision).to eq("01abcde")
+        expect(revision).to eq('01abcde')
       end
     end
   end

--- a/spec/lib/capistrano/hg_spec.rb
+++ b/spec/lib/capistrano/hg_spec.rb
@@ -1,14 +1,14 @@
-require "spec_helper"
+require 'spec_helper'
 
-require "capistrano/hg"
+require 'capistrano/hg'
 
 module Capistrano
   describe Hg do
     let(:context) { Class.new.new }
     subject { Capistrano::Hg.new(context, Capistrano::Hg::DefaultStrategy) }
 
-    describe "#hg" do
-      it "should call execute hg in the context, with arguments" do
+    describe '#hg' do
+      it 'should call execute hg in the context, with arguments' do
         context.expects(:execute).with(:hg, :init)
         subject.hg(:init)
       end
@@ -19,71 +19,71 @@ module Capistrano
     let(:context) { Class.new.new }
     subject { Capistrano::Hg.new(context, Capistrano::Hg::DefaultStrategy) }
 
-    describe "#test" do
-      it "should call test for repo HEAD" do
-        context.expects(:repo_path).returns("/path/to/repo")
-        context.expects(:test).with " [ -d /path/to/repo/.hg ] "
+    describe '#test' do
+      it 'should call test for repo HEAD' do
+        context.expects(:repo_path).returns('/path/to/repo')
+        context.expects(:test).with ' [ -d /path/to/repo/.hg ] '
 
         subject.test
       end
     end
 
-    describe "#check" do
-      it "should test the repo url" do
+    describe '#check' do
+      it 'should test the repo url' do
         context.expects(:repo_url).returns(:url)
-        context.expects(:execute).with(:hg, "id", :url)
+        context.expects(:execute).with(:hg, 'id', :url)
 
         subject.check
       end
     end
 
-    describe "#clone" do
-      it "should run hg clone" do
+    describe '#clone' do
+      it 'should run hg clone' do
         context.expects(:repo_url).returns(:url)
         context.expects(:repo_path).returns(:path)
 
-        context.expects(:execute).with(:hg, "clone", "--noupdate", :url, :path)
+        context.expects(:execute).with(:hg, 'clone', '--noupdate', :url, :path)
 
         subject.clone
       end
     end
 
-    describe "#update" do
-      it "should run hg update" do
-        context.expects(:execute).with(:hg, "pull")
+    describe '#update' do
+      it 'should run hg update' do
+        context.expects(:execute).with(:hg, 'pull')
 
         subject.update
       end
     end
 
-    describe "#release" do
-      it "should run hg archive without a subtree" do
+    describe '#release' do
+      it 'should run hg archive without a subtree' do
         context.expects(:fetch).with(:repo_tree).returns(nil)
         context.expects(:fetch).with(:branch).returns(:branch)
         context.expects(:release_path).returns(:path)
 
-        context.expects(:execute).with(:hg, "archive", :path, "--rev", :branch)
+        context.expects(:execute).with(:hg, 'archive', :path, '--rev', :branch)
 
         subject.release
       end
 
-      it "should run hg archive with a subtree" do
-        context.expects(:fetch).with(:repo_tree).returns("tree")
+      it 'should run hg archive with a subtree' do
+        context.expects(:fetch).with(:repo_tree).returns('tree')
         context.expects(:fetch).with(:branch).returns(:branch)
         context.expects(:release_path).returns(:path)
 
-        context.expects(:execute).with(:hg, "archive --type tgz -p . -I", "tree", "--rev", :branch, "| tar -x --strip-components 1 -f - -C", :path)
+        context.expects(:execute).with(:hg, 'archive --type tgz -p . -I', 'tree', '--rev', :branch, '| tar -x --strip-components 1 -f - -C', :path)
 
         subject.release
       end
     end
 
-    describe "#fetch_revision" do
-      it "should capture hg log" do
+    describe '#fetch_revision' do
+      it 'should capture hg log' do
         context.expects(:fetch).with(:branch).returns(:branch)
-        context.expects(:capture).with(:hg, "log --rev branch --template \"{node}\n\"").returns("01abcde")
+        context.expects(:capture).with(:hg, "log --rev branch --template \"{node}\n\"").returns('01abcde')
         revision = subject.fetch_revision
-        expect(revision).to eq("01abcde")
+        expect(revision).to eq('01abcde')
       end
     end
   end

--- a/spec/lib/capistrano/immutable_task_spec.rb
+++ b/spec/lib/capistrano/immutable_task_spec.rb
@@ -1,6 +1,6 @@
-require "spec_helper"
-require "rake"
-require "capistrano/immutable_task"
+require 'spec_helper'
+require 'rake'
+require 'capistrano/immutable_task'
 
 module Capistrano
   describe ImmutableTask do
@@ -9,10 +9,10 @@ module Capistrano
       Rake::Task.clear
     end
 
-    it "prints warning and raises when task is enhanced" do
+    it 'prints warning and raises when task is enhanced' do
       extend(Rake::DSL)
 
-      load_defaults = Rake::Task.define_task("load:defaults")
+      load_defaults = Rake::Task.define_task('load:defaults')
       load_defaults.extend(Capistrano::ImmutableTask)
 
       $stderr.expects(:puts).with do |message|

--- a/spec/lib/capistrano/plugin_spec.rb
+++ b/spec/lib/capistrano/plugin_spec.rb
@@ -1,5 +1,5 @@
-require "spec_helper"
-require "capistrano/plugin"
+require 'spec_helper'
+require 'capistrano/plugin'
 
 module Capistrano
   describe Plugin do
@@ -13,26 +13,26 @@ module Capistrano
       end
 
       def register_hooks
-        before "deploy:published", "hello"
+        before 'deploy:published', 'hello'
       end
     end
 
     class ExternalTasksPlugin < Capistrano::Plugin
       def define_tasks
         eval_rakefile(
-          File.expand_path("../../../support/tasks/plugin.rake", __FILE__)
+          File.expand_path('../../../support/tasks/plugin.rake', __FILE__)
         )
       end
 
       # Called from plugin.rake to demonstrate that helper methods work
       def hello
-        set :plugin_result, "hello"
+        set :plugin_result, 'hello'
       end
     end
 
     before do
       # Define an example task to allow testing hooks
-      task "deploy:published"
+      task 'deploy:published'
     end
 
     after do
@@ -41,19 +41,19 @@ module Capistrano
       Capistrano::Configuration.reset!
     end
 
-    it "defines tasks when constructed" do
+    it 'defines tasks when constructed' do
       DummyPlugin.new
-      expect(Rake::Task["hello"]).not_to be_nil
+      expect(Rake::Task['hello']).not_to be_nil
     end
 
-    it "registers hooks when constructed" do
+    it 'registers hooks when constructed' do
       DummyPlugin.new
-      expect(Rake::Task["deploy:published"].prerequisites).to include("hello")
+      expect(Rake::Task['deploy:published'].prerequisites).to include('hello')
     end
 
-    it "skips registering hooks if :hooks => false" do
+    it 'skips registering hooks if :hooks => false' do
       DummyPlugin.new(hooks: false)
-      expect(Rake::Task["deploy:published"].prerequisites).to be_empty
+      expect(Rake::Task['deploy:published'].prerequisites).to be_empty
     end
 
     it "doesn't call set_defaults immediately" do
@@ -61,19 +61,19 @@ module Capistrano
       dummy.expects(:set_defaults).never
     end
 
-    it "calls set_defaults during load:defaults" do
+    it 'calls set_defaults during load:defaults' do
       dummy = DummyPlugin.new
       dummy.expects(:set_defaults).once
-      Rake::Task["load:defaults"].invoke
+      Rake::Task['load:defaults'].invoke
     end
 
-    it "is able to load tasks from a .rake file" do
+    it 'is able to load tasks from a .rake file' do
       ExternalTasksPlugin.new
-      Rake::Task["plugin_test"].invoke
-      expect(fetch(:plugin_result)).to eq("hello")
+      Rake::Task['plugin_test'].invoke
+      expect(fetch(:plugin_result)).to eq('hello')
     end
 
-    it "exposes the SSHKit backend to subclasses" do
+    it 'exposes the SSHKit backend to subclasses' do
       SSHKit::Backend.expects(:current).returns(:backend)
       plugin = DummyPlugin.new
       expect(plugin.send(:backend)).to eq(:backend)

--- a/spec/lib/capistrano/scm_spec.rb
+++ b/spec/lib/capistrano/scm_spec.rb
@@ -1,6 +1,6 @@
-require "spec_helper"
+require 'spec_helper'
 
-require "capistrano/scm"
+require 'capistrano/scm'
 
 module RaiseNotImplementedMacro
   def raise_not_implemented_on(method)
@@ -18,7 +18,7 @@ end
 
 module DummyStrategy
   def test
-    test!("you dummy!")
+    test!('you dummy!')
   end
 end
 
@@ -28,48 +28,48 @@ module Capistrano
   describe SCM do
     let(:context) { Class.new.new }
 
-    describe "#initialize" do
+    describe '#initialize' do
       subject { Capistrano::SCM.new(context, DummyStrategy) }
 
-      it "should load the provided strategy" do
-        context.expects(:test).with("you dummy!")
+      it 'should load the provided strategy' do
+        context.expects(:test).with('you dummy!')
         subject.test
       end
     end
 
-    describe "Convenience methods" do
+    describe 'Convenience methods' do
       subject { Capistrano::SCM.new(context, BlindStrategy) }
 
-      describe "#test!" do
-        it "should return call test on the context" do
+      describe '#test!' do
+        it 'should return call test on the context' do
           context.expects(:test).with(:x)
           subject.test!(:x)
         end
       end
 
-      describe "#repo_url" do
-        it "should return the repo url according to the context" do
+      describe '#repo_url' do
+        it 'should return the repo url according to the context' do
           context.expects(:repo_url).returns(:url)
           expect(subject.repo_url).to eq(:url)
         end
       end
 
-      describe "#repo_path" do
-        it "should return the repo path according to the context" do
+      describe '#repo_path' do
+        it 'should return the repo path according to the context' do
           context.expects(:repo_path).returns(:path)
           expect(subject.repo_path).to eq(:path)
         end
       end
 
-      describe "#release_path" do
-        it "should return the release path according to the context" do
-          context.expects(:release_path).returns("/path/to/nowhere")
-          expect(subject.release_path).to eq("/path/to/nowhere")
+      describe '#release_path' do
+        it 'should return the release path according to the context' do
+          context.expects(:release_path).returns('/path/to/nowhere')
+          expect(subject.release_path).to eq('/path/to/nowhere')
         end
       end
 
-      describe "#fetch" do
-        it "should call fetch on the context" do
+      describe '#fetch' do
+        it 'should call fetch on the context' do
           context.expects(:fetch)
           subject.fetch(:branch)
         end
@@ -79,23 +79,23 @@ module Capistrano
     describe "With a 'blind' strategy" do
       subject { Capistrano::SCM.new(context, BlindStrategy) }
 
-      describe "#test" do
+      describe '#test' do
         raise_not_implemented_on(:test)
       end
 
-      describe "#check" do
+      describe '#check' do
         raise_not_implemented_on(:check)
       end
 
-      describe "#clone" do
+      describe '#clone' do
         raise_not_implemented_on(:clone)
       end
 
-      describe "#update" do
+      describe '#update' do
         raise_not_implemented_on(:update)
       end
 
-      describe "#release" do
+      describe '#release' do
         raise_not_implemented_on(:release)
       end
     end

--- a/spec/lib/capistrano/svn_spec.rb
+++ b/spec/lib/capistrano/svn_spec.rb
@@ -1,17 +1,17 @@
-require "spec_helper"
+require 'spec_helper'
 
-require "capistrano/svn"
+require 'capistrano/svn'
 
 module Capistrano
   describe Svn do
     let(:context) { Class.new.new }
     subject { Capistrano::Svn.new(context, Capistrano::Svn::DefaultStrategy) }
 
-    describe "#svn" do
-      it "should call execute svn in the context, with arguments" do
-        context.expects(:execute).with(:svn, :init, "--username someuser", "--password somepassword")
-        context.expects(:fetch).twice.with(:svn_username).returns("someuser")
-        context.expects(:fetch).twice.with(:svn_password).returns("somepassword")
+    describe '#svn' do
+      it 'should call execute svn in the context, with arguments' do
+        context.expects(:execute).with(:svn, :init, '--username someuser', '--password somepassword')
+        context.expects(:fetch).twice.with(:svn_username).returns('someuser')
+        context.expects(:fetch).twice.with(:svn_password).returns('somepassword')
         context.expects(:fetch).once.with(:svn_revision).returns(nil)
         subject.svn(:init)
       end
@@ -22,83 +22,83 @@ module Capistrano
     let(:context) { Class.new.new }
     subject { Capistrano::Svn.new(context, Capistrano::Svn::DefaultStrategy) }
 
-    describe "#test" do
-      it "should call test for repo HEAD" do
-        context.expects(:repo_path).returns("/path/to/repo")
-        context.expects(:test).with " [ -d /path/to/repo/.svn ] "
+    describe '#test' do
+      it 'should call test for repo HEAD' do
+        context.expects(:repo_path).returns('/path/to/repo')
+        context.expects(:test).with ' [ -d /path/to/repo/.svn ] '
 
         subject.test
       end
     end
 
-    describe "#check" do
-      it "should test the repo url" do
+    describe '#check' do
+      it 'should test the repo url' do
         context.expects(:repo_url).returns(:url)
-        context.expects(:test).with(:svn, :info, :url, "--username someuser", "--password somepassword").returns(true)
-        context.expects(:fetch).twice.with(:svn_username).returns("someuser")
-        context.expects(:fetch).twice.with(:svn_password).returns("somepassword")
+        context.expects(:test).with(:svn, :info, :url, '--username someuser', '--password somepassword').returns(true)
+        context.expects(:fetch).twice.with(:svn_username).returns('someuser')
+        context.expects(:fetch).twice.with(:svn_password).returns('somepassword')
 
         subject.check
       end
     end
 
-    describe "#clone" do
-      it "should run svn checkout" do
+    describe '#clone' do
+      it 'should run svn checkout' do
         context.expects(:repo_url).returns(:url)
         context.expects(:repo_path).returns(:path)
-        context.expects(:fetch).twice.with(:svn_username).returns("someuser")
-        context.expects(:fetch).twice.with(:svn_password).returns("somepassword")
+        context.expects(:fetch).twice.with(:svn_username).returns('someuser')
+        context.expects(:fetch).twice.with(:svn_password).returns('somepassword')
         context.expects(:fetch).once.with(:svn_revision).returns(nil)
 
-        context.expects(:execute).with(:svn, :checkout, :url, :path, "--username someuser", "--password somepassword")
+        context.expects(:execute).with(:svn, :checkout, :url, :path, '--username someuser', '--password somepassword')
 
         subject.clone
       end
     end
 
-    describe "#update" do
-      it "should run svn update" do
-        context.expects(:execute).with(:svn, :update, "--username someuser", "--password somepassword")
-        context.expects(:fetch).twice.with(:svn_username).returns("someuser")
-        context.expects(:fetch).twice.with(:svn_password).returns("somepassword")
+    describe '#update' do
+      it 'should run svn update' do
+        context.expects(:execute).with(:svn, :update, '--username someuser', '--password somepassword')
+        context.expects(:fetch).twice.with(:svn_username).returns('someuser')
+        context.expects(:fetch).twice.with(:svn_password).returns('somepassword')
         context.expects(:fetch).once.with(:svn_revision).returns(nil)
 
         subject.update
       end
     end
 
-    describe "#update_specific_revision" do
-      it "should run svn update and update to a specific revision" do
-        context.expects(:execute).with(:svn, :update, "--username someuser", "--password somepassword", "--revision 12345")
-        context.expects(:fetch).twice.with(:svn_username).returns("someuser")
-        context.expects(:fetch).twice.with(:svn_password).returns("somepassword")
-        context.expects(:fetch).twice.with(:svn_revision).returns("12345")
+    describe '#update_specific_revision' do
+      it 'should run svn update and update to a specific revision' do
+        context.expects(:execute).with(:svn, :update, '--username someuser', '--password somepassword', '--revision 12345')
+        context.expects(:fetch).twice.with(:svn_username).returns('someuser')
+        context.expects(:fetch).twice.with(:svn_password).returns('somepassword')
+        context.expects(:fetch).twice.with(:svn_revision).returns('12345')
 
         subject.update
       end
     end
 
-    describe "#release" do
-      it "should run svn export" do
+    describe '#release' do
+      it 'should run svn export' do
         context.expects(:release_path).returns(:path)
-        context.expects(:fetch).twice.with(:svn_username).returns("someuser")
-        context.expects(:fetch).twice.with(:svn_password).returns("somepassword")
+        context.expects(:fetch).twice.with(:svn_username).returns('someuser')
+        context.expects(:fetch).twice.with(:svn_password).returns('somepassword')
         context.expects(:fetch).once.with(:svn_revision).returns(nil)
 
-        context.expects(:execute).with(:svn, :export, "--force", ".", :path, "--username someuser", "--password somepassword")
+        context.expects(:execute).with(:svn, :export, '--force', '.', :path, '--username someuser', '--password somepassword')
 
         subject.release
       end
     end
 
-    describe "#fetch_revision" do
-      it "should capture svn version" do
+    describe '#fetch_revision' do
+      it 'should capture svn version' do
         context.expects(:repo_path).returns(:path)
 
-        context.expects(:capture).with(:svnversion, :path).returns("12345")
+        context.expects(:capture).with(:svnversion, :path).returns('12345')
 
         revision = subject.fetch_revision
-        expect(revision).to eq("12345")
+        expect(revision).to eq('12345')
       end
     end
   end

--- a/spec/lib/capistrano/upload_task_spec.rb
+++ b/spec/lib/capistrano/upload_task_spec.rb
@@ -1,19 +1,19 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe Capistrano::UploadTask do
   let(:app) { Rake.application = Rake::Application.new }
 
-  subject(:upload_task) { described_class.define_task("path/file.yml") }
+  subject(:upload_task) { described_class.define_task('path/file.yml') }
 
   it { is_expected.to be_a(Rake::FileCreationTask) }
   it { is_expected.to be_needed }
 
-  context "inside namespace" do
-    let(:normal_task) { Rake::Task.define_task("path/other_file.yml") }
+  context 'inside namespace' do
+    let(:normal_task) { Rake::Task.define_task('path/other_file.yml') }
 
-    around { |ex| app.in_namespace("namespace", &ex) }
+    around { |ex| app.in_namespace('namespace', &ex) }
 
-    it { expect(upload_task.name).to eq("path/file.yml") }
-    it { expect(upload_task.scope.path).to eq("namespace") }
+    it { expect(upload_task.name).to eq('path/file.yml') }
+    it { expect(upload_task.scope.path).to eq('namespace') }
   end
 end

--- a/spec/lib/capistrano/version_validator_spec.rb
+++ b/spec/lib/capistrano/version_validator_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 module Capistrano
   describe VersionValidator do
@@ -6,13 +6,13 @@ module Capistrano
     let(:version) { stub }
 
     describe '#new' do
-      it "takes a version" do
+      it 'takes a version' do
         expect(validator)
       end
     end
 
     describe '#verify' do
-      let(:current_version) { "3.0.1" }
+      let(:current_version) { '3.0.1' }
 
       subject { validator.verify }
 
@@ -20,71 +20,71 @@ module Capistrano
         validator.stubs(:current_version).returns(current_version)
       end
 
-      context "with exact version" do
-        context "valid" do
-          let(:version) { "3.0.1" }
+      context 'with exact version' do
+        context 'valid' do
+          let(:version) { '3.0.1' }
           it { expect(subject).to be_truthy }
         end
 
-        context "invalid - lower" do
-          let(:version) { "3.0.0" }
+        context 'invalid - lower' do
+          let(:version) { '3.0.0' }
 
-          it "fails" do
+          it 'fails' do
             expect { subject }.to raise_error(RuntimeError)
           end
         end
 
-        context "invalid - higher" do
-          let(:version) { "3.0.2" }
+        context 'invalid - higher' do
+          let(:version) { '3.0.2' }
 
-          it "fails" do
+          it 'fails' do
             expect { subject }.to raise_error(RuntimeError)
           end
         end
       end
 
-      context "with optimistic versioning" do
-        context "valid" do
-          let(:version) { ">= 3.0.0" }
+      context 'with optimistic versioning' do
+        context 'valid' do
+          let(:version) { '>= 3.0.0' }
           it { expect(subject).to be_truthy }
         end
 
-        context "invalid - lower" do
-          let(:version) { "<= 2.0.0" }
+        context 'invalid - lower' do
+          let(:version) { '<= 2.0.0' }
 
-          it "fails" do
+          it 'fails' do
             expect { subject }.to raise_error(RuntimeError)
           end
         end
       end
 
-      context "with pessimistic versioning" do
-        context "2 decimal places" do
-          context "valid" do
-            let(:version) { "~> 3.0.0" }
+      context 'with pessimistic versioning' do
+        context '2 decimal places' do
+          context 'valid' do
+            let(:version) { '~> 3.0.0' }
             it { expect(subject).to be_truthy }
           end
 
-          context "invalid" do
-            let(:version) { "~> 3.1.0" }
+          context 'invalid' do
+            let(:version) { '~> 3.1.0' }
 
-            it "fails" do
+            it 'fails' do
               expect { subject }.to raise_error(RuntimeError)
             end
           end
         end
 
-        context "1 decimal place" do
-          let(:current_version) { "3.5.0" }
+        context '1 decimal place' do
+          let(:current_version) { '3.5.0' }
 
-          context "valid" do
-            let(:version) { "~> 3.1" }
+          context 'valid' do
+            let(:version) { '~> 3.1' }
             it { expect(subject).to be_truthy }
           end
 
-          context "invalid" do
-            let(:version) { "~> 3.6" }
-            it "fails" do
+          context 'invalid' do
+            let(:version) { '~> 3.6' }
+            it 'fails' do
               expect { subject }.to raise_error(RuntimeError)
             end
           end

--- a/spec/lib/capistrano_spec.rb
+++ b/spec/lib/capistrano_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 module Capistrano
   describe Application do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,9 @@
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
-require "capistrano/all"
-require "rspec"
-require "mocha/api"
-require "time"
+require 'capistrano/all'
+require 'rspec'
+require 'mocha/api'
+require 'time'
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
@@ -12,5 +12,5 @@ Dir['#{File.dirname(__FILE__)}/support/**/*.rb'].each { |f| require f }
 RSpec.configure do |config|
   config.raise_errors_for_deprecations!
   config.mock_framework = :mocha
-  config.order = "random"
+  config.order = 'random'
 end

--- a/spec/support/Vagrantfile
+++ b/spec/support/Vagrantfile
@@ -1,16 +1,16 @@
-require "open-uri"
+require 'open-uri'
 
-Vagrant.configure("2") do |config|
+Vagrant.configure('2') do |config|
   config.ssh.insert_key = false
 
   [:app].each_with_index do |role, i|
     config.vm.define(role, primary: true) do |primary|
       primary.vm.define role
-      primary.vm.box = "hashicorp/precise64"
-      primary.vm.network "forwarded_port", guest: 22, host: "222#{i}".to_i
-      primary.vm.provision :shell, inline: "sudo apt-get -y install git-core"
+      primary.vm.box = 'hashicorp/precise64'
+      primary.vm.network 'forwarded_port', guest: 22, host: "222#{i}".to_i
+      primary.vm.provision :shell, inline: 'sudo apt-get -y install git-core'
 
-      vagrantkey = open("https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub", "r", &:read)
+      vagrantkey = open('https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub', 'r', &:read)
 
       primary.vm.provision :shell,
                            inline: <<-INLINE

--- a/spec/support/tasks/database.rake
+++ b/spec/support/tasks/database.rake
@@ -1,11 +1,11 @@
 namespace :deploy do
   namespace :check do
-    task linked_files: "config/database.yml"
+    task linked_files: 'config/database.yml'
   end
 end
 
-remote_file "config/database.yml" => "/tmp/database.yml", :roles => :all
+remote_file 'config/database.yml' => '/tmp/database.yml', :roles => :all
 
-file "/tmp/database.yml" do |t|
+file '/tmp/database.yml' do |t|
   sh "touch #{t.name}"
 end

--- a/spec/support/tasks/fail.rake
+++ b/spec/support/tasks/fail.rake
@@ -1,8 +1,8 @@
 set :fail, proc { raise }
-before "deploy:starting", :fail do
+before 'deploy:starting', :fail do
   on roles :all do
-    execute :mkdir, "-p", shared_path
-    execute :touch, shared_path.join("fail")
+    execute :mkdir, '-p', shared_path
+    execute :touch, shared_path.join('fail')
   end
   fetch(:fail)
 end

--- a/spec/support/tasks/failed.rake
+++ b/spec/support/tasks/failed.rake
@@ -1,5 +1,5 @@
-after "deploy:failed", :custom_failed do
+after 'deploy:failed', :custom_failed do
   on roles :all do
-    execute :touch, shared_path.join("failed")
+    execute :touch, shared_path.join('failed')
   end
 end

--- a/spec/support/tasks/root.rake
+++ b/spec/support/tasks/root.rake
@@ -1,11 +1,11 @@
 task :am_i_root do
   on roles(:all) do |host|
-    host.user = "root"
-    ident = capture :id, "-a"
+    host.user = 'root'
+    ident = capture :id, '-a'
     info "I am #{ident}"
   end
   on roles(:all) do |_host|
-    ident = capture :id, "-a"
+    ident = capture :id, '-a'
     info "I am #{ident}"
   end
 end

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -1,6 +1,6 @@
-require "English"
-require "fileutils"
-require "pathname"
+require 'English'
+require 'fileutils'
+require 'pathname'
 
 module TestApp
   extend self
@@ -38,7 +38,7 @@ module TestApp
     FileUtils.rm_rf(test_app_path)
     FileUtils.mkdir(test_app_path)
 
-    File.open(gemfile, "w+") do |file|
+    File.open(gemfile, 'w+') do |file|
       file.write "gem 'capistrano', path: '#{path_to_cap}'"
     end
 
@@ -56,20 +56,20 @@ module TestApp
   end
 
   def write_local_deploy_file(config)
-    File.open(test_stage_path, "w") do |file|
+    File.open(test_stage_path, 'w') do |file|
       file.write config
     end
   end
 
   def append_to_deploy_file(config)
-    File.open(test_stage_path, "a") do |file|
+    File.open(test_stage_path, 'a') do |file|
       file.write config + "\n"
     end
   end
 
   def prepend_to_capfile(config)
     current_capfile = File.read(capfile)
-    File.open(capfile, "w") do |file|
+    File.open(capfile, 'w') do |file|
       file.write config
       file.write current_capfile
     end
@@ -80,7 +80,7 @@ module TestApp
   end
 
   def create_shared_file(path)
-    File.open(shared_path.join(path), "w")
+    File.open(shared_path.join(path), 'w')
   end
 
   def cap(task)
@@ -96,31 +96,31 @@ module TestApp
   end
 
   def stage
-    "test"
+    'test'
   end
 
   def test_stage_path
-    test_app_path.join("config/deploy/test.rb")
+    test_app_path.join('config/deploy/test.rb')
   end
 
   def test_app_path
-    Pathname.new("/tmp/test_app")
+    Pathname.new('/tmp/test_app')
   end
 
   def deploy_to
-    Pathname.new("/home/vagrant/var/www/deploy")
+    Pathname.new('/home/vagrant/var/www/deploy')
   end
 
   def shared_path
-    deploy_to.join("shared")
+    deploy_to.join('shared')
   end
 
   def current_path
-    deploy_to.join("current")
+    deploy_to.join('current')
   end
 
   def releases_path
-    deploy_to.join("releases")
+    deploy_to.join('releases')
   end
 
   def release_path
@@ -128,23 +128,23 @@ module TestApp
   end
 
   def timestamp
-    Time.now.utc.strftime("%Y%m%d%H%M%S")
+    Time.now.utc.strftime('%Y%m%d%H%M%S')
   end
 
   def repo_path
-    deploy_to.join("repo")
+    deploy_to.join('repo')
   end
 
   def path_to_cap
-    File.expand_path(".")
+    File.expand_path('.')
   end
 
   def gemfile
-    test_app_path.join("Gemfile")
+    test_app_path.join('Gemfile')
   end
 
   def capfile
-    test_app_path.join("Capfile")
+    test_app_path.join('Capfile')
   end
 
   def current_user
@@ -152,7 +152,7 @@ module TestApp
   end
 
   def task_dir
-    test_app_path.join("lib/capistrano/tasks")
+    test_app_path.join('lib/capistrano/tasks')
   end
 
   def copy_task_to_test_app(source)
@@ -160,7 +160,7 @@ module TestApp
   end
 
   def config_path
-    test_app_path.join("config")
+    test_app_path.join('config')
   end
 
   def move_configuration_to_custom_location(location)


### PR DESCRIPTION
For discussion.

This changes the default syntax to single quotes unless there is string interpolation or apostrophes.

Followup to https://github.com/capistrano/capistrano/pull/1594