### PR TITLE
Move git-specific repo_url logic into git plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ https://github.com/capistrano/capistrano/compare/v3.7.2...HEAD
 * [#1856](https://github.com/capistrano/capistrano/pull/1856): Fix hg repo_tree implementation - [@mattbrictson](https://github.com/mattbrictson)
 * [#1857](https://github.com/capistrano/capistrano/pull/1857): Don't emit doctor warning when repo_tree is set - [@mattbrictson](https://github.com/mattbrictson)
 * [#1860](https://github.com/capistrano/capistrano/pull/1860): Allow cap to be run within subdir and still work - [@mattbrictson](https://github.com/mattbrictson)
+* [#1859](https://github.com/capistrano/capistrano/pull/1859): Move git-specific repo_url logic into git plugin - [@mattbrictson](https://github.com/mattbrictson)
 * Your contribution here!
 
 ## `3.7.2` (2017-01-27)

--- a/lib/capistrano/dsl/paths.rb
+++ b/lib/capistrano/dsl/paths.rb
@@ -36,20 +36,7 @@ module Capistrano
       end
 
       def repo_url
-        require "cgi"
-        require "uri"
-        if fetch(:git_http_username) && fetch(:git_http_password)
-          URI.parse(fetch(:repo_url)).tap do |repo_uri|
-            repo_uri.user     = fetch(:git_http_username)
-            repo_uri.password = CGI.escape(fetch(:git_http_password))
-          end.to_s
-        elsif fetch(:git_http_username)
-          URI.parse(fetch(:repo_url)).tap do |repo_uri|
-            repo_uri.user = fetch(:git_http_username)
-          end.to_s
-        else
-          fetch(:repo_url)
-        end
+        fetch(:repo_url)
       end
 
       def repo_path

--- a/spec/lib/capistrano/scm/git_spec.rb
+++ b/spec/lib/capistrano/scm/git_spec.rb
@@ -81,6 +81,20 @@ module Capistrano
 
         subject.clone_repo
       end
+
+      context "with username and password specified" do
+        before do
+          env.set(:git_http_username, "hello")
+          env.set(:git_http_password, "topsecret")
+          env.set(:repo_url, "https://example.com/repo.git")
+          env.set(:repo_path, "path")
+        end
+
+        it "should include the credentials in the url" do
+          backend.expects(:execute).with(:git, :clone, "--mirror", "https://hello:topsecret@example.com/repo.git", "path")
+          subject.clone_repo
+        end
+      end
     end
 
     describe "#update_mirror" do


### PR DESCRIPTION
The implementation of the `repo_url` helper method had some special logic that was Git-specific. It looked for the presence of `:git_http_username` and `:git_http_password` and used these to mutate the original `:repo_url`.

Since we eventually want to move all SCM implementations out of core and into separate plugins, I have moved this code into the Git plugin.

Also add a unit test (this feature was previously untested).

Fixes #1715.