### PR TITLE
Capistrano::SCM::* depends on Capistrano/deploy

### DIFF
--- a/UPGRADING-3.7.md
+++ b/UPGRADING-3.7.md
@@ -12,7 +12,7 @@ set :scm, :svn
 To avoid deprecation warnings:
 
 1. Remove `set :scm, ...` from your Capistrano configuration.
-2. Add *one* of the following SCM declarations to your `Capfile`:
+2. Add *one* of the following SCM declarations to your `Capfile` after `require "capistrano/deploy"`:
 
 ```ruby
 # To use Git


### PR DESCRIPTION
Editing the UPGRADING-3.7.md file to clarify that, when adding the following code to the Capfile:
```
require "capistrano/scm/git"
install_plugin Capistrano::SCM::Git
```
it should come after `require 'capistrano/deploy'`.

As reported in [Stack Overflow](http://stackoverflow.com/questions/41307044/capistrano-dont-know-how-to-build-task-deploynew-release-path) and in an [issue](https://github.com/capistrano/capistrano/issues/1824).