### PR TITLE
Implement Harrow.io integration on `cap install`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and how to configure it, visit the
   instead of `Capfile`. (@mattbrictson)
 * Added option to set specific revision when using Subversion as SCM (@marcovtwout)
 * Deduplicate list of linked directories
+* Integration with Harrow.io (See http://capistranorb.com/documentation/harrow/) when running `cap install`
 
 ### Fixes:
 

--- a/capistrano.gemspec
+++ b/capistrano.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "i18n"
   gem.add_dependency "rake", ">= 10.0.0"
   gem.add_dependency "sshkit", ">= 1.9.0"
+  gem.add_dependency "capistrano-harrow"
 
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "mocha"

--- a/lib/Capfile
+++ b/lib/Capfile
@@ -1,3 +1,7 @@
 #!/usr/bin/env cap
 include Capistrano::DSL
 require "capistrano/install"
+
+require "capistrano/harrow"
+require "capistrano/harrow/plugin"
+install_plugin Capistrano::Harrow::Plugin


### PR DESCRIPTION
More information and background regarding this change can be found:

- http://capistranorb.com/documentation/harrow/
- http://lee.hambley.name/2016/04/24/seven-years-under-a-palm-tree.html
- https://github.com/harrowio/capistrano-harrow