### PR TITLE
Added a dry_run? helper method to the DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Reverse Chronological Order:
 
 https://github.com/capistrano/capistrano/compare/v3.4.0...HEAD
 
+* Added a `dry_run?` helper method
 **You'll notice a big cosmetic change in this release: the default logging
 format has been changed to
 [Airbrussh](https://github.com/mattbrictson/airbrussh).** For more details on

--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -147,6 +147,10 @@ module Capistrano
       @filters.reduce(list) { |l, f| f.filter l }
     end
 
+    def dry_run?
+      fetch(:sshkit_backend) == SSHKit::Backend::Printer
+    end
+
     private
 
     def cmdline_filters

--- a/lib/capistrano/dsl/env.rb
+++ b/lib/capistrano/dsl/env.rb
@@ -6,7 +6,7 @@ module Capistrano
       extend Forwardable
       def_delegators :env,
                      :configure_backend, :fetch, :set, :set_if_empty, :delete,
-                     :ask, :role, :server, :primary, :validate, :append, :remove
+                     :ask, :role, :server, :primary, :validate, :append, :remove, :dry_run?
 
       def is_question?(key)
         env.is_question?(key)

--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -269,5 +269,17 @@ module Capistrano
         end
       end
     end
+
+    describe "dry_run?" do
+      it "returns false when using default backend" do
+        expect(config.dry_run?).to eq(false)
+      end
+
+      it "returns true when using printer backend" do
+        config.set :sshkit_backend, SSHKit::Backend::Printer
+
+        expect(config.dry_run?).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
Added a `Configuration#dry_run?` helper method and delegated to it from `DSL::Env`, as discussed in #1564.