### PR TITLE
Explain where to add new Capfile lines in scm deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ https://github.com/capistrano/capistrano/compare/v3.8.1...HEAD
 
 * Your contribution here!
 
+* [#1882](https://github.com/capistrano/capistrano/pull/1882): Explain where to add new Capfile lines in scm deprecation warning - [@robd](https://github.com/robd)
+
 ## `3.8.1` (2017-04-21)
 
 https://github.com/capistrano/capistrano/compare/v3.8.0...v3.8.1

--- a/lib/capistrano/configuration/scm_resolver.rb
+++ b/lib/capistrano/configuration/scm_resolver.rb
@@ -112,7 +112,8 @@ module Capistrano
         $stderr.puts(<<-MESSAGE)
 [Deprecation Notice] `set :scm, #{scm_name.inspect}` is deprecated.
 To ensure your project is compatible with future versions of Capistrano,
-remove the :scm setting and instead add these lines to your Capfile:
+remove the :scm setting and instead add these lines to your Capfile after
+`require "capistrano/deploy"`:
 
     require "capistrano/scm/#{scm_name}"
     install_plugin #{built_in_scm_plugin_class_name}
@@ -124,7 +125,7 @@ MESSAGE
         $stderr.puts(<<-MESSAGE)
 [Deprecation Notice] Future versions of Capistrano will not load the Git SCM
 plugin by default. To silence this deprecation warning, add the following to
-your Capfile:
+your Capfile after `require "capistrano/deploy"`:
 
     require "capistrano/scm/git"
     install_plugin Capistrano::SCM::Git


### PR DESCRIPTION
Try and avoid people adding new SCM lines to the wrong place in their Capfiles: https://github.com/capistrano/capistrano/issues/1824