### PR TITLE
Drop dependency on `capistrano-harrow' gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ https://github.com/capistrano/capistrano/compare/v3.7.2...HEAD
 * [#1843](https://github.com/capistrano/capistrano/pull/1843): Properly shell escape git:wrapper steps - [@mattbrictson](https://github.com/mattbrictson)
 * [#1846](https://github.com/capistrano/capistrano/pull/1846): Defining a role is now O(hosts) instead of O(hosts^2) [(@dbenamy)](https://github.com/dbenamy)
 * [#1846](https://github.com/capistrano/capistrano/pull/1846): add_host will add a new host in a case where it used to incorrectly update an existing one (potentially breaking) [(@dbenamy)](https://github.com/dbenamy)
+* [capistrano-harrow#4](https://github.com/harrowio/capistrano-harrow/issues/4): Drop dependency on `capistrano-harrow` gem. Gem can still be installed separately [(@leehambley)](https://github.com/leehambley)
 * Your contribution here!
 
 ## `3.7.2` (2017-01-27)

--- a/capistrano.gemspec
+++ b/capistrano.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "i18n"
   gem.add_dependency "rake", ">= 10.0.0"
   gem.add_dependency "sshkit", ">= 1.9.0"
-  gem.add_dependency "capistrano-harrow"
 
   gem.add_development_dependency "danger"
   gem.add_development_dependency "mocha"

--- a/lib/Capfile
+++ b/lib/Capfile
@@ -1,7 +1,3 @@
 #!/usr/bin/env cap
 include Capistrano::DSL
 require "capistrano/install"
-
-require "capistrano/harrow"
-require "capistrano/harrow/plugin"
-install_plugin Capistrano::Harrow::Plugin


### PR DESCRIPTION
Related to https://github.com/harrowio/capistrano-harrow/issues/4 - easy fix, just sending as a PR to get the other maintainers in the loop.