### PR TITLE
Skip invalid releases instead of skipping the whole cleanup

### DIFF
--- a/lib/capistrano/i18n.rb
+++ b/lib/capistrano/i18n.rb
@@ -13,7 +13,7 @@ en = {
   question: "Please enter %{key}: ",
   question_default: "Please enter %{key} (%{default_value}): ",
   keeping_releases: "Keeping %{keep_releases} of %{releases} deployed releases on %{host}",
-  skip_cleanup: "Skipping cleanup of old releases on %{host}; unexpected foldername found (should be timestamp)",
+  invalid_releases_found: "Invalid release folders found on %{host}; unexpected foldername found (should be timestamp)"
   no_old_releases: "No old releases (keeping newest %{keep_releases}) on %{host}",
   linked_file_does_not_exist: "linked file %{file} does not exist on %{host}",
   cannot_rollback: "There are no older releases to rollback to",

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -149,9 +149,12 @@ namespace :deploy do
   task :cleanup do
     on release_roles :all do |host|
       releases = capture(:ls, "-x", releases_path).split
-      if !(releases.all? { |e| /^\d{14}$/ =~ e })
-        warn t(:skip_cleanup, host: host.to_s)
-      elsif releases.count >= fetch(:keep_releases)
+      invalid_releases = releases.select { |e| /^\d{14}$/ =~ e }
+      if invalid_releases.any?
+        warn t(:invalid_releases_found, host: host.to_s)
+        releases -= invalid_releases
+      end
+      if releases.count >= fetch(:keep_releases)
         info t(:keeping_releases, host: host.to_s, keep_releases: fetch(:keep_releases), releases: releases.count)
         directories = (releases - releases.last(fetch(:keep_releases)))
         if directories.any?


### PR DESCRIPTION
The change introduced in #1811 skips the whole cleanup processes if an invalid folder is found.
In our case we create an `initial` folder in the releases during the initial server configuration so we can have an existing `current` symlink so nginx wont crash.

After upgrading capistrano no releases were cleaned anymore and just a warning was given which is barely noticeable by the big loads of capistrano output. This caused our production server disk to run out of free space.

I suggest that the cleanup process should still happen and the invalid folders should be skipped.