### PR TITLE
Restricting the uploaded git wrapper file permissions to 700.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Reverse Chronological Order:
 
 https://github.com/capistrano/capistrano/compare/v3.5.0...HEAD
 
+  * Restrict the uploaded git wrapper script permissions to 700 (@irvingwashington)
   * Make path to git wrapper script configurable (@thickpaddy)
   * Change git wrapper path to work better with multiple users (@thickpaddy)
   * Make name of current directory configurable via configuration variable `:current_directory` (@websi)

--- a/features/deploy.feature
+++ b/features/deploy.feature
@@ -8,6 +8,7 @@ Feature: Deploy
     When I run cap "git:check"
     Then the task is successful
     And references in the remote repo are listed
+    And git wrapper permissions are 0700
 
   Scenario: Creating the directory structure
     When I run cap "deploy:check:directories"

--- a/features/step_definitions/assertions.rb
+++ b/features/step_definitions/assertions.rb
@@ -2,6 +2,11 @@ Then(/^references in the remote repo are listed$/) do
   expect(@output).to include("refs/heads/master")
 end
 
+Then(/^git wrapper permissions are 0700$/) do
+  permissions_test = %Q([ $(stat -c "%a" #{TestApp.git_wrapper_path}) == "700" ])
+  expect(vagrant_cli_command("ssh -c '#{permissions_test}'")).to be_success
+end
+
 Then(/^the shared path is created$/) do
   run_vagrant_command(test_dir_exists(TestApp.shared_path))
 end

--- a/lib/capistrano/tasks/git.rake
+++ b/lib/capistrano/tasks/git.rake
@@ -22,7 +22,7 @@ namespace :git do
     on release_roles :all do
       execute :mkdir, "-p", File.dirname(fetch(:git_wrapper_path))
       upload! StringIO.new("#!/bin/sh -e\nexec /usr/bin/ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no \"$@\"\n"), fetch(:git_wrapper_path)
-      execute :chmod, "+rx", fetch(:git_wrapper_path)
+      execute :chmod, "700", fetch(:git_wrapper_path)
     end
   end
 

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -175,4 +175,8 @@ module TestApp
     FileUtils.mkdir_p(location)
     FileUtils.mv(config_path, location)
   end
+
+  def git_wrapper_path
+    "/tmp/git-ssh-my_app_name-#{stage}-#{current_user}.sh"
+  end
 end


### PR DESCRIPTION
Additional step in the 'Creating the repo' scenario to test this adjustment.

Fixes #910 