### PR TITLE
Fix RuboCop 0.48 violations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,11 @@ Style/ClassAndModuleChildren:
   Enabled: false
 Style/DoubleNegation:
   Enabled: false
+Style/FileName:
+  Exclude:
+    - "Dangerfile"
+Style/IndentHeredoc:
+  Enabled: false
 Style/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: no_space
 Style/StringLiterals:

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require "cucumber/rake/task"
 require "rspec/core/rake_task"
 require "rubocop/rake_task"
 
-task default: [:spec, :rubocop]
+task default: %i(spec rubocop)
 RSpec::Core::RakeTask.new
 
 Cucumber::Rake::Task.new(:features)

--- a/capistrano.gemspec
+++ b/capistrano.gemspec
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "capistrano/version"

--- a/lib/capistrano/configuration/filter.rb
+++ b/lib/capistrano/configuration/filter.rb
@@ -8,7 +8,7 @@ module Capistrano
   class Configuration
     class Filter
       def initialize(type, values=nil)
-        raise "Invalid filter type #{type}" unless [:host, :role].include? type
+        raise "Invalid filter type #{type}" unless %i(host role).include? type
         av = Array(values)
         @strategy = if av.empty? then EmptyFilter.new
                     elsif av.include?(:all) || av.include?("all") then NullFilter.new

--- a/lib/capistrano/defaults.rb
+++ b/lib/capistrano/defaults.rb
@@ -8,7 +8,7 @@ validate :application do |_key, value|
   end
 end
 
-[:git_strategy, :hg_strategy, :svn_strategy].each do |strategy|
+%i(git_strategy hg_strategy svn_strategy).each do |strategy|
   validate(strategy) do |key, _value|
     warn(
       "[Deprecation Warning] #{key} is deprecated and will be removed in "\

--- a/lib/capistrano/doctor/variables_doctor.rb
+++ b/lib/capistrano/doctor/variables_doctor.rb
@@ -7,7 +7,7 @@ module Capistrano
     class VariablesDoctor
       # These are keys that have no default values in Capistrano, but are
       # nonetheless expected to be set.
-      WHITELIST = [:application, :repo_url, :repo_tree].freeze
+      WHITELIST = %i(application repo_url repo_tree).freeze
       private_constant :WHITELIST
 
       include Capistrano::Doctor::OutputHelpers

--- a/lib/capistrano/scm/git.rb
+++ b/lib/capistrano/scm/git.rb
@@ -9,7 +9,7 @@ class Capistrano::SCM::Git < Capistrano::SCM::Plugin
     set_if_empty :git_wrapper_path, lambda {
       # Try to avoid permissions issues when multiple users deploy the same app
       # by using different file names in the same dir for each deployer and stage.
-      suffix = [:application, :stage, :local_user].map { |key| fetch(key).to_s }.join("-")
+      suffix = %i(application stage local_user).map { |key| fetch(key).to_s }.join("-")
       "#{fetch(:tmp_dir)}/git-ssh-#{suffix}.sh"
     }
     set_if_empty :git_environmental_variables, lambda {

--- a/spec/lib/capistrano/configuration/filter_spec.rb
+++ b/spec/lib/capistrano/configuration/filter_spec.rb
@@ -5,7 +5,7 @@ module Capistrano
     describe Filter do
       let(:available) do
         [
-          Server.new("server1").add_roles([:web, :db]),
+          Server.new("server1").add_roles(%i(web db)),
           Server.new("server2").add_role(:web),
           Server.new("server3").add_role(:redis),
           Server.new("server4").add_role(:db),

--- a/spec/lib/capistrano/configuration/role_filter_spec.rb
+++ b/spec/lib/capistrano/configuration/role_filter_spec.rb
@@ -7,7 +7,7 @@ module Capistrano
 
       let(:available) do
         [
-          Server.new("server1").add_roles([:web, :db]),
+          Server.new("server1").add_roles(%i(web db)),
           Server.new("server2").add_role(:web),
           Server.new("server3").add_role(:redis),
           Server.new("server4").add_role(:db),
@@ -41,7 +41,7 @@ module Capistrano
         end
 
         context "with multiple roles" do
-          let(:values) { [:web, :db] }
+          let(:values) { %i(web db) }
           it_behaves_like "it filters roles correctly", 3, %w{server1 server2 server4}
         end
 

--- a/spec/lib/capistrano/configuration/server_spec.rb
+++ b/spec/lib/capistrano/configuration/server_spec.rb
@@ -13,7 +13,7 @@ module Capistrano
       end
 
       describe "adding roles" do
-        subject { server.add_roles([:things, :stuff]) }
+        subject { server.add_roles(%i(things stuff)) }
         it "adds the roles" do
           expect { subject }.to change { server.roles.size }.from(0).to(2)
         end

--- a/spec/lib/capistrano/configuration/servers_spec.rb
+++ b/spec/lib/capistrano/configuration/servers_spec.rb
@@ -56,7 +56,7 @@ module Capistrano
 
       describe "collecting server roles" do
         let(:app) { Set.new([:app]) }
-        let(:web_app) { Set.new([:web, :app]) }
+        let(:web_app) { Set.new(%i(web app)) }
         let(:web) { Set.new([:web]) }
 
         before do
@@ -108,7 +108,7 @@ module Capistrano
         end
 
         it "returns the correct app and web servers" do
-          expect(servers.roles_for([:app, :web]).map(&:hostname)).to eq %w{1 2 3}
+          expect(servers.roles_for(%i(app web)).map(&:hostname)).to eq %w{1 2 3}
         end
 
         it "returns all servers" do
@@ -284,7 +284,7 @@ module Capistrano
           end
 
           context "when selecting specific roles" do
-            let(:roles) { [:app, :web] }
+            let(:roles) { %i(app web) }
             it "ignores it" do
               expect(subject).to eq %w{1 2 3 4}
             end
@@ -312,7 +312,7 @@ module Capistrano
           end
 
           context "when selecting specific roles" do
-            let(:roles) { [:app, :web] }
+            let(:roles) { %i(app web) }
             it "ignores it" do
               expect(subject).to eq %w{1 2 3 4}
             end

--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -238,7 +238,7 @@ module Capistrano
       end
 
       it "returns all set keys" do
-        expect(subject).to match_array [:key1, :key2]
+        expect(subject).to match_array %i(key1 key2)
       end
     end
 
@@ -255,7 +255,7 @@ module Capistrano
 
     describe "asking" do
       let(:question) { stub }
-      let(:options) { Hash.new }
+      let(:options) { {} }
 
       before do
         Configuration::Question.expects(:new).with(:branch, :default, options)


### PR DESCRIPTION
The major change in RuboCop 0.48 seems to be the recommendation of the Ruby 2.0 `%i` literal syntax for declaring arrays of symbols. I like the recommendation.

Any objections?