### PR TITLE
Exclude docs from gem package to prevent gem from getting 10x larger

### DIFF
--- a/capistrano.gemspec
+++ b/capistrano.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.summary       = "Capistrano - Welcome to easy deployment with Ruby over SSH"
   gem.homepage      = "http://capistranorb.com/"
 
-  gem.files         = `git ls-files -z`.split("\x0")
+  gem.files         = `git ls-files -z`.split("\x0").reject { |f| f =~ /^docs/ }
   gem.executables   = %w(cap capify)
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]


### PR DESCRIPTION
Now that the entire Capistrano docs website is contained in the docs directory, by default all those files will be included in the .gem file that is created by `rake build`.

This means that the next release of the capistrano gem will increase in size from 68 KB to 802 KB. More than 10x!

This commit updates the gemspec to include the docs directory when building the gem, to avoid this bloat.

Agree/disagree this is a good idea?