### PR TITLE
Add support for adding custom filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ https://github.com/capistrano/capistrano/compare/v3.7.0.beta1...HEAD
 * Your contribution here!
 
 * Fix the removal of old releases `deploy:cleanup`. Logic is changed because of unreliable modification times on folders. Removal of directories is now decided by sorting on folder names (name is generated from current datetime format YmdHis). Cleanup is skipped, and a warning is given when a folder name is in a different format.
+* Add support for custom on-filters
+  [#1776](https://github.com/capistrano/capistrano/issues/1776)
 
 ## `3.7.0.beta1` (2016-11-02)
 

--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -41,6 +41,7 @@
   <li><a href="/documentation/advanced-features/property-filtering/">Property Filtering</a></li>
   <li><a href="/documentation/advanced-features/host-filtering/">Host filtering</a></li>
   <li><a href="/documentation/advanced-features/role-filtering/">Role Filtering</a></li>
+  <li><a href="/documentation/advanced-features/custom-filters/">Custom Filters</a></li>
   <li><a href="/documentation/advanced-features/overriding-capistrano-tasks/">Overriding Capistrano Tasks</a></li>
   <li><a href="/documentation/advanced-features/remote-file/">Remote File Task</a></li>
   <li><a href="/documentation/advanced-features/ssh-kit">Remote Commands with SSHKit</a></li>

--- a/docs/documentation/advanced-features/custom-filters/index.markdown
+++ b/docs/documentation/advanced-features/custom-filters/index.markdown
@@ -1,0 +1,83 @@
+---
+title: Custom Filters
+layout: default
+---
+
+Custom filters (specifically, Custom On-Filters) limit the hosts that are being
+deployed to, in the same way as
+[Host](/documentation/advanced-features/host-filtering/) and
+[Role](/documentation/advanced-features/role-filtering/) filters, but the exact
+method used to filter servers is up to the user of Capistrano.
+
+Filters may be added to Capistrano's list of filters by using the
+`Configuration#add_filter` method.  Filters must respond to a `filter` method,
+which will be given an array of Servers, and should return a subset of that
+array (the servers which passed the filter).
+
+`Configuration#add_filter` may also take a block, in which case the block is
+expected to be unary. The block will be passed an array of servers, and is
+expected to return a subset of that array.
+
+Either a block or object may be passed to `add_filter`, but not both.
+
+### Example
+
+You may have a large group of servers that are partitioned into separate regions
+that correspond to actual geographic regions. Usually, you deploy to all of
+them, but there are cases where you want to deploy to a specific region.
+
+Capistrano recognizes the concept of a server's *role* and *hostname*, but has
+no concept of a *region*. In this case, you can construct your own filter that
+selects servers based on their region. When defining servers, you may provide
+them with a `region` property, and use that property in your filter.
+
+
+The filter could look like this:
+
+`config/deploy.rb`
+
+    class RegionFilter
+
+      def initialize(regions)
+        @regions = Array(regions)
+      end
+
+      def filter(servers)
+        servers.select {|server|
+          region = server.fetch(:region)
+          region && @regions.include?(region)
+        }
+      end
+
+    end
+
+You would add servers like this:
+
+`config/deploy/production.rb`
+
+    server('123.123.123.123', region: 'north-east')
+    server('12.12.12.12',     region: 'south-west')
+    server('4.5.6.7',         region: 'mid-west')
+
+To tell Capistrano to use this filter, you would use the
+`Configuration#add_filter` method. In this example, we look at the `REGIONS`
+environment variable, and take it to be a comma-separated list of regions that
+we're interested in:
+
+`config/deploy.rb`
+
+    if ENV['REGIONS']
+      regions = ENV['REGIONS'].split(',')
+      filter = RegionFilter.new(regions)
+      Capistrano::Configuration.env.add_filter(filter)
+    end
+
+We obtain a list of regions to deploy to from the environment variable,
+construct a new filter with those regions, and add it to Capistrano's list of
+filters.
+
+Of course, we're not limited to regions. Any time you can classify or partition
+a list of servers in a way that you only want to deploy to some of them, you can
+use a custom filter. For another example, you might arbitrarily assign your
+servers to either an *A* group or a *B* group, and deploy a new version only to
+the *B* group as a simple variant of A/B Testing.

--- a/docs/documentation/advanced-features/filtering/index.markdown
+++ b/docs/documentation/advanced-features/filtering/index.markdown
@@ -31,7 +31,7 @@ and the configuration ones which are _Property-Filters_
 
 ### On-Filtering
 
-On-filters apply only to the `on()` method that invokes SSH. There are two types:
+On-filters apply only to the `on()` method that invokes SSH. There are two default types:
 
 * [Host Filters](/documentation/advanced-features/host-filtering/), and
 
@@ -49,6 +49,9 @@ available servers to only those with the role `app`, then filter them
 to look for servers with the hostname `server1` or `server2`. If only `server2`
 had the role `app` (`server1` has some other role), then in this situation your
 task would only run on `server2`.
+
+Custom filters may also be added; see
+[Custom Filters](/documentation/advanced-features/custom-filters/).
 
 ### Property-Filtering
 


### PR DESCRIPTION
Users of the API may now add their own 'on'-filters by calling
Configuration#add_filter, e.g:
`Capistrano::Configuration.env.add_filter(RegionFilter.new('NE'))`.

An filter object passed into this method must respond to .filter, and
this method should accept an array of Server objects and return a subset
of this array.

Addresses Issue #1776 
