### PR TITLE
Print a warning if a task is skipped because of re-invocation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Reverse Chronological Order:
 
 https://github.com/capistrano/capistrano/compare/v3.5.0...HEAD
 
+  * Added warning about future deprecation of reinvocation behaviour (@troelskn)
   * Added a `doctor:servers` subtask that outputs a summary of servers, roles & properties (@irvingwashington)
   * Raise a better error when an ‘after’ hook isn’t found (@jdelStrother)
   * Restrict the uploaded git wrapper script permissions to 700 (@irvingwashington)

--- a/spec/lib/capistrano/dsl_spec.rb
+++ b/spec/lib/capistrano/dsl_spec.rb
@@ -69,5 +69,16 @@ module Capistrano
         end
       end
     end
+
+    describe "#invoke" do
+      it "will print a message on stderr, when reinvoking task" do
+        Rake::Task.define_task("some_task")
+
+        dsl.invoke("some_task")
+        expect do
+          dsl.invoke("some_task")
+        end.to output(/.*Capistrano tasks may only be invoked once.*/).to_stderr
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves #1689