### PR TITLE
Enforce %Q syntax for string literals (disallow bare %)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,8 @@ AllCops:
   DisplayStyleGuide: true
   TargetRubyVersion: 2.0
 
+Style/BarePercentLiterals:
+  EnforcedStyle: percent_q
 Style/ClassAndModuleChildren:
   Enabled: false
 Style/DoubleNegation:

--- a/features/support/remote_command_helpers.rb
+++ b/features/support/remote_command_helpers.rb
@@ -12,7 +12,7 @@ module RemoteCommandHelpers
   end
 
   def exists?(type, path)
-    %{[ -#{type} "#{path}" ]}
+    %Q{[ -#{type} "#{path}" ]}
   end
 
   def safely_remove_file(_path)

--- a/lib/capistrano/defaults.rb
+++ b/lib/capistrano/defaults.rb
@@ -1,7 +1,7 @@
 validate :application do |_key, value|
   changed_value = value.gsub(/[^A-Z0-9\.\-]/i, "_")
   if value != changed_value
-    warn %(The :application value "#{value}" is invalid!)
+    warn %Q(The :application value "#{value}" is invalid!)
     warn "Use only letters, numbers, hyphens, dots, and underscores. For example:"
     warn "  set :application, '#{changed_value}'"
     raise Capistrano::ValidationError

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -192,7 +192,7 @@ namespace :deploy do
   task :log_revision do
     on release_roles(:all) do
       within releases_path do
-        execute :echo, %{"#{revision_log_message}" >> #{revision_log}}
+        execute :echo, %Q{"#{revision_log_message}" >> #{revision_log}}
       end
     end
   end

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -9,7 +9,7 @@ module TestApp
   end
 
   def default_config
-    %{
+    <<-CONFIG
       set :deploy_to, '#{deploy_to}'
       set :repo_url, 'git://github.com/capistrano/capistrano.git'
       set :branch, 'master'
@@ -18,7 +18,7 @@ module TestApp
       set :linked_files, #{linked_files}
       set :linked_dirs, #{linked_dirs}
       set :format_options, log_file: nil
-    }
+    CONFIG
   end
 
   def linked_files
@@ -164,10 +164,10 @@ module TestApp
 
   def move_configuration_to_custom_location(location)
     prepend_to_capfile(
-      %{
+      <<-CONFIG
         set :stage_config_path, "app/config/deploy"
         set :deploy_config_path, "app/config/deploy.rb"
-      }
+      CONFIG
     )
 
     location = test_app_path.join(location)


### PR DESCRIPTION
Here's one more RuboCop suggestion.

By default, RuboCop prefers using the bare `%` for declaring string literals that contain both single and double quotes, like this:

```ruby
%{Isn't this "great".}
```

`%Q` does the same thing, but it is more explicit:

```ruby
%Q{Isn't this "great".}
```

I prefer the latter syntax. Many times I have made the mistake where I mean to declare an array using `%w`, but I forget the `w` and end up with a `%` string instead. It is a subtle typo and can be easy to miss.

```ruby
%(one two three)  # Looks like an array but it's not
%w(one two three) # What I meant to write
```

Prohibiting the use of bare `%` helps prevent this mistake.

/cc @will-in-wi 