### PR TITLE
Bring back :git_enable_submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Reverse Chronological Order:
 https://github.com/capistrano/capistrano/compare/v3.7.1...HEAD
 
 * Your contribution here!
+* Bring back `:git_enable_submodules` (@1st8)
 
 ## `3.7.1` (2016-12-16)
 

--- a/lib/capistrano/scm/tasks/git.rake
+++ b/lib/capistrano/scm/tasks/git.rake
@@ -54,6 +54,7 @@ namespace :git do
         within repo_path do
           execute :mkdir, "-p", release_path
           git_plugin.archive_to_release_path
+          git_plugin.submodules_to_release_path if fetch(:git_enable_submodules)
         end
       end
     end


### PR DESCRIPTION
### Summary

This PR tries to reintroduce a simple and robust implementation of `:git_enable_submodule` handling.
It works beautifully so far and I really like it. Please let me know what you all think.


### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?
- [x] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?

### Other Information

This is what the log looks like:

```
00:08 git:create_release
      01 mkdir -p /var/www/my_project/releases/20161221135840
    ✔ 01 someuser@someserver.mixxt.net 0.122s
      02 git archive develop | /usr/bin/env tar -x -f - -C /var/www/my_project/releases/20161221135840
    ✔ 02 someuser@someserver.mixxt.net 0.186s
      03 git reset --mixed develop
    ✔ 03 someuser@someserver.mixxt.net 0.164s
      04 git submodule update --init --depth 1 --checkout --recursive
      04 Submodul-Pfad: 'app/assets/stylesheets/shared': '38dd96eec99672944c65021bcffd059e56832cb2' ausgecheckt
      04 Submodul-Pfad: 'app/models/fs': '3d039ef331ef236fd86769c7278e79a0990dbb3c' ausgecheckt
      04 Submodul-Pfad: 'vendor/submodules/converse.js': '37d6a51258c7e9cd5e51f9379dc2cf1d1a957b1b' ausgecheckt
      04 Submodul-Pfad: 'vendor/submodules/formbuilder': '831214fc8a6f065e6f863c84e782d1f619bd6395' ausgecheckt
    ✔ 04 someuser@someserver.mixxt.net 0.981s
      05 rm /var/www/my_project/releases/20161221135840/INDEX_20161221135840
    ✔ 05 someuser@someserver.mixxt.net 0.191s
```