### PR TITLE
Make add_role O(hosts) & fix port handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ https://github.com/capistrano/capistrano/compare/v3.7.2...HEAD
 * [#1835](https://github.com/capistrano/capistrano/pull/1835): Stopped printing parenthesis in ask prompt if no default or nil was passed as argument [(@chamini2)](https://github.com/chamini2)
 * [#1840](https://github.com/capistrano/capistrano/pull/1840): Git plugin: shellescape git_wrapper_path [(@olleolleolle)](https://github.com/olleolleolle)
 * [#1843](https://github.com/capistrano/capistrano/pull/1843): Properly shell escape git:wrapper steps - [@mattbrictson](https://github.com/mattbrictson)
+* [#1846](https://github.com/capistrano/capistrano/pull/1846): Defining a role is now O(hosts) instead of O(hosts^2) [(@dbenamy)](https://github.com/dbenamy)
+* [#1846](https://github.com/capistrano/capistrano/pull/1846): add_host will add a new host in a case where it used to incorrectly update an existing one (potentially breaking) [(@dbenamy)](https://github.com/dbenamy)
 * Your contribution here!
 
 ## `3.7.2` (2017-01-27)

--- a/lib/capistrano/configuration/server.rb
+++ b/lib/capistrano/configuration/server.rb
@@ -64,6 +64,7 @@ module Capistrano
       end
 
       def matches?(other)
+        # This matching logic must stay in sync with `Servers#add_host`.
         hostname == other.hostname && port == other.port
       end
 

--- a/lib/capistrano/configuration/servers.rb
+++ b/lib/capistrano/configuration/servers.rb
@@ -9,6 +9,7 @@ module Capistrano
 
       def add_host(host, properties={})
         new_host = Server[host]
+        new_host.port = properties[:port] if properties.key?(:port)
         if (server = servers.find { |s| s.matches? new_host })
           server.user = new_host.user if new_host.user
           server.with(properties)

--- a/spec/lib/capistrano/configuration/servers_spec.rb
+++ b/spec/lib/capistrano/configuration/servers_spec.rb
@@ -130,6 +130,7 @@ module Capistrano
 
         it "can accept multiple servers with the same hostname but different ports or users" do
           servers.add_host("1", roles: [:app, "web"], test: :value, port: 12)
+          expect(servers.count).to eq(2)
           servers.add_host("1", roles: [:app, "web"], test: :value, port: 34)
           servers.add_host("1", roles: [:app, "web"], test: :value, user: "root")
           servers.add_host("1", roles: [:app, "web"], test: :value, user: "deployer")

--- a/spec/lib/capistrano/configuration/servers_spec.rb
+++ b/spec/lib/capistrano/configuration/servers_spec.rb
@@ -137,7 +137,7 @@ module Capistrano
           servers.add_host("1", roles: [:app, "web"], test: :value, user: "root", port: 34)
           servers.add_host("1", roles: [:app, "web"], test: :value, user: "deployer", port: 34)
           servers.add_host("1", roles: [:app, "web"], test: :value, user: "deployer", port: 56)
-          expect(servers.count).to eq(5)
+          expect(servers.count).to eq(4)
         end
 
         describe "with a :user property" do


### PR DESCRIPTION
### Summary

This makes add_role O(hosts) instead of O(hosts^2). I'm using cap in a deployment with enough servers that the previous behavior makes it take 7+ seconds to start.

I also think I fixed a bug in add_host's handling of ports, but I'm not totally sure of the intended behavior so let me know if I misunderstood!

Each commit stands alone if that helps with reviewing.

### Other Information

I benchmarked using

```
from subprocess import check_output
from time import time

for cnt in range(0, 12001, 100):
    with file('Capfile', 'w') as f:
        f.write("require 'capistrano/setup'\n")
        f.write("role :r, %%w(%s)\n" % ' '.join(['i-%017d' % i for i in range(cnt)]))
    start = time()
    check_output(['bin/cap', '--rakefile=Capfile', '-T'])
    print '%d,%f' % (cnt, time() - start)
```

`RUBYLIB=lib python bench.py`

<img width="558" alt="screen shot 2017-02-12 at 1 23 50 am" src="https://cloud.githubusercontent.com/assets/354611/22860125/f3d64b40-f0c1-11e6-81ca-48e9a2605bb0.png">

The detailed data is at https://docs.google.com/spreadsheets/d/14OvbOwF8eGflgWhYleI9RDkpmfUtDQDF-iH2oEIFPko. The commits shown there don't match the PR any more because I squashed in a tiny fix. They should be equivalent to 5aea6dc for baseline, and 45e1920 for the fix.