### PR TITLE
Fix latest violations identified by Rubocop 0.41

### DIFF
--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -7,7 +7,7 @@ require_relative "configuration/validated_variables"
 require_relative "configuration/variables"
 
 module Capistrano
-  class ValidationError < Exception; end
+  class ValidationError < RuntimeError; end
 
   class Configuration
     def self.env

--- a/spec/lib/capistrano/configuration/empty_filter_spec.rb
+++ b/spec/lib/capistrano/configuration/empty_filter_spec.rb
@@ -5,7 +5,7 @@ module Capistrano
     describe EmptyFilter do
       subject(:empty_filter) { EmptyFilter.new }
 
-      describe '#filter' do
+      describe "#filter" do
         let(:servers) { mock("servers") }
 
         it "returns an empty array" do

--- a/spec/lib/capistrano/configuration/filter_spec.rb
+++ b/spec/lib/capistrano/configuration/filter_spec.rb
@@ -13,7 +13,7 @@ module Capistrano
         ]
       end
 
-      describe '#new' do
+      describe "#new" do
         it "won't create an invalid type of filter" do
           expect do
             Filter.new(:zarg)
@@ -73,12 +73,12 @@ module Capistrano
         end
       end
 
-      describe '#filter' do
+      describe "#filter" do
         let(:strategy) { filter.instance_variable_get(:@strategy) }
         let(:results) { mock("result") }
 
-        shared_examples 'it calls #filter on its strategy' do
-          it 'calls #filter on its strategy' do
+        shared_examples "it calls #filter on its strategy" do
+          it "calls #filter on its strategy" do
             strategy.expects(:filter).with(available).returns(results)
             expect(filter.filter(available)).to eq(results)
           end
@@ -86,22 +86,22 @@ module Capistrano
 
         context "for an empty filter" do
           let(:filter) { Filter.new(:role) }
-          it_behaves_like 'it calls #filter on its strategy'
+          it_behaves_like "it calls #filter on its strategy"
         end
 
         context "for a null filter" do
           let(:filter) { Filter.new(:role, :all) }
-          it_behaves_like 'it calls #filter on its strategy'
+          it_behaves_like "it calls #filter on its strategy"
         end
 
         context "for a role filter" do
           let(:filter) { Filter.new(:role, "web") }
-          it_behaves_like 'it calls #filter on its strategy'
+          it_behaves_like "it calls #filter on its strategy"
         end
 
         context "for a host filter" do
           let(:filter) { Filter.new(:host, "server1") }
-          it_behaves_like 'it calls #filter on its strategy'
+          it_behaves_like "it calls #filter on its strategy"
         end
       end
     end

--- a/spec/lib/capistrano/configuration/host_filter_spec.rb
+++ b/spec/lib/capistrano/configuration/host_filter_spec.rb
@@ -20,7 +20,7 @@ module Capistrano
         end
       end
 
-      describe '#filter' do
+      describe "#filter" do
         context "with a string" do
           let(:values) { "server1" }
           it_behaves_like "it filters hosts correctly", %w{server1}

--- a/spec/lib/capistrano/configuration/null_filter_spec.rb
+++ b/spec/lib/capistrano/configuration/null_filter_spec.rb
@@ -5,7 +5,7 @@ module Capistrano
     describe NullFilter do
       subject(:null_filter) { NullFilter.new }
 
-      describe '#filter' do
+      describe "#filter" do
         let(:servers) { mock("servers") }
 
         it "returns the servers passed in as arguments" do

--- a/spec/lib/capistrano/configuration/question_spec.rb
+++ b/spec/lib/capistrano/configuration/question_spec.rb
@@ -15,7 +15,7 @@ module Capistrano
         end
       end
 
-      describe '#call' do
+      describe "#call" do
         context "value is entered" do
           let(:branch) { "branch" }
 

--- a/spec/lib/capistrano/configuration/role_filter_spec.rb
+++ b/spec/lib/capistrano/configuration/role_filter_spec.rb
@@ -23,7 +23,7 @@ module Capistrano
         end
       end
 
-      describe '#filter' do
+      describe "#filter" do
         context "with a single role string" do
           let(:values) { "web" }
           it_behaves_like "it filters roles correctly", 2, %w{server1 server2}

--- a/spec/lib/capistrano/configuration/server_spec.rb
+++ b/spec/lib/capistrano/configuration/server_spec.rb
@@ -141,7 +141,7 @@ module Capistrano
         end
       end
 
-      describe '#include?' do
+      describe "#include?" do
         let(:options) { {} }
 
         subject { server.select?(options) }

--- a/spec/lib/capistrano/dsl/paths_spec.rb
+++ b/spec/lib/capistrano/dsl/paths_spec.rb
@@ -12,7 +12,7 @@ describe Capistrano::DSL::Paths do
     dsl.set(:deploy_to, "/var/www")
   end
 
-  describe '#linked_dirs' do
+  describe "#linked_dirs" do
     subject { paths.linked_dirs(parent) }
 
     before do
@@ -27,7 +27,7 @@ describe Capistrano::DSL::Paths do
     end
   end
 
-  describe '#linked_files' do
+  describe "#linked_files" do
     subject { paths.linked_files(parent) }
 
     before do
@@ -43,7 +43,7 @@ describe Capistrano::DSL::Paths do
     end
   end
 
-  describe '#linked_file_dirs' do
+  describe "#linked_file_dirs" do
     subject { paths.linked_file_dirs(parent) }
 
     before do
@@ -58,7 +58,7 @@ describe Capistrano::DSL::Paths do
     end
   end
 
-  describe '#linked_dir_parents' do
+  describe "#linked_dir_parents" do
     subject { paths.linked_dir_parents(parent) }
 
     before do
@@ -73,7 +73,7 @@ describe Capistrano::DSL::Paths do
     end
   end
 
-  describe '#release path' do
+  describe "#release path" do
     subject { dsl.release_path }
 
     context "where no release path has been set" do
@@ -97,7 +97,7 @@ describe Capistrano::DSL::Paths do
     end
   end
 
-  describe '#set_release_path' do
+  describe "#set_release_path" do
     let(:now) { Time.parse("Oct 21 16:29:00 2015") }
     subject { dsl.release_path }
 
@@ -123,7 +123,7 @@ describe Capistrano::DSL::Paths do
     end
   end
 
-  describe '#deploy_config_path' do
+  describe "#deploy_config_path" do
     subject { dsl.deploy_config_path.to_s }
 
     context "when not specified" do
@@ -147,7 +147,7 @@ describe Capistrano::DSL::Paths do
     end
   end
 
-  describe '#stage_config_path' do
+  describe "#stage_config_path" do
     subject { dsl.stage_config_path.to_s }
 
     context "when not specified" do
@@ -171,7 +171,7 @@ describe Capistrano::DSL::Paths do
     end
   end
 
-  describe '#repo_path' do
+  describe "#repo_path" do
     subject { dsl.repo_path.to_s }
 
     context "when not specified" do

--- a/spec/lib/capistrano/dsl_spec.rb
+++ b/spec/lib/capistrano/dsl_spec.rb
@@ -9,7 +9,7 @@ module Capistrano
   describe DSL do
     let(:dsl) { DummyDSL.new }
 
-    describe '#t' do
+    describe "#t" do
       before do
         I18n.expects(:t).with(:phrase, count: 2, scope: :capistrano)
       end
@@ -19,7 +19,7 @@ module Capistrano
       end
     end
 
-    describe '#stage_set?' do
+    describe "#stage_set?" do
       subject { dsl.stage_set? }
 
       context "stage is set" do
@@ -37,7 +37,7 @@ module Capistrano
       end
     end
 
-    describe '#sudo' do
+    describe "#sudo" do
       before do
         dsl.expects(:execute).with(:sudo, :my, :command)
       end

--- a/spec/lib/capistrano/version_validator_spec.rb
+++ b/spec/lib/capistrano/version_validator_spec.rb
@@ -5,13 +5,13 @@ module Capistrano
     let(:validator) { VersionValidator.new(version) }
     let(:version) { stub }
 
-    describe '#new' do
+    describe "#new" do
       it "takes a version" do
         expect(validator)
       end
     end
 
-    describe '#verify' do
+    describe "#verify" do
       let(:current_version) { "3.0.1" }
 
       subject { validator.verify }


### PR DESCRIPTION
The latest version of Rubocop flags some new violations that were missed previously. This PR fixes them.

* Lint/InheritException: Inherit from RuntimeError instead of Exception.
* Style/StringLiterals: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping. (https://github.com/bbatsov/ruby-style-guide#consistent-string-literals)
