### PR TITLE
Include link to DNSimple in the footer. They sponsor our DNS.

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -20,7 +20,7 @@
         <li class="foundicon"><a href="//twitter.com/capistranorb"><i class="foundicon-twitter"></i></a></li>
         <li class="foundicon"><a href="//github.com/capistrano"><i class="foundicon-github"></i></a></li>
         <li class="thanks-dnsimple">
-          <a href="http://dnsimple.link/resolving-hanami" target="_blank">
+          <a href="https://dnsimple.link/resolving-capistrano" target="_blank">
             <span>DNS Services Kindly Hosted By<br></span>
             <img src="https://cdn.dnsimple.com/assets/resolving-with-us/logo-dark.png" alt="DNSimple" style="display:block;margin:0;padding:0;width:100px;">
           </a>

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -2,9 +2,9 @@
   <div class="row">
     <div class="large-4 columns">
       <ul>
-      <li><a href="/documentation/overview/what-is-capistrano/">About Capistrano</a></li>
-      <li><a href="https://github.com/capistrano/capistrano/blob/master/CONTRIBUTING.md">Contributing</a></li>
-      <li><a href="https://rubygems.org/gems/capistrano/versions">Releases</a></li>
+        <li><a href="/documentation/overview/what-is-capistrano/">About Capistrano</a></li>
+        <li><a href="https://github.com/capistrano/capistrano/blob/master/CONTRIBUTING.md">Contributing</a></li>
+        <li><a href="https://rubygems.org/gems/capistrano/versions">Releases</a></li>
       </ul>
     </div>
 
@@ -17,8 +17,14 @@
 
     <div class="large-4 columns">
       <ul class="social icons">
-        <li><a href="//twitter.com/capistranorb"><i class="foundicon-twitter"></i></a></li>
-        <li><a href="//github.com/capistrano"><i class="foundicon-github"></i></a></li>
+        <li class="foundicon"><a href="//twitter.com/capistranorb"><i class="foundicon-twitter"></i></a></li>
+        <li class="foundicon"><a href="//github.com/capistrano"><i class="foundicon-github"></i></a></li>
+        <li class="thanks-dnsimple">
+          <a href="http://dnsimple.link/resolving-hanami" target="_blank">
+            <span>DNS Services Kindly Hosted By<br></span>
+            <img src="https://cdn.dnsimple.com/assets/resolving-with-us/logo-dark.png" alt="DNSimple" style="display:block;margin:0;padding:0;width:100px;">
+          </a>
+        </li>
       </ul>
     </div>
   </div>

--- a/docs/css/capistrano.css
+++ b/docs/css/capistrano.css
@@ -106,7 +106,7 @@ footer {
   color: #fff;
 }
 
-footer a {
+footer a, footer a:hover {
   color: #fff;
 }
 
@@ -119,10 +119,14 @@ li {
   margin-left: 2em;
 }
 
-footer ul.social.icons li {
+footer ul.social.icons li.foundicon {
   float: left;
   margin-left: 10px;
   font-size: 5em;
+}
+
+footer ul.social.icons li.thanks-dnsimple {
+  clear: left;
 }
 
 .github-widget {


### PR DESCRIPTION
Whilst trying to reduce the impact the loss of any one maintainer can
have, we were offered a solution to the DNS ownership problem by
DNSimple who kindly sponsored our DNS entry. This allows the three core
maintainers to have access to the DNS system incase changes need to be
made.

Part of the deal was including a link to DNSimple in the footer of the
site (as Hanamai, and others do).

I forgot, apparently to keep my end of the bargain, and during a recent
audit they've checked in with me to see if we're still making use of the
sponsored service. As I like DNSimple and find them to be very useful,
I'd like them to continue to sponsor us, and offer this tweak to the
doce to fulfil our obligations in that regard.
