### PR TITLE
Allow the tar command name to be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Reverse Chronological Order:
 https://github.com/capistrano/capistrano/compare/v3.6.1...HEAD
 
 * Your contribution here!
+* The `tar` used by the Git SCM now honors the SSHKit command map, allowing an alternative tar binary to be used (e.g. gtar) #1787 (@caius)
 * Fix test suite to work with Mocha 1.2.0 (@caius)
 * `remote_file` feature has been removed and is no longer available to use @SaiVardhan
 * Fix bug where host_filter and role_filter were overly greedy [#1766](https://github.com/capistrano/capistrano/issues/1766) (@cseeger-epages)

--- a/lib/capistrano/git.rb
+++ b/lib/capistrano/git.rb
@@ -41,9 +41,9 @@ class Capistrano::Git < Capistrano::SCM
       if (tree = fetch(:repo_tree))
         tree = tree.slice %r#^/?(.*?)/?$#, 1
         components = tree.split("/").size
-        git :archive, fetch(:branch), tree, "| tar -x --strip-components #{components} -f - -C", release_path
+        git :archive, fetch(:branch), tree, "| #{SSHKit.config.command_map[:tar]} -x --strip-components #{components} -f - -C", release_path
       else
-        git :archive, fetch(:branch), "| tar -x -f - -C", release_path
+        git :archive, fetch(:branch), "| #{SSHKit.config.command_map[:tar]} -x -f - -C", release_path
       end
     end
 

--- a/spec/lib/capistrano/git_spec.rb
+++ b/spec/lib/capistrano/git_spec.rb
@@ -81,7 +81,7 @@ module Capistrano
         context.expects(:fetch).with(:branch).returns(:branch)
         context.expects(:release_path).returns(:path)
 
-        context.expects(:execute).with(:git, :archive, :branch, "| tar -x -f - -C", :path)
+        context.expects(:execute).with(:git, :archive, :branch, "| /usr/bin/env tar -x -f - -C", :path)
 
         subject.release
       end
@@ -91,7 +91,18 @@ module Capistrano
         context.expects(:fetch).with(:branch).returns(:branch)
         context.expects(:release_path).returns(:path)
 
-        context.expects(:execute).with(:git, :archive, :branch, "tree", "| tar -x --strip-components 1 -f - -C", :path)
+        context.expects(:execute).with(:git, :archive, :branch, "tree", "| /usr/bin/env tar -x --strip-components 1 -f - -C", :path)
+
+        subject.release
+      end
+
+      it "should run tar with an overridden name" do
+        context.expects(:fetch).with(:repo_tree).returns(nil)
+        context.expects(:fetch).with(:branch).returns(:branch)
+        SSHKit.config.command_map.expects(:[]).with(:tar).returns("/usr/bin/env gtar")
+        context.expects(:release_path).returns(:path)
+
+        context.expects(:execute).with(:git, :archive, :branch, "| /usr/bin/env gtar -x -f - -C", :path)
 
         subject.release
       end


### PR DESCRIPTION
When using the git integration, it generates a tarball and then untars it to generate the release folder. This has been hardcoded to use `tar` up until now, but some OS's provide a tar that isn't gnu compatible (eg, SmartOS). Instead they generally have gnu-compatible tar available under a different name (e.g., `gtar`).

This is now picked up from a variable, defaulting to `tar` for backwards compatibility and can be overridden when required:

    set :tar, 'gtar'
