### PR TITLE
Add dkdeploy to documentation of 3rd party plugins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@ AllCops:
   DisplayStyleGuide: true
   TargetRubyVersion: 2.0
 
+Lint/AmbiguousBlockAssociation:
+  Enabled:
+    false
 Metrics/BlockLength:
   Exclude:
     - "spec/**/*"

--- a/capistrano.gemspec
+++ b/capistrano.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "danger"
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "rspec"
-  gem.add_development_dependency "rubocop"
+  gem.add_development_dependency "rubocop", "0.48.1"
 end

--- a/docs/documentation/third-party-plugins/index.markdown
+++ b/docs/documentation/third-party-plugins/index.markdown
@@ -43,3 +43,9 @@ This list is neither complete nor audited in any way.
 <div class="github-widget" data-repo="aidistan/capistrano-pm2"></div>
 
 <div class="github-widget" data-repo="mgrachev/capistrano-hanami"></div>
+
+<div class="github-widget" data-repo="dkdeploy/dkdeploy-core"></div>
+
+<div class="github-widget" data-repo="dkdeploy/dkdeploy-php"></div>
+
+<div class="github-widget" data-repo="dkdeploy/dkdeploy-typo3-cms"></div>


### PR DESCRIPTION
### Summary

Adds the dkdeploy-core, dkdeploy-php and dkdeploy-typo3-cms gems to the 3rd party plugins section of the documentation
