### PR TITLE
add customizable variables doctor

### DIFF
--- a/lib/capistrano/doctor/variables_doctor.rb
+++ b/lib/capistrano/doctor/variables_doctor.rb
@@ -12,7 +12,8 @@ module Capistrano
 
       include Capistrano::Doctor::OutputHelpers
 
-      def initialize(env=Capistrano::Configuration.env)
+      def initialize(additional_variables_whitelist=%i(), env=Capistrano::Configuration.env)
+        @additional_variables_whitelist = additional_variables_whitelist
         @env = env
       end
 
@@ -53,12 +54,16 @@ module Capistrano
       end
 
       def suspicious_keys
-        (variables.untrusted_keys & variables.unused_keys) - WHITELIST
+        (variables.untrusted_keys & variables.unused_keys) - actual_whitelist
       end
 
       def location(key)
         loc = variables.source_locations(key).first
         loc && loc.sub(/^#{Regexp.quote(Dir.pwd)}/, "").sub(/:in.*/, "")
+      end
+
+      def actual_whitelist
+        WHITELIST | @additional_variables_whitelist
       end
     end
   end

--- a/lib/capistrano/tasks/doctor.rake
+++ b/lib/capistrano/tasks/doctor.rake
@@ -14,7 +14,7 @@ namespace :doctor do
 
   desc "Display the values of all Capistrano variables"
   task :variables do
-    Capistrano::Doctor::VariablesDoctor.new.call
+    Capistrano::Doctor::VariablesDoctor.new(fetch(:doctor_variables_whitelist, %i())).call
   end
 
   desc "Display the effective servers configuration"


### PR DESCRIPTION
Variable `:doctor_variables_whitelist` (array of symbols, defaults to emtpy array) can now be set to customize additional variables for variables doctor