### PR TITLE
Update style for alert messages at documentation pages

### DIFF
--- a/docs/css/capistrano.css
+++ b/docs/css/capistrano.css
@@ -95,6 +95,30 @@ h1, h2, h3, h4, h5, h6 {
   margin-bottom: 1.25em;
 }
 
+.alert-box {
+  font-weight: normal;
+  color: black;
+
+  background-color: #d7ecfa;
+  border: none;
+  padding-left: 20px;
+}
+
+.alert-box.alert {
+  background-color: #f7e4e1;
+  color: black;
+}
+
+.alert-box.success {
+  background-color: #e1faea;
+  color: black;
+}
+
+.alert-box.secondary {
+  background-color: #eaeaea;
+  color: black;
+}
+
 /*p code, li code {
   padding: 3px;
   background-color: #E6E6E6;

--- a/docs/documentation/faq/how-can-i-set-capistrano-configuration-paths/index.markdown
+++ b/docs/documentation/faq/how-can-i-set-capistrano-configuration-paths/index.markdown
@@ -16,7 +16,7 @@ set :stage_config_path, 'cap/stages'
 # previous variables MUST be set before 'capistrano/setup'
 require 'capistrano/setup'
 
-# default tasks path is `lib/capistrano/tasks/*.rake` 
+# default tasks path is `lib/capistrano/tasks/*.rake`
 # (note that you can also change the file extensions)
 Dir.glob('cap/tasks/*.rb').each { |r| import r }
 ```
@@ -34,7 +34,7 @@ Here is the corresponding capistrano configuration structure:
     └── deploy.rb
 ```
 
-<div class="alert-box alert">
+<p class="alert-box alert">
 Be aware that you will have to provide an absolute path, if you want your "deploy_config_path" to be "capistrano/deploy.rb".
 See <a href="https://github.com/capistrano/capistrano/issues/1519#issuecomment-152357282">this issue</a> for more explanations and how to get an absolute path in Ruby.
-</div>
+</p>

--- a/docs/documentation/getting-started/installation/index.markdown
+++ b/docs/documentation/getting-started/installation/index.markdown
@@ -8,10 +8,10 @@ Capistrano is bundled as a Ruby Gem. **It requires Ruby 2.0 or newer.**
 Capistrano can be installed as a standalone Gem, or bundled into your
 application.
 
-<div class="alert">
+<p class="alert-box alert">
 It is recommended to fix the version number when using Capistrano, and is
 therefore recommended to use an appropriate bundler.
-</div>
+</p>
 
 ### General Usage
 

--- a/docs/documentation/getting-started/preparing-your-application/index.markdown
+++ b/docs/documentation/getting-started/preparing-your-application/index.markdown
@@ -3,7 +3,7 @@ title: Preparing Your Application
 layout: default
 ---
 
-<p class="alert-box radius">
+<p class="alert-box">
   This will focus on preparing a Rails application, but most ideas expressed
   here have parallels in Python, or PHP applications
 </p>
@@ -136,7 +136,7 @@ server 'world.com', roles: [:web], user: 'hello'
 server 'example.com', roles: [:web], port: 1234
 ```
 
-<p class="alert-box radius"> You can define a server or role using both syntaxes and the
+<p class="alert-box"> You can define a server or role using both syntaxes and the
 properties will be merged. See the Properties Documentation for details
 </p>
 

--- a/docs/documentation/getting-started/preparing-your-application/index.markdown
+++ b/docs/documentation/getting-started/preparing-your-application/index.markdown
@@ -3,10 +3,10 @@ title: Preparing Your Application
 layout: default
 ---
 
-<div class="alert-box radius">
+<p class="alert-box radius">
   This will focus on preparing a Rails application, but most ideas expressed
   here have parallels in Python, or PHP applications
-</div>
+</p>
 
 ### 1. Commit your application to some externally available source control hosting provider.
 
@@ -18,12 +18,12 @@ There might be 3<sup>rd</sup> party plugins adding support for various other sys
 
 ### 2. Move secrets out of the repository.
 
-<div class="alert-box alert">
+<p class="alert-box alert">
 If you've accidentally committed state secrets to the repository, you might
 want to take
 <a href="https://help.github.com/articles/remove-sensitive-data">special steps</a>
 to erase them from the repository history for all time.
-</div>
+</p>
 
 Ideally one should remove `config/database.yml` to something like
 `config/database.yml.example`. You and your team should copy the example file
@@ -34,7 +34,7 @@ configuration into place at deploy time.
 The original `database.yml` should be added to the `.gitignore` (or your SCM's
 parallel concept of ignored files)
 
-```bash 
+```bash
 $ cp config/database.yml{,.example}
 $ echo config/database.yml >> .gitignore
 ```
@@ -136,14 +136,14 @@ server 'world.com', roles: [:web], user: 'hello'
 server 'example.com', roles: [:web], port: 1234
 ```
 
-<div class="alert-box radius"> You can define a server or role using both syntaxes and the
+<p class="alert-box radius"> You can define a server or role using both syntaxes and the
 properties will be merged. See the Properties Documentation for details
-</div>
+</p>
 
-<div class="alert-box alert"> If you define servers with either the simple or the extended
+<p class="alert-box alert"> If you define servers with either the simple or the extended
 syntax and explicitly specify a user or a port number, the last definition will win. This
 is identical behaviour to scalar custom properties. In older versions of Capistrano,
-<b>multiple</b> servers were created and the merging was ill-defined.  </div>
+<b>multiple</b> servers were created and the merging was ill-defined. </p>
 
 ### 5. Set the shared information in `deploy.rb`.
 


### PR DESCRIPTION
### Summary

This PR is attempt to fix alert messages style at capistrano documentation.

### Other Information

Hello!

At first I found forgotten class (.alert-box) at alert message on [Installation page](http://capistranorb.com/documentation/getting-started/installation/).

This page looked like:

![1_1](https://cloud.githubusercontent.com/assets/3241812/22866453/3c9bdeca-f190-11e6-917a-8a3befd4ffcc.jpg)

After I added this class, alert message began to look like this (as all alert messages at documentation):

![3](https://cloud.githubusercontent.com/assets/3241812/22866320/2451728c-f18e-11e6-8e37-1395d5cc8e63.jpg)

It looks like alerts lost their line-height property (compared with paragraphs of text on same page).

To fix this I did not touch documentation stylesheets (.alert-box class styles). I took advantage of the fact that «p» tags has this property and have changed tag for all alerts from «div» to «p».

After that alert messages began looks like this (before and after update versions):

![2](https://cloud.githubusercontent.com/assets/3241812/22866321/2b200d6c-f18e-11e6-86c4-535e5c8438bc.jpg)

It touched some list of pages:

* [Installation](http://capistranorb.com/documentation/getting-started/installation/)
* [Preparing Your Application](http://capistranorb.com/documentation/getting-started/preparing-your-application/)
* [How can I set Capistrano configuration paths?](http://capistranorb.com/documentation/faq/how-can-i-set-capistrano-configuration-paths/)

It seems to me that the styles of alert messages look more pleasant.

Thanks :)