### PR TITLE
Ensure validation works for callable values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Reverse Chronological Order:
 
 https://github.com/capistrano/capistrano/compare/v3.6.0...HEAD
 
+* Fix `NoMethodError: undefined method gsub` when setting `:application` to a Proc, for real this time! The original fix released in 3.6.0 worked for values specified with blocks, but not for those specified with procs or lambdas (the latter syntax is much more common). [#1681](https://github.com/capistrano/capistrano/issues/1681)
 * Your contribution here!
 
 ## `3.6.0` (2016-07-26)

--- a/lib/capistrano/configuration/validated_variables.rb
+++ b/lib/capistrano/configuration/validated_variables.rb
@@ -7,9 +7,9 @@ module Capistrano
     # user-supplied validation rules. Each rule for a given key is invoked
     # immediately whenever `set` is called with a value for that key.
     #
-    # If `set` is called with a block, validation is not performed immediately.
-    # Instead, the validation rules are invoked the first time `fetch` is used
-    # to access the value.
+    # If `set` is called with a callable value or a block, validation is not
+    # performed immediately. Instead, the validation rules are invoked the first
+    # time `fetch` is used to access the value.
     #
     # A rule is simply a block that accepts two arguments: key and value. It is
     # up to the rule to raise an exception when it deems the value is invalid
@@ -31,10 +31,18 @@ module Capistrano
 
       # Decorate Variables#set to add validation behavior.
       def set(key, value=nil, &block)
-        if value.nil? && callable_without_parameters?(block)
-          super(key, nil, &assert_valid_later(key, &block))
+        assert_value_or_block_not_both(value, block)
+
+        # Skip validation behavior if no validators are registered for this key
+        return super unless validators.key?(key)
+
+        value_to_evaluate = block || value
+
+        if callable_without_parameters?(value_to_evaluate)
+          add_validation_to_call_method(key, value_to_evaluate)
+          super(key, value_to_evaluate, &nil)
         else
-          assert_valid_now(key, block || value)
+          assert_valid(key, value_to_evaluate)
           super
         end
       end
@@ -50,12 +58,26 @@ module Capistrano
 
       attr_reader :validators
 
-      # Wrap a block with a proc that validates the value of the block. This
-      # allows us to defer validation until the time the value is requested.
-      def assert_valid_later(key)
-        lambda do
-          value = yield
-          assert_valid_now(key, value)
+      # Patch the #call method of a callable object with logic that validates
+      # the return value. This allows us to defer validation until the time the
+      # callable's value is requested.
+      #
+      # Essentially we are changing the behavior of #call but leaving the rest
+      # of the callable object as-is. This is important because the callable
+      # might be a Question object, and want it to remain a Question object so
+      # that Configuration#is_question? still works.
+      #
+      def add_validation_to_call_method(key, callable)
+        # Note that `self` changes meaning inside the `define_singleton_method`
+        # block, so we have to explicitly assign it to a variable to retain
+        # access to it.
+        variables = self
+
+        callable.define_singleton_method(:call) do
+          value = super()
+          # Need to use `send` because #assert_valid is private and we can't
+          # access using the normal `self.assert_valid` in this context.
+          variables.send(:assert_valid, key, value)
           value
         end
       end
@@ -63,11 +85,16 @@ module Capistrano
       # Runs all validation rules registered for the given key against the
       # user-supplied value for that variable. If no validator raises an
       # exception, the value is assumed to be valid.
-      def assert_valid_now(key, value)
-        return unless validators.key?(key)
-
+      def assert_valid(key, value)
         validators[key].each do |validator|
           validator.call(key, value)
+        end
+      end
+
+      def assert_value_or_block_not_both(value, block)
+        unless value.nil? || block.nil?
+          raise Capistrano::ValidationError,
+                "Value and block both passed to Configuration#set"
         end
       end
     end

--- a/lib/capistrano/configuration/variables.rb
+++ b/lib/capistrano/configuration/variables.rb
@@ -35,7 +35,6 @@ module Capistrano
       end
 
       def set(key, value=nil, &block)
-        assert_value_or_block_not_both(value, block)
         @trusted_keys << key if trusted?
         remember_location(key)
         values[key] = block || value
@@ -102,13 +101,6 @@ module Capistrano
           IGNORED_LOCATIONS.none? { |i| line.include?(i) }
         end
         (locations[key] ||= []) << location
-      end
-
-      def assert_value_or_block_not_both(value, block)
-        unless value.nil? || block.nil?
-          raise Capistrano::ValidationError,
-                "Value and block both passed to Configuration#set"
-        end
       end
 
       def trace_set(key)

--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -154,8 +154,13 @@ module Capistrano
           config.set(:key, "longer_value")
         end
 
-        it "validates proc without error" do
+        it "validates block without error" do
           config.set(:key) { "longer_value" }
+          expect(config.fetch(:key)).to eq "longer_value"
+        end
+
+        it "validates lambda without error" do
+          config.set :key, -> { "longer_value" }
           expect(config.fetch(:key)).to eq "longer_value"
         end
 
@@ -163,8 +168,13 @@ module Capistrano
           expect { config.set(:key, "sho") }.to raise_error(Capistrano::ValidationError)
         end
 
-        it "raises an exception on invalid string provided by proc" do
+        it "raises an exception on invalid string provided by block" do
           config.set(:key) { "sho" }
+          expect { config.fetch(:key) }.to raise_error(Capistrano::ValidationError)
+        end
+
+        it "raises an exception on invalid string provided by lambda" do
+          config.set :key, -> { "sho" }
           expect { config.fetch(:key) }.to raise_error(Capistrano::ValidationError)
         end
       end


### PR DESCRIPTION
Fixes #1681, again!

The previous solution worked for validating values set using the block syntax, like this: `set(:application) { "value" }`. However it failed for the much more common scenario of `set :application, -> { "value" }`.

To fix this, we have to check whether the value passed to `set` is callable (i.e. responds to `call` with no arguments). If so, we apply the deferred validation logic in this scenario as well.

The additional wrinkle is the case where the value is a `Question` object. A Question responds to `call`, but it is not a normal Ruby Proc. We can't wrap it in another object to add validation because then `Configuration#is_question?` (which uses `is_a?(Question)`) would erroneously return false.

To account for this, I have changed the technique used for deferred validation to use `define_singleton_method` to wrap just the `call` method instead of wrapping the entire object. This ensures that `is_a?(Question)` remains true even after validation is applied.

Finally, in an effort to keep backtraces as clean as possible, all of this validation wrapping stuff is only applied if a validation rule is actually registered. If no validation rules are defined for a given key, there is no benefit to this meta-programming.