### PR TITLE
Fix space in git suffix. Fixes 1738

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Reverse Chronological Order:
 https://github.com/capistrano/capistrano/compare/v3.6.0...HEAD
 
 * Your contribution here!
+* Replace spaces with dashes when computing the git-ssh suffix. (@will_in_wi)
 
 ## `3.6.0` (2016-07-26)
 

--- a/lib/capistrano/tasks/git.rake
+++ b/lib/capistrano/tasks/git.rake
@@ -6,7 +6,7 @@ namespace :git do
   set :git_wrapper_path, lambda {
     # Try to avoid permissions issues when multiple users deploy the same app
     # by using different file names in the same dir for each deployer and stage.
-    suffix = [:application, :stage, :local_user].map { |key| fetch(key).to_s }.join("-")
+    suffix = [:application, :stage, :local_user].map { |key| fetch(key).to_s }.join("-").gsub(/\s+/, "-")
     "#{fetch(:tmp_dir)}/git-ssh-#{suffix}.sh"
   }
 


### PR DESCRIPTION
Fix for https://github.com/capistrano/capistrano/issues/1738

Still trying to figure out a test.