### PR TITLE
Run svn switch with branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ https://github.com/capistrano/capistrano/compare/v3.7.2...HEAD
 * [#1846](https://github.com/capistrano/capistrano/pull/1846): Defining a role is now O(hosts) instead of O(hosts^2) [(@dbenamy)](https://github.com/dbenamy)
 * [#1846](https://github.com/capistrano/capistrano/pull/1846): add_host will add a new host in a case where it used to incorrectly update an existing one (potentially breaking) [(@dbenamy)](https://github.com/dbenamy)
 * [capistrano-harrow#4](https://github.com/harrowio/capistrano-harrow/issues/4): Drop dependency on `capistrano-harrow` gem. Gem can still be installed separately [(@leehambley)](https://github.com/leehambley)
+* Run `svn switch` to work with svn branches if repo_url is changed
 * Your contribution here!
 
 ## `3.7.2` (2017-01-27)

--- a/lib/capistrano/scm/svn.rb
+++ b/lib/capistrano/scm/svn.rb
@@ -34,6 +34,9 @@ class Capistrano::SCM::Svn < Capistrano::SCM::Plugin
   end
 
   def update_mirror
+    # Switch the repository URL if necessary.
+    repo_mirror_url = fetch_repo_mirror_url
+    svn :switch, repo_url unless repo_mirror_url == repo_url
     svn :update
   end
 
@@ -43,5 +46,11 @@ class Capistrano::SCM::Svn < Capistrano::SCM::Plugin
 
   def fetch_revision
     backend.capture(:svnversion, repo_path.to_s)
+  end
+
+  def fetch_repo_mirror_url
+    backend.capture(:svn, :info, repo_path.to_s).each_line do |line|
+      return $1 if /\AURL: (.*)\n\z/ =~ line
+    end
   end
 end

--- a/spec/lib/capistrano/scm/svn_spec.rb
+++ b/spec/lib/capistrano/scm/svn_spec.rb
@@ -71,6 +71,10 @@ module Capistrano
 
     describe "#update_mirror" do
       it "should run svn update" do
+        env.set(:repo_url, "url")
+        env.set(:repo_path, "path")
+        backend.expects(:capture).with(:svn, :info, "path").returns("URL: url\n")
+
         env.set(:svn_username, "someuser")
         env.set(:svn_password, "somepassword")
         backend.expects(:execute).with(:svn, :update, "--username someuser", "--password somepassword")
@@ -80,6 +84,10 @@ module Capistrano
 
       context "for specific revision" do
         it "should run svn update" do
+          env.set(:repo_url, "url")
+          env.set(:repo_path, "path")
+          backend.expects(:capture).with(:svn, :info, "path").returns("URL: url\n")
+
           env.set(:svn_username, "someuser")
           env.set(:svn_password, "somepassword")
           env.set(:svn_revision, "12345")
@@ -87,6 +95,19 @@ module Capistrano
 
           subject.update_mirror
         end
+      end
+
+      it "should run svn switch if repo_url is changed" do
+        env.set(:repo_url, "url")
+        env.set(:repo_path, "path")
+        backend.expects(:capture).with(:svn, :info, "path").returns("URL: old_url\n")
+
+        env.set(:svn_username, "someuser")
+        env.set(:svn_password, "somepassword")
+        backend.expects(:execute).with(:svn, :switch, "url", "--username someuser", "--password somepassword")
+        backend.expects(:execute).with(:svn, :update, "--username someuser", "--password somepassword")
+
+        subject.update_mirror
       end
     end
 


### PR DESCRIPTION
When repo_url is changed to another branch using svn, fetched
repository is not changed on the server.
In the case `svn switch` is needed to switch branches.

This is a fix for #1545.

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?
- [x] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?
