### PR TITLE
Fix specs according changes in sshkit 1.11

### DIFF
--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -265,7 +265,10 @@ module Capistrano
           config.set :ssh_options, user: "albert"
           SSHKit::Backend::Netssh.configure { |ssh| ssh.ssh_options = { password: "einstein" } }
           config.configure_backend
-          expect(config.backend.config.backend.config.ssh_options).to eq(user: "albert", password: "einstein")
+
+          expect(
+            config.backend.config.backend.config.ssh_options
+          ).to include(user: "albert", password: "einstein")
         end
       end
     end


### PR DESCRIPTION
SSHkit 1.11 adds a `:known_hosts` option to `ssh_options`,
which breaks one spec in the current master.