### PR TITLE
Update documentation styles: add bottom margin to code blocks.

### DIFF
--- a/docs/css/capistrano.css
+++ b/docs/css/capistrano.css
@@ -91,6 +91,10 @@ h1, h2, h3, h4, h5, h6 {
   font-family: 'Enriqueta', serif;
 }
 
+.highlighter-rouge {
+  margin-bottom: 1.25em;
+}
+
 /*p code, li code {
   padding: 3px;
   background-color: #E6E6E6;


### PR DESCRIPTION
Hello!

There is a small update for your documentation styles.

The update fixes annoying small margins (more precisely a lack of it) between block of code and folowed after that paragraph of text.

**After applying changes from my commit we got that (first half of image is before changes/ next half - after changes):**

![pull-request-image](https://cloud.githubusercontent.com/assets/3241812/22856918/9f7544c8-f0b4-11e6-931a-567099785ee2.jpg)




