### PR TITLE
Skip RuboCop in Travis for Rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ rvm:
   - 2.2
   - 2.1
   - 2.0
-  - rbx-2
+matrix:
+  include:
+    # Run specs on Rubinius, but not RuboCop, since it seg faults
+    - rvm: rbx-2
+      script: bundle exec rake spec
 script: bundle exec rake spec rubocop
 install: bundle install --jobs=1
 cache: bundler


### PR DESCRIPTION
For some reason Rubinius seg faults sometimes when running RuboCop on Travis. Rather than have periodically failing builds, just disable it. We still get adequate coverage because RuboCop results shouldn't be different for rbx anyway.