### PR TITLE
WIP: Making the default :application validator accept blocks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Reverse Chronological Order:
 ## master
 
 https://github.com/capistrano/capistrano/compare/v3.5.0...HEAD
-
+  * Make the default :application validator handle blocks correctly (@irvingwashington)
   * Raise a better error when an ‘after’ hook isn’t found (@jdelStrother)
   * Restrict the uploaded git wrapper script permissions to 700 (@irvingwashington)
   * Make path to git wrapper script configurable (@thickpaddy)

--- a/lib/capistrano/defaults.rb
+++ b/lib/capistrano/defaults.rb
@@ -1,4 +1,6 @@
-validate :application do |_key, value|
+validate :application do |_key, value_or_block|
+  value = value_or_block.respond_to?(:call) ? value_or_block.call : value_or_block
+
   changed_value = value.gsub(/[^A-Z0-9\.\-]/i, "_")
   if value != changed_value
     warn %Q(The :application value "#{value}" is invalid!)


### PR DESCRIPTION
I'm in doubt regarding tests for this. Ideally I'd test the validator on it's own, but it also makes sense to test the `set :application, -> { "some_name" }` case integrated. 
Please let me know what you think, and I'll update this PR.

(work in progress) Fixes #1681