### PR TITLE
Fix test suite for mocha 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Reverse Chronological Order:
 https://github.com/capistrano/capistrano/compare/v3.6.1...HEAD
 
 * Your contribution here!
+* Fix test suite to work with Mocha 1.2.0 (@caius)
 * `remote_file` feature has been removed and is no longer available to use @SaiVardhan
 * Fix bug where host_filter and role_filter were overly greedy [#1766](https://github.com/capistrano/capistrano/issues/1766) (@cseeger-epages)
 

--- a/spec/lib/capistrano/git_spec.rb
+++ b/spec/lib/capistrano/git_spec.rb
@@ -4,7 +4,7 @@ require "capistrano/git"
 
 module Capistrano
   describe Git do
-    let(:context) { Class.new.new }
+    let(:context) { mock }
     subject { Capistrano::Git.new(context, Capistrano::Git::DefaultStrategy) }
 
     describe "#git" do
@@ -16,7 +16,7 @@ module Capistrano
   end
 
   describe Git::DefaultStrategy do
-    let(:context) { Class.new.new }
+    let(:context) { mock }
     subject { Capistrano::Git.new(context, Capistrano::Git::DefaultStrategy) }
 
     describe "#test" do

--- a/spec/lib/capistrano/hg_spec.rb
+++ b/spec/lib/capistrano/hg_spec.rb
@@ -4,7 +4,7 @@ require "capistrano/hg"
 
 module Capistrano
   describe Hg do
-    let(:context) { Class.new.new }
+    let(:context) { mock }
     subject { Capistrano::Hg.new(context, Capistrano::Hg::DefaultStrategy) }
 
     describe "#hg" do
@@ -16,7 +16,7 @@ module Capistrano
   end
 
   describe Hg::DefaultStrategy do
-    let(:context) { Class.new.new }
+    let(:context) { mock }
     subject { Capistrano::Hg.new(context, Capistrano::Hg::DefaultStrategy) }
 
     describe "#test" do

--- a/spec/lib/capistrano/scm_spec.rb
+++ b/spec/lib/capistrano/scm_spec.rb
@@ -26,7 +26,7 @@ module BlindStrategy; end
 
 module Capistrano
   describe SCM do
-    let(:context) { Class.new.new }
+    let(:context) { mock }
 
     describe "#initialize" do
       subject { Capistrano::SCM.new(context, DummyStrategy) }

--- a/spec/lib/capistrano/svn_spec.rb
+++ b/spec/lib/capistrano/svn_spec.rb
@@ -4,7 +4,7 @@ require "capistrano/svn"
 
 module Capistrano
   describe Svn do
-    let(:context) { Class.new.new }
+    let(:context) { mock }
     subject { Capistrano::Svn.new(context, Capistrano::Svn::DefaultStrategy) }
 
     describe "#svn" do
@@ -19,7 +19,7 @@ module Capistrano
   end
 
   describe Svn::DefaultStrategy do
-    let(:context) { Class.new.new }
+    let(:context) { mock }
     subject { Capistrano::Svn.new(context, Capistrano::Svn::DefaultStrategy) }
 
     describe "#test" do


### PR DESCRIPTION
This comes down to a behaviour change in mocha not playing so nicely with how we've been generating empty mock objects so far.

Mocha 1.2.0 now pays attention to the visibility of methods you stub (expect(), etc) and disallows you calling them in a different scope. ie, if you stub a private method it can't be called from outside the instance. Previously doing that worked fine and you had no indication you were calling a private method. This change totally makes sense!

However, we're providing "empty" contexts in our specs by using `Class.new.new` which is creating an anonymous instance of an anonymous class. Note that the anonymous class contains Kernel in the ancestors.

We then stub out `test` on these anonymous instances, which we don't expect to respond to `test` without the stubbing, and the stubbed method then gets called. However, remember back to where we had `Kernel` methods available in our anonymous instance? Turns out there's `Kernel#test` and it's marked private! Except that our method on the real context instances is public, so we want that to work.

Easiest fix I can see is to use Mocha's `mock` method to create a mock object for us to stub out our methods on, rather than trying to be ruby-ish and use an anonymous instance of an anonymous class. (I attempted using BasicObject first, but we'd have to include Mocha into that ourselves, and it leans on some methods provided by Kernel.)

Fixes #1789 