### PR TITLE
Allow `cap -T` to run without Capfile present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ gem "capistrano", :github => "capistrano/capistrano"
 https://github.com/capistrano/capistrano/compare/v3.7.2...HEAD
 
 * Your contribution here!
+* [#1867](https://github.com/capistrano/capistrano/pull/1867): Allow `cap -T` to run without Capfile present - [@mattbrictson](https://github.com/mattbrictson)
 
 ## `3.8.0` (2017-03-10)
 

--- a/features/installation.feature
+++ b/features/installation.feature
@@ -3,6 +3,11 @@ Feature: Installation
   Background:
     Given a test app without any configuration
 
+  Scenario: The "install" task documentation can be viewed
+    When I run "cap -T"
+    Then the task is successful
+    And contains "cap install" in the output
+
   Scenario: With default stages
     When I run "cap install"
     Then the deploy.rb file is created

--- a/features/installation.feature
+++ b/features/installation.feature
@@ -1,16 +1,16 @@
 Feature: Installation
 
   Background:
-    Given a test app with the default configuration
+    Given a test app without any configuration
 
   Scenario: With default stages
-    When I run cap "install"
+    When I run "cap install"
     Then the deploy.rb file is created
     And the default stage files are created
     And the tasks folder is created
 
   Scenario: With specified stages
-    When I run cap "install STAGES=qa,production"
+    When I run "cap install STAGES=qa,production"
     Then the deploy.rb file is created
     And the specified stage files are created
     And the tasks folder is created

--- a/features/step_definitions/setup.rb
+++ b/features/step_definitions/setup.rb
@@ -2,6 +2,10 @@ Given(/^a test app with the default configuration$/) do
   TestApp.install
 end
 
+Given(/^a test app without any configuration$/) do
+  TestApp.create_test_app
+end
+
 Given(/^servers with the roles app and web$/) do
   begin
     vagrant_cli_command("up")

--- a/lib/capistrano/application.rb
+++ b/lib/capistrano/application.rb
@@ -96,7 +96,7 @@ module Capistrano
     end
 
     def load_imports
-      if options.show_tasks
+      if options.show_tasks && Rake::Task.task_defined?("load:defaults")
         invoke "load:defaults"
         set(:stage, "")
         Dir[deploy_config_path].each { |f| add_import f }


### PR DESCRIPTION
Previously, the `cap -T` command assumed the presence of the `load:defaults` task. This task is only present if a proper Capfile is loaded, and so `cap -T` wouldn't work in a new, not yet "capified" project.

This PR fixes the bug by testing that `load:defaults` is defined before calling it.

Also in this PR:

**Invoke `bundle` correctly within feature tests** 

During the feature tests we create a separate directory with its own `Gemfile` and use `bundle` and `bundle exec` within that directory.

However if `bundle exec` was used to run the feature tests, then a bundler environment is already loaded, and so the test Gemfile is never consulted. Running `bundle` doesn't have the desired effect, because the child process inherits the bundler environment variables from the parent process.

Bundler's solution for this problem is the `Bundle.with_clean_env` method. This ensures that the child process doesn't inherit the parent's bundler environment.

**Use empty app as background for cap install tests**

Previously, a fully-configured app was used as the background for the `cap install` feature tests. This somewhat defeated the purpose of these tests, because `cap install` is supposed to be run on a project that hasn't yet been "capified".

Fixes #1865 