### PR TITLE
Fix brittle server configuration spec

### DIFF
--- a/spec/lib/capistrano/doctor/servers_doctor_spec.rb
+++ b/spec/lib/capistrano/doctor/servers_doctor_spec.rb
@@ -57,6 +57,7 @@ module Capistrano
       end
 
       it "doesn't fail for no servers" do
+        Capistrano::Configuration.reset!
         expect { doc.call }.to output("\nServers (0)\n    \n").to_stdout
       end
 


### PR DESCRIPTION
The `servers_doctor_spec.rb` was randomly failing for me (can be reproduced with `bundle exec rspec --seed 5127`), because the server configuration was not reset after some of the specs.