### PR TITLE
Fix build failures due to the release of RuboCop 0.48.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@ AllCops:
   DisplayStyleGuide: true
   TargetRubyVersion: 2.0
 
+Lint/AmbiguousBlockAssociation:
+  Enabled:
+    false
 Metrics/BlockLength:
   Exclude:
     - "spec/**/*"

--- a/capistrano.gemspec
+++ b/capistrano.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "danger"
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "rspec"
-  gem.add_development_dependency "rubocop"
+  gem.add_development_dependency "rubocop", "0.48.1"
 end


### PR DESCRIPTION
Travis CI for `master` (and all PRs) is currently broken because `Lint/AmbiguousBlockAssociation` in RuboCop 0.48.1 forbids this construct:

```ruby
set :foo, -> { "bar" }
```

It apparently wants:

```ruby
set(:foo, -> { "bar" })
```

This recommendation isn't desirable in Capistrano, so I disabled it.

I also pinned our RuboCop dependency so that new versions won't suddenly cause our builds to break in the future. We can always manually upgrade RuboCop if desired.

