### PR TITLE
Explicit requirement of Ruby >= 2.0, reflection of that in the changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,7 @@ and how to configure it, visit the
 
 ### Potentially breaking changes:
 
-* Drop support for Ruby 1.9.3 (Capistrano may still work with 1.9.3, but it is
-  no longer officially supported)
+* Drop support for Ruby 1.9.3 (Capistrano does no longer work with 1.9.3)
 * Git version 1.6.3 or greater is now required
 * Remove 'vendor/bundle' from default :linked_dirs (@ojab)
 * Old versions of SSHKit (before 1.9.0) are no longer supported

--- a/capistrano.gemspec
+++ b/capistrano.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.licenses      = ["MIT"]
 
-  gem.required_ruby_version = ">= 1.9.3"
+  gem.required_ruby_version = ">= 2.0"
   gem.add_dependency "airbrussh", ">= 1.0.0"
   gem.add_dependency "i18n"
   gem.add_dependency "rake", ">= 10.0.0"


### PR DESCRIPTION
This is a PR as suggested in #1656.