### PR TITLE
Explain the six-week release cadence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Capistrano 3.x Changelog
 
-Reverse Chronological Order:
+All notable changes to this project will be documented in this file, in reverse chronological order. This project adheres to [Semantic Versioning](http://semver.org).
+
+**Capistrano uses a six-week release cadence.** Every six weeks, give or take, any changes in master will be published as a new rubygems version. If you'd like to use a feature or fix that is in master and you can't wait for the next planned release, put this in your project's Gemfile to use the master branch directly:
+
+```ruby
+gem "capistrano", :github => "capistrano/capistrano"
+```
 
 ## master
 


### PR DESCRIPTION
I've mentioned that I want Capistrano to use a six-week release cadence. Any objections to making this "official policy" by mentioning it in the changelog?

I chose six weeks because I think it strikes a good balance:

* Often enough that contributions are regularly published
* Not too often that users are overwhelmed trying to keep up with new versions

I also prefer a regular schedule (as opposed to "release whenever it's ready") because:

* Contributors know when their code will be published
* It encourages stability in `master` (since a release is always imminent)
* A steady project "heartbeat" keeps the community interested and involved

/cc @will-in-wi @leehambley 