### PR TITLE
Allow cap to be run within subdir and still work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ https://github.com/capistrano/capistrano/compare/v3.7.2...HEAD
 * Run `svn switch` to work with svn branches if repo_url is changed
 * [#1856](https://github.com/capistrano/capistrano/pull/1856): Fix hg repo_tree implementation - [@mattbrictson](https://github.com/mattbrictson)
 * [#1857](https://github.com/capistrano/capistrano/pull/1857): Don't emit doctor warning when repo_tree is set - [@mattbrictson](https://github.com/mattbrictson)
+* [#1860](https://github.com/capistrano/capistrano/pull/1860): Allow cap to be run within subdir and still work - [@mattbrictson](https://github.com/mattbrictson)
 * Your contribution here!
 
 ## `3.7.2` (2017-01-27)

--- a/features/step_definitions/cap_commands.rb
+++ b/features/step_definitions/cap_commands.rb
@@ -2,6 +2,10 @@ When(/^I run cap "(.*?)"$/) do |task|
   @success, @output = TestApp.cap(task)
 end
 
+When(/^I run cap "(.*?)" within the "(.*?)" directory$/) do |task, directory|
+  @success, @output = TestApp.cap(task, directory)
+end
+
 When(/^I run cap "(.*?)" as part of a release$/) do |task|
   TestApp.cap("deploy:new_release_path #{task}")
 end

--- a/features/subdirectory.feature
+++ b/features/subdirectory.feature
@@ -1,0 +1,9 @@
+Feature: cap can be run from a subdirectory, and will still find the Capfile
+
+  Background:
+    Given a test app with the default configuration
+    And servers with the roles app and web
+
+  Scenario: Running cap from a subdirectory
+    When I run cap "git:check" within the "config" directory
+    Then the task is successful

--- a/lib/capistrano/application.rb
+++ b/lib/capistrano/application.rb
@@ -2,7 +2,7 @@ module Capistrano
   class Application < Rake::Application
     def initialize
       super
-      @rakefiles = %w{capfile Capfile capfile.rb Capfile.rb} << capfile
+      @rakefiles = %w{capfile Capfile capfile.rb Capfile.rb}
     end
 
     def name
@@ -76,6 +76,15 @@ module Capistrano
       end
     end
 
+    # allows the `cap install` task to load without a capfile
+    def find_rakefile_location
+      if (location = super).nil?
+        [capfile, Dir.pwd]
+      else
+        location
+      end
+    end
+
     private
 
     def backtrace_pattern
@@ -96,7 +105,6 @@ module Capistrano
       super
     end
 
-    # allows the `cap install` task to load without a capfile
     def capfile
       File.expand_path(File.join(File.dirname(__FILE__), "..", "Capfile"))
     end

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -90,13 +90,14 @@ module TestApp
     File.open(shared_path.join(path), "w")
   end
 
-  def cap(task)
-    run "bundle exec cap #{stage} #{task}"
+  def cap(task, subdirectory=nil)
+    run "bundle exec cap #{stage} #{task}", subdirectory
   end
 
-  def run(command)
+  def run(command, subdirectory=nil)
     output = nil
-    Dir.chdir(test_app_path) do
+    dir = subdirectory ? test_app_path.join(subdirectory) : test_app_path
+    Dir.chdir(dir) do
       output = `#{command}`
     end
     [$CHILD_STATUS.success?, output]


### PR DESCRIPTION
Much like rake can find its Rakefile even when run in a subdirectory, cap can now find its Capfile. Since cap is built on top of rake, this was really just restoring default behavior that was accidentally overridden.

Also add a feature test to ensure it works.

Fixes #1832.