### PR TITLE
Don't emit warning when repo_tree is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ https://github.com/capistrano/capistrano/compare/v3.7.2...HEAD
 * [capistrano-harrow#4](https://github.com/harrowio/capistrano-harrow/issues/4): Drop dependency on `capistrano-harrow` gem. Gem can still be installed separately [(@leehambley)](https://github.com/leehambley)
 * Run `svn switch` to work with svn branches if repo_url is changed
 * [#1856](https://github.com/capistrano/capistrano/pull/1856): Fix hg repo_tree implementation - [@mattbrictson](https://github.com/mattbrictson)
+* [#1857](https://github.com/capistrano/capistrano/pull/1857): Don't emit doctor warning when repo_tree is set - [@mattbrictson](https://github.com/mattbrictson)
 * Your contribution here!
 
 ## `3.7.2` (2017-01-27)

--- a/lib/capistrano/doctor/variables_doctor.rb
+++ b/lib/capistrano/doctor/variables_doctor.rb
@@ -7,7 +7,7 @@ module Capistrano
     class VariablesDoctor
       # These are keys that have no default values in Capistrano, but are
       # nonetheless expected to be set.
-      WHITELIST = [:application, :repo_url].freeze
+      WHITELIST = [:application, :repo_url, :repo_tree].freeze
       private_constant :WHITELIST
 
       include Capistrano::Doctor::OutputHelpers

--- a/spec/lib/capistrano/doctor/variables_doctor_spec.rb
+++ b/spec/lib/capistrano/doctor/variables_doctor_spec.rb
@@ -14,6 +14,7 @@ module Capistrano
 
         env.variables.untrusted! do
           set :application, "my_app"
+          set :repo_tree, "public"
           set :repo_url, ".git"
           set :copy_strategy, :scp
           set :custom_setting, "hello"
@@ -35,6 +36,7 @@ module Capistrano
         expect { doc.call }.to output(/:pty\s+false$/).to_stdout
         expect { doc.call }.to output(/:application\s+"my_app"$/).to_stdout
         expect { doc.call }.to output(/:repo_url\s+".git"$/).to_stdout
+        expect { doc.call }.to output(/:repo_tree\s+"public"$/).to_stdout
         expect { doc.call }.to output(/:copy_strategy\s+:scp$/).to_stdout
         expect { doc.call }.to output(/:custom_setting\s+"hello"$/).to_stdout
         expect { doc.call }.to output(/"string_setting"\s+"hello"$/).to_stdout
@@ -53,6 +55,12 @@ module Capistrano
       it "does not print warning for unrecognized variable that is fetched" do
         expect { doc.call }.not_to \
           output(/:custom_setting is not a recognized Capistrano setting/)\
+          .to_stdout
+      end
+
+      it "does not print warning for whitelisted variable" do
+        expect { doc.call }.not_to \
+          output(/:repo_tree is not a recognized Capistrano setting/)\
           .to_stdout
       end
 


### PR DESCRIPTION
`:repo_tree` is a valid Capistrano setting ([it is documented](http://capistranorb.com/documentation/getting-started/configuration/)). Using it should not result in warnings.

Fixes #1852.