### PR TITLE
Use git_wrapper_path when setting GIT_SSH

### DIFF
--- a/lib/capistrano/tasks/git.rake
+++ b/lib/capistrano/tasks/git.rake
@@ -13,7 +13,7 @@ namespace :git do
   set :git_environmental_variables, lambda {
     {
       git_askpass: "/bin/echo",
-      git_ssh: "#{fetch(:tmp_dir)}/#{fetch(:application)}/git-ssh.sh"
+      git_ssh: fetch(:git_wrapper_path)
     }
   }
 


### PR DESCRIPTION
Apologies, this went missing when resolving merge conflicts for #1517 

@mattbrictson could you test this for me? Sorry, not using Capistrano at the moment, and don't have anything set up to test locally. Thanks.