### PR TITLE
Raise a better error when an ‘after’ hook isn’t found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Reverse Chronological Order:
 
 https://github.com/capistrano/capistrano/compare/v3.5.0...HEAD
 
+  * Raise a better error when an ‘after’ hook isn’t found (@jdelStrother)
   * Restrict the uploaded git wrapper script permissions to 700 (@irvingwashington)
   * Make path to git wrapper script configurable (@thickpaddy)
   * Change git wrapper path to work better with multiple users (@thickpaddy)

--- a/lib/capistrano/dsl/task_enhancements.rb
+++ b/lib/capistrano/dsl/task_enhancements.rb
@@ -11,7 +11,9 @@ module Capistrano
       Rake::Task.define_task(post_task, *args, &block) if block_given?
       task = Rake::Task[task]
       task.enhance do
-        Rake.application.lookup(post_task, task.scope).invoke
+        post = Rake.application.lookup(post_task, task.scope)
+        raise ArgumentError, "Task #{post_task.inspect} not found" unless post
+        post.invoke
       end
     end
 

--- a/spec/lib/capistrano/dsl/task_enhancements_spec.rb
+++ b/spec/lib/capistrano/dsl/task_enhancements_spec.rb
@@ -98,6 +98,11 @@ module Capistrano
           ["namespace:before_task", "namespace:task", "namespace:after_task"]
         )
       end
+
+      it "raises a sensible error if the task isn't found" do
+        task_enhancements.after("task", "non_existent_task")
+        expect { Rake::Task["task"].invoke order }.to raise_error(ArgumentError, 'Task "non_existent_task" not found')
+      end
     end
 
     describe "remote_file" do


### PR DESCRIPTION
Prior to this, if an after-hook didn’t exist, we’d end up calling `nil.invoke`, which would end up in the DSL `invoke` method and raise “wrong number of arguments (0 for 1+)”

WDYT?