### PR TITLE
Don't assume that variables are keys

### DIFF
--- a/lib/capistrano/doctor/variables_doctor.rb
+++ b/lib/capistrano/doctor/variables_doctor.rb
@@ -20,18 +20,17 @@ module Capistrano
         title("Variables")
         values = inspect_all_values
 
-        table(variables.keys.sort) do |key, row|
+        table(variables.keys.sort_by(&:to_s)) do |key, row|
           row.yellow if suspicious_keys.include?(key)
-          row << ":#{key}"
+          row << key.inspect
           row << values[key]
         end
 
         puts if suspicious_keys.any?
 
-        suspicious_keys.sort.each do |key|
-          warning(
-            ":#{key} is not a recognized Capistrano setting (#{location(key)})"
-          )
+        suspicious_keys.sort_by(&:to_s).each do |key|
+          warning("#{key.inspect} is not a recognized Capistrano setting "\
+                  "(#{location(key)})")
         end
       end
 

--- a/spec/lib/capistrano/doctor/variables_doctor_spec.rb
+++ b/spec/lib/capistrano/doctor/variables_doctor_spec.rb
@@ -17,6 +17,7 @@ module Capistrano
           set :repo_url, ".git"
           set :copy_strategy, :scp
           set :custom_setting, "hello"
+          set "string_setting", "hello"
           ask :secret
         end
 
@@ -36,6 +37,7 @@ module Capistrano
         expect { doc.call }.to output(/:repo_url\s+".git"$/).to_stdout
         expect { doc.call }.to output(/:copy_strategy\s+:scp$/).to_stdout
         expect { doc.call }.to output(/:custom_setting\s+"hello"$/).to_stdout
+        expect { doc.call }.to output(/"string_setting"\s+"hello"$/).to_stdout
       end
 
       it "prints unanswered question variable as <ask>" do


### PR DESCRIPTION
I'm not sure why, but based on a recent bug report (#1691) it seems possible that a variable could have a string key rather than a symbol key. This commit fixes a `comparison of Symbol with String failed` error in that scenario by calling `to_s` before sorting.

Fixes #1691.