### PR TITLE
Do not abbreviate git revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Other changes:
   * Allow dot in :application name (@marcovtwout)
   * Fixed git-ssh permission error (@spight)
   * Added option to set specific revision when using Subversion as SCM (@marcovtwout)
+  * SHA1 hash of current git revision written to REVISION file is no longer abbreviated
 
 ## `3.4.0`
 

--- a/lib/capistrano/git.rb
+++ b/lib/capistrano/git.rb
@@ -48,7 +48,7 @@ class Capistrano::Git < Capistrano::SCM
     end
 
     def fetch_revision
-      context.capture(:git, "rev-list --max-count=1 --abbrev-commit --abbrev=12 #{fetch(:branch)}")
+      context.capture(:git, "rev-list --max-count=1 #{fetch(:branch)}")
     end
   end
 end

--- a/spec/lib/capistrano/git_spec.rb
+++ b/spec/lib/capistrano/git_spec.rb
@@ -100,9 +100,9 @@ module Capistrano
     describe "#fetch_revision" do
       it "should capture git rev-list" do
         context.expects(:fetch).with(:branch).returns(:branch)
-        context.expects(:capture).with(:git, "rev-list --max-count=1 --abbrev-commit --abbrev=12 branch").returns("01abcde")
+        context.expects(:capture).with(:git, "rev-list --max-count=1 branch").returns("81cec13b777ff46348693d327fc8e7832f79bf43")
         revision = subject.fetch_revision
-        expect(revision).to eq("01abcde")
+        expect(revision).to eq("81cec13b777ff46348693d327fc8e7832f79bf43")
       end
     end
   end


### PR DESCRIPTION
There doesn't seem to be any significant benefit in forcing the revision SHA to be a shorter length. 

@z5h brings up some good points here: https://github.com/capistrano/capistrano/pull/1469
and here: https://github.com/capistrano/capistrano/pull/1423

If someone needs the abbreviated version of the revision, then they can always shorten it themselves. It's a lot harder to get the full SHA out of an abbreviated version.
