### PR TITLE
Updating the variables in the VariblesDoctor WHITELIST.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ https://github.com/capistrano/capistrano/compare/v3.5.0...HEAD
   * Make path to git wrapper script configurable (@thickpaddy)
   * Change git wrapper path to work better with multiple users (@thickpaddy)
   * Make name of current directory configurable via configuration variable `:current_directory` (@websi)
-  * Updating the variables in the VariblesDoctor WHITELIST. (@shanesaww)
+  * `doctor` no longer erroneously warns that `:git_strategy` and other SCM options are "unrecognized" (@shanesaww)
 
 ## `3.5.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ https://github.com/capistrano/capistrano/compare/v3.5.0...HEAD
   * Make path to git wrapper script configurable (@thickpaddy)
   * Change git wrapper path to work better with multiple users (@thickpaddy)
   * Make name of current directory configurable via configuration variable `:current_directory` (@websi)
+  * Updating the variables in the VariblesDoctor WHITELIST. (@shanesaww)
 
 ## `3.5.0`
 

--- a/lib/capistrano/doctor/variables_doctor.rb
+++ b/lib/capistrano/doctor/variables_doctor.rb
@@ -7,7 +7,7 @@ module Capistrano
     class VariablesDoctor
       # These are keys that have no default values in Capistrano, but are
       # nonetheless expected to be set.
-      WHITELIST = [:application, :repo_url].freeze
+      WHITELIST = [:application, :repo_url, :git_strategy, :hg_strategy, :svn_strategy].freeze
       private_constant :WHITELIST
 
       include Capistrano::Doctor::OutputHelpers

--- a/spec/lib/capistrano/doctor/variables_doctor_spec.rb
+++ b/spec/lib/capistrano/doctor/variables_doctor_spec.rb
@@ -15,6 +15,7 @@ module Capistrano
         env.variables.untrusted! do
           set :application, "my_app"
           set :repo_url, ".git"
+          set :git_strategy, "Capistrano::Git::DefaultStrategy"
           set :copy_strategy, :scp
           set :custom_setting, "hello"
           set "string_setting", "hello"
@@ -53,6 +54,12 @@ module Capistrano
       it "does not print warning for unrecognized variable that is fetched" do
         expect { doc.call }.not_to \
           output(/:custom_setting is not a recognized Capistrano setting/)\
+          .to_stdout
+      end
+
+      it "does not print warning for the whitelisted git_strategy variable" do
+        expect { doc.call }.not_to \
+          output(/:git_strategy is not a recognized Capistrano setting/)\
           .to_stdout
       end
 


### PR DESCRIPTION
This PR fixes: #1694 by adding `:git_strategy, :hg_strategy, :svn_strategy` to the Whitelist for VariablesDoctor. 