### PR TITLE
Fix hg repo_tree implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ https://github.com/capistrano/capistrano/compare/v3.7.2...HEAD
 * [#1846](https://github.com/capistrano/capistrano/pull/1846): add_host will add a new host in a case where it used to incorrectly update an existing one (potentially breaking) [(@dbenamy)](https://github.com/dbenamy)
 * [capistrano-harrow#4](https://github.com/harrowio/capistrano-harrow/issues/4): Drop dependency on `capistrano-harrow` gem. Gem can still be installed separately [(@leehambley)](https://github.com/leehambley)
 * Run `svn switch` to work with svn branches if repo_url is changed
+* [#1856](https://github.com/capistrano/capistrano/pull/1856): Fix hg repo_tree implementation - [@mattbrictson](https://github.com/mattbrictson)
 * Your contribution here!
 
 ## `3.7.2` (2017-01-27)

--- a/spec/lib/capistrano/scm/hg_spec.rb
+++ b/spec/lib/capistrano/scm/hg_spec.rb
@@ -85,8 +85,13 @@ module Capistrano
         env.set(:repo_tree, "tree")
         env.set(:branch, :branch)
         env.set(:release_path, "path")
+        env.set(:tmp_dir, "/tmp")
 
-        backend.expects(:execute).with(:hg, "archive --type tgz -p . -I", "tree", "--rev", :branch, "| tar -x --strip-components 1 -f - -C", "path")
+        SecureRandom.stubs(:hex).with(10).returns("random")
+        backend.expects(:execute).with(:hg, "archive -p . -I", "tree", "--rev", :branch, "/tmp/random.tar")
+        backend.expects(:execute).with(:mkdir, "-p", "path")
+        backend.expects(:execute).with(:tar, "-x --strip-components 1 -f", "/tmp/random.tar", "-C", "path")
+        backend.expects(:execute).with(:rm, "/tmp/random.tar")
 
         subject.archive_to_release_path
       end


### PR DESCRIPTION
`hg archive` does not write to standard out, so Capistrano's `git` implementation of the `:repo_tree` option does not work for `hg`. As a workaround, generate a temporary tar file, extract it, and then remove it. This is not as efficient or elegant as doing it via stdout and pipes in a single line, but it should work.

Fixes #1849.

@zebastiane can you test the branch to see if it works? Do you have any concerns about the implementation? Thanks!
