### PR TITLE
Mention the 2.x docs since the wiki is now gone

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ end
 after "deploy:published", "restart_sidekiq"
 ```
 
+*Note: This documentation is for the current version of Capistrano (3.x). If you are looking for Capistrano 2.x documentation, you can find it in [this archive](https://github.com/capistrano/capistrano-2.x-docs).*
+
 ---
 
 ## Contents


### PR DESCRIPTION
Now that the wiki is turned off (#1646), it would be nice to give 2.x users a hint at where to find the old docs. This adds a short mention to the README.