### PR TITLE
Document the additional gems needed to support ed25519 keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ Add Capistrano to your project's Gemfile:
 ``` ruby
 group :development do
   gem "capistrano", "~> 3.7"
+
+  # Optional: these gems are needed to support ed25519 SSH keys
+  gem "bcrypt_pbkdf", require: false
+  gem "net-ssh", ">= 4.0.0", require: false
+  gem "rbnacl", "~> 3.4", require: false
+  gem "rbnacl-libsodium", require: false
 end
 ```
 


### PR DESCRIPTION
Through trial and error, I discovered I needed to upgrade to net-ssh 4.0.0, plus install three additional optional gems in order to use the new, more secure ed25519 type SSH keys with Capistrano.

Is the Capistrano README the best place to document this?