### PR TITLE
Allow repo_url changes to be realized on existing hosts when using the Git SCM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ https://github.com/capistrano/capistrano/compare/v3.7.1...HEAD
 
 * Your contribution here!
 * Suppress log messages of `git ls-remote` by filtering remote refs (@aeroastro)
+* The Git SCM now allows the repo_url to be changed without manually wiping out the mirror on each target host first (@javanthropus)
 
 ## `3.7.1` (2016-12-16)
 

--- a/docs/documentation/getting-started/configuration/index.markdown
+++ b/docs/documentation/getting-started/configuration/index.markdown
@@ -68,7 +68,7 @@ The following variables are settable:
   * Example: `set :repo_url, 'git@example.com:me/my_repo.git'` for a git repo located in /home/git/me
   * Hint #1: to access a repo on a machine using a non-standard ssh port: `set :repo_url, 'ssh://git@example.com:30000/~/me/my_repo.git'`
   * Hint #2: when using :svn and branches, declare the repo_url like this: `set :repo_url, -> { "svn://myhost/myrepo/#{fetch(:branch)}" }`
-  * Warning: if you move your repository to a new URL and change this variable, already deployed remote servers won't reflect this change automatically, you have to manually re-configure the repository on the remote servers (in path determined by `:repo_path`) or delete it (`rm -rf repo` in the default setup) and let Capistrano recreate it on the next deploy using the updated URL.
+  * Warning: if you move your repository to a new URL when using an SCM other than Git and change this variable, already deployed remote servers won't reflect this change automatically, you have to manually re-configure the repository on the remote servers (in path determined by `:repo_path`) or delete it (`rm -rf repo` in the default setup) and let Capistrano recreate it on the next deploy using the updated URL.
 
 * `:branch`
   * **default:** `'master'`

--- a/lib/capistrano/scm/git.rb
+++ b/lib/capistrano/scm/git.rb
@@ -44,6 +44,9 @@ class Capistrano::SCM::Git < Capistrano::SCM::Plugin
   end
 
   def update_mirror
+    # Update the origin URL if necessary.
+    git :remote, "set-url", "origin", repo_url
+
     # Note: Requires git version 1.9 or greater
     if (depth = fetch(:git_shallow_clone))
       git :fetch, "--depth", depth, "origin", fetch(:branch)

--- a/spec/lib/capistrano/scm/git_spec.rb
+++ b/spec/lib/capistrano/scm/git_spec.rb
@@ -74,6 +74,9 @@ module Capistrano
 
     describe "#update_mirror" do
       it "should run git update" do
+        env.set(:repo_url, "url")
+
+        backend.expects(:execute).with(:git, :remote, "set-url", "origin", "url")
         backend.expects(:execute).with(:git, :remote, :update, "--prune")
 
         subject.update_mirror
@@ -82,6 +85,9 @@ module Capistrano
       it "should run git update in shallow mode" do
         env.set(:git_shallow_clone, "1")
         env.set(:branch, "branch")
+        env.set(:repo_url, "url")
+
+        backend.expects(:execute).with(:git, :remote, "set-url", "origin", "url")
         backend.expects(:execute).with(:git, :fetch, "--depth", "1", "origin", "branch")
 
         subject.update_mirror


### PR DESCRIPTION
When the repo_url setting needs to be changed, currently exiting deployment hosts will not update their mirror URL to fetch from the new URL.  The user either needs to clobber the mirror directory or manually update the remote URL prior to deployment.

This patch sets the URL just before updating from the origin.  It's effectively a fast and harmless noop most of the time, but we have a large number of hosts for various applications that have needed this operation as we have moved from one Git host to another.