### PR TITLE
Rename git to git_plugin, etc.

### DIFF
--- a/lib/capistrano/scm/tasks/git.rake
+++ b/lib/capistrano/scm/tasks/git.rake
@@ -1,5 +1,5 @@
 # This trick lets us access the Git plugin within `on` blocks.
-git = self
+git_plugin = self
 
 namespace :git do
   desc "Upload the git wrapper script, this script guarantees that we can script git without getting an interactive prompt"
@@ -16,7 +16,7 @@ namespace :git do
     fetch(:branch)
     on release_roles :all do
       with fetch(:git_environmental_variables) do
-        git.check_repo_is_reachable
+        git_plugin.check_repo_is_reachable
       end
     end
   end
@@ -24,12 +24,12 @@ namespace :git do
   desc "Clone the repo to the cache"
   task clone: :'git:wrapper' do
     on release_roles :all do
-      if git.repo_mirror_exists?
+      if git_plugin.repo_mirror_exists?
         info t(:mirror_exists, at: repo_path)
       else
         within deploy_path do
           with fetch(:git_environmental_variables) do
-            git.clone_repo
+            git_plugin.clone_repo
           end
         end
       end
@@ -41,7 +41,7 @@ namespace :git do
     on release_roles :all do
       within repo_path do
         with fetch(:git_environmental_variables) do
-          git.update_mirror
+          git_plugin.update_mirror
         end
       end
     end
@@ -53,7 +53,7 @@ namespace :git do
       with fetch(:git_environmental_variables) do
         within repo_path do
           execute :mkdir, "-p", release_path
-          git.archive_to_release_path
+          git_plugin.archive_to_release_path
         end
       end
     end
@@ -64,7 +64,7 @@ namespace :git do
     on release_roles :all do
       within repo_path do
         with fetch(:git_environmental_variables) do
-          set :current_revision, git.fetch_revision
+          set :current_revision, git_plugin.fetch_revision
         end
       end
     end

--- a/lib/capistrano/scm/tasks/hg.rake
+++ b/lib/capistrano/scm/tasks/hg.rake
@@ -1,24 +1,24 @@
 # TODO: this is nearly identical to git.rake. DRY up?
 
 # This trick lets us access the Hg plugin within `on` blocks.
-hg = self
+hg_plugin = self
 
 namespace :hg do
   desc "Check that the repo is reachable"
   task :check do
     on release_roles :all do
-      hg.check_repo_is_reachable
+      hg_plugin.check_repo_is_reachable
     end
   end
 
   desc "Clone the repo to the cache"
   task :clone do
     on release_roles :all do
-      if hg.repo_mirror_exists?
+      if hg_plugin.repo_mirror_exists?
         info t(:mirror_exists, at: repo_path)
       else
         within deploy_path do
-          hg.clone_repo
+          hg_plugin.clone_repo
         end
       end
     end
@@ -37,7 +37,7 @@ namespace :hg do
   task create_release: :'hg:update' do
     on release_roles :all do
       within repo_path do
-        hg.archive_to_release_path
+        hg_plugin.archive_to_release_path
       end
     end
   end
@@ -46,7 +46,7 @@ namespace :hg do
   task :set_current_revision do
     on release_roles :all do
       within repo_path do
-        set :current_revision, hg.fetch_revision
+        set :current_revision, hg_plugin.fetch_revision
       end
     end
   end

--- a/lib/capistrano/scm/tasks/svn.rake
+++ b/lib/capistrano/scm/tasks/svn.rake
@@ -1,24 +1,24 @@
 # TODO: this is nearly identical to git.rake. DRY up?
 
 # This trick lets us access the Svn plugin within `on` blocks.
-svn = self
+svn_plugin = self
 
 namespace :svn do
   desc "Check that the repo is reachable"
   task :check do
     on release_roles :all do
-      svn.check_repo_is_reachable
+      svn_plugin.check_repo_is_reachable
     end
   end
 
   desc "Clone the repo to the cache"
   task :clone do
     on release_roles :all do
-      if svn.repo_mirror_exists?
+      if svn_plugin.repo_mirror_exists?
         info t(:mirror_exists, at: repo_path)
       else
         within deploy_path do
-          svn.clone_repo
+          svn_plugin.clone_repo
         end
       end
     end
@@ -28,7 +28,7 @@ namespace :svn do
   task update: :'svn:clone' do
     on release_roles :all do
       within repo_path do
-        svn.update_mirror
+        svn_plugin.update_mirror
       end
     end
   end
@@ -37,7 +37,7 @@ namespace :svn do
   task create_release: :'svn:update' do
     on release_roles :all do
       within repo_path do
-        svn.archive_to_release_path
+        svn_plugin.archive_to_release_path
       end
     end
   end
@@ -46,7 +46,7 @@ namespace :svn do
   task :set_current_revision do
     on release_roles :all do
       within repo_path do
-        set :current_revision, svn.fetch_revision
+        set :current_revision, svn_plugin.fetch_revision
       end
     end
   end


### PR DESCRIPTION
### Summary

This makes it more explicit which object we are referring to, which is to say the SCM plugin object. As suggested by @will-in-wi here: https://github.com/capistrano/capistrano/pull/1572/files#r54176503

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [ ] ~~If relevant, did you create a test?~~
- [x] Did you confirm that the RSpec tests pass?
- [ ] ~~If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?~~
