### PR TITLE
Remove :clear_cache example from deploy.rb template

### DIFF
--- a/lib/capistrano/templates/deploy.rb.erb
+++ b/lib/capistrano/templates/deploy.rb.erb
@@ -34,16 +34,3 @@ set :repo_url, 'git@example.com:me/my_repo.git'
 
 # Default value for keep_releases is 5
 # set :keep_releases, 5
-
-namespace :deploy do
-
-  after :restart, :clear_cache do
-    on roles(:web), in: :groups, limit: 3, wait: 10 do
-      # Here we can do anything such as:
-      # within release_path do
-      #   execute :rake, 'cache:clear'
-      # end
-    end
-  end
-
-end


### PR DESCRIPTION
This example was confusing for beginners. Remove it for now until we can replace it with something more beginner-friendly, like a link to a video tutorial.

Fixes #1716 

cc @leehambley 