### PR TITLE
Git plugin: shellescape git_wrapper_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Reverse Chronological Order:
 https://github.com/capistrano/capistrano/compare/v3.7.2...HEAD
 
 * [#1835](https://github.com/capistrano/capistrano/pull/1835): Stopped printing parenthesis in ask prompt if no default or nil was passed as argument [(@chamini2)](https://github.com/chamini2)
+* [#1840](https://github.com/capistrano/capistrano/pull/1840): Git plugin: shellescape git_wrapper_path [(@olleolleolle)](https://github.com/olleolleolle)
 * Your contribution here!
 
 ## `3.7.2` (2017-01-27)

--- a/lib/capistrano/scm/git.rb
+++ b/lib/capistrano/scm/git.rb
@@ -1,4 +1,5 @@
 require "capistrano/scm/plugin"
+require "shellwords"
 
 class Capistrano::SCM::Git < Capistrano::SCM::Plugin
   def set_defaults
@@ -6,7 +7,7 @@ class Capistrano::SCM::Git < Capistrano::SCM::Plugin
     set_if_empty :git_wrapper_path, lambda {
       # Try to avoid permissions issues when multiple users deploy the same app
       # by using different file names in the same dir for each deployer and stage.
-      suffix = [:application, :stage, :local_user].map { |key| fetch(key).to_s }.join("-").gsub(/\s+/, "-")
+      suffix = [:application, :stage, :local_user].map { |key| fetch(key).to_s }.join("-").shellescape
       "#{fetch(:tmp_dir)}/git-ssh-#{suffix}.sh"
     }
     set_if_empty :git_environmental_variables, lambda {

--- a/spec/lib/capistrano/scm/git_spec.rb
+++ b/spec/lib/capistrano/scm/git_spec.rb
@@ -27,6 +27,17 @@ module Capistrano
       Capistrano::Configuration.reset!
     end
 
+    describe "#set_defaults" do
+      it "sets ::git_wrapper_path in a shell-safe way" do
+        env.set(:tmp_dir, "/tmp")
+        env.set(:application, "my_app")
+        env.set(:stage, "staging")
+        env.set(:local_user, "(Git Web User) via ShipIt")
+        subject.set_defaults
+        expect(env.fetch(:git_wrapper_path)).to eq('/tmp/git-ssh-my_app-staging-\(Git\ Web\ User\)\ via\ ShipIt.sh')
+      end
+    end
+
     describe "#git" do
       it "should call execute git in the context, with arguments" do
         backend.expects(:execute).with(:git, :init)


### PR DESCRIPTION
### Summary

Fixes a bug where deploy would fail if `:local_user` contained a paranthesis; the produced git-ssh suffix is now shell-escaped. See #1742.

(The Git plugin's setting `git_wrapper_path` is a concatenated string, based on three parts. One of them is the username, which can include any character.)

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [ ] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?
- [x] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?

### Other Information

The previous behavior stopped the rubygems.org staging server from getting a deploy done after upgrading to this newer version of Capistrano (which has the `git_wrapper_path` way of wrapping Git).

The `:local_user` username seems to have been `(GitHub Web Flow) via ShipIt`.