### PR TITLE
Unset the :scm variable when an SCM plugin is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ https://github.com/capistrano/capistrano/compare/v3.7.2...HEAD
 * [#1857](https://github.com/capistrano/capistrano/pull/1857): Don't emit doctor warning when repo_tree is set - [@mattbrictson](https://github.com/mattbrictson)
 * [#1860](https://github.com/capistrano/capistrano/pull/1860): Allow cap to be run within subdir and still work - [@mattbrictson](https://github.com/mattbrictson)
 * [#1859](https://github.com/capistrano/capistrano/pull/1859): Move git-specific repo_url logic into git plugin - [@mattbrictson](https://github.com/mattbrictson)
+* [#1858](https://github.com/capistrano/capistrano/pull/1858): Unset the :scm variable when an SCM plugin is used - [@mattbrictson](https://github.com/mattbrictson)
 * Your contribution here!
 
 ## `3.7.2` (2017-01-27)

--- a/lib/capistrano/configuration/scm_resolver.rb
+++ b/lib/capistrano/configuration/scm_resolver.rb
@@ -29,8 +29,12 @@ module Capistrano
         set(:scm, :git) if using_default_scm?
 
         print_deprecation_warnings_if_applicable
+
         # Note that `scm_plugin_installed?` comes from Capistrano::DSL
-        return if scm_plugin_installed?
+        if scm_plugin_installed?
+          delete(:scm)
+          return
+        end
 
         if built_in_scm_name?
           load_built_in_scm

--- a/spec/lib/capistrano/configuration/scm_resolver_spec.rb
+++ b/spec/lib/capistrano/configuration/scm_resolver_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+module Capistrano
+  class Configuration
+    describe SCMResolver do
+      include Capistrano::DSL
+
+      let(:resolver) { SCMResolver.new }
+
+      before do
+        Rake::Task.define_task("deploy:check")
+        Rake::Task.define_task("deploy:new_release_path")
+        Rake::Task.define_task("deploy:set_current_revision")
+        set :scm, SCMResolver::DEFAULT_GIT
+      end
+
+      after do
+        Rake::Task.clear
+        Capistrano::Configuration.reset!
+      end
+
+      context "default scm, no plugin installed" do
+        it "emits a warning" do
+          expect { resolver.resolve }.to output(/will not load the git scm/i).to_stderr
+        end
+
+        it "activates the git scm" do
+          resolver.resolve
+          expect(Rake::Task["git:wrapper"]).not_to be_nil
+        end
+
+        it "sets :scm to :git" do
+          resolver.resolve
+          expect(fetch(:scm)).to eq(:git)
+        end
+      end
+
+      context "default scm, git plugin installed" do
+        before do
+          install_plugin Capistrano::SCM::Git
+        end
+
+        it "emits no warning" do
+          expect { resolver.resolve }.not_to output.to_stderr
+        end
+
+        it "deletes :scm" do
+          resolver.resolve
+          expect(fetch(:scm)).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
If the user has opted into the new SCM plugin mechanism, there is no reason to keep the `:scm` variable around. This also fixes a bug where `:scm` would always be set it `:git`, regardless of what plugin was being used.

Also, add some much needed test coverage for `SCMResolver`.

Fixes #1851.