### PR TITLE
releases_path should be configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.gem
 *.rbc
 *.swp
+*.idea
 .bundle
 .config
 .rspec

--- a/lib/capistrano/dsl/paths.rb
+++ b/lib/capistrano/dsl/paths.rb
@@ -15,7 +15,7 @@ module Capistrano
       end
 
       def releases_path
-        deploy_path.join("releases")
+        deploy_path.join(fetch(:releases_directory, "releases"))
       end
 
       def release_path

--- a/spec/lib/capistrano/dsl/paths_spec.rb
+++ b/spec/lib/capistrano/dsl/paths_spec.rb
@@ -97,6 +97,32 @@ describe Capistrano::DSL::Paths do
     end
   end
 
+  describe "#releases path" do
+    subject { dsl.releases_path }
+
+    context "where no releases directory has been set" do
+      before do
+        dsl.delete(:releases_directory)
+      end
+
+      it "returns the `releases_path` value" do
+        expect(subject.to_s).to eq "/var/www/releases"
+      end
+    end
+
+    context "where the release path has been set" do
+      before do
+        dsl.set(:releases_directory, "release_directory")
+      end
+
+      it "returns the set `releases_path` value" do
+        expect(subject.to_s).to eq "/var/www/release_directory"
+      end
+    end
+  end
+
+
+
   describe "#set_release_path" do
     let(:now) { Time.parse("Oct 21 16:29:00 2015") }
     subject { dsl.release_path }


### PR DESCRIPTION
### Summary
In Capistrano 2, the release_path was configurable. The variable was called "version_dir".
I need the same function, so I changed the method paths#releases_path analog to current_path.
The variable is called :releases_directory. 

Christian

