### PR TITLE
Fix guard-clause warnings reported by RuboCop 0.43

### DIFF
--- a/features/support/vagrant_helpers.rb
+++ b/features/support/vagrant_helpers.rb
@@ -25,11 +25,9 @@ module VagrantHelpers
   end
 
   def run_vagrant_command(command)
-    if (status = vagrant_cli_command("ssh -c #{command.inspect}")).success?
-      true
-    else
-      raise VagrantSSHCommandError, status
-    end
+    status = vagrant_cli_command("ssh -c #{command.inspect}")
+    return true if status.success?
+    raise VagrantSSHCommandError, status
   end
 end
 

--- a/lib/capistrano/configuration/validated_variables.rb
+++ b/lib/capistrano/configuration/validated_variables.rb
@@ -91,10 +91,9 @@ module Capistrano
       end
 
       def assert_value_or_block_not_both(value, block)
-        unless value.nil? || block.nil?
-          raise Capistrano::ValidationError,
-                "Value and block both passed to Configuration#set"
-        end
+        return if value.nil? || block.nil?
+        raise Capistrano::ValidationError,
+              "Value and block both passed to Configuration#set"
       end
 
       class ValidatedQuestion < Question

--- a/lib/capistrano/version_validator.rb
+++ b/lib/capistrano/version_validator.rb
@@ -5,11 +5,8 @@ module Capistrano
     end
 
     def verify
-      if match?
-        self
-      else
-        raise "Capfile locked at #{version}, but #{current_version} is loaded"
-      end
+      return self if match?
+      raise "Capfile locked at #{version}, but #{current_version} is loaded"
     end
 
     private


### PR DESCRIPTION
A new version of RuboCop was released today, and it brought a few new violations, all regarding guard clauses. I made the necessary tweaks to make RuboCop 0.43 happy.

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [ ] If relevant, did you create a test? (N/A)
- [x] Did you confirm that the RSpec tests pass?
- [ ] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry? (N/A)
