### PR TITLE
Suppress log by filtering remote refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Reverse Chronological Order:
 https://github.com/capistrano/capistrano/compare/v3.7.0.beta1...HEAD
 
 * Your contribution here!
+* Suppress log messages of `git ls-remote` by filtering remote refs (@aeroastro)
 
 ## `3.7.0.beta1` (2016-11-02)
 

--- a/features/deploy.feature
+++ b/features/deploy.feature
@@ -7,7 +7,6 @@ Feature: Deploy
   Scenario: Creating the repo
     When I run cap "git:check"
     Then the task is successful
-    And references in the remote repo are listed
     And git wrapper permissions are 0700
 
   Scenario: Creating the directory structure

--- a/lib/capistrano/scm/git.rb
+++ b/lib/capistrano/scm/git.rb
@@ -32,7 +32,7 @@ class Capistrano::SCM::Git < Capistrano::SCM::Plugin
   end
 
   def check_repo_is_reachable
-    git :'ls-remote --heads', repo_url
+    git :'ls-remote', repo_url, "HEAD"
   end
 
   def clone_repo

--- a/spec/lib/capistrano/scm/git_spec.rb
+++ b/spec/lib/capistrano/scm/git_spec.rb
@@ -46,7 +46,7 @@ module Capistrano
     describe "#check_repo_is_reachable" do
       it "should test the repo url" do
         env.set(:repo_url, "url")
-        backend.expects(:execute).with(:git, :'ls-remote --heads', "url").returns(true)
+        backend.expects(:execute).with(:git, :'ls-remote', "url", "HEAD").returns(true)
 
         subject.check_repo_is_reachable
       end


### PR DESCRIPTION
### Summary

This patch can suppress long logs generated by `git ls-remote`, especially for repositories with many tags and branches.

Because the primary objective of `git ls-remote` used is to check the access rights to `remote_url`, we can omit a number of remote refs by specifying HEAD as `<refs>` at the end of the command.

Although the default exit code of `git ls-remote` is always 0 regardless of matched refs, I think specifying `HEAD` as `<refs>` is fairly simple option for Git users.

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [ ] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?
- [ ] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?

### Other Information

Ref. https://git-scm.com/docs/git-ls-remote.html