### PR TITLE
`git ls-remote` should be performed within repo_path

### DIFF
--- a/lib/capistrano/scm/tasks/git.rake
+++ b/lib/capistrano/scm/tasks/git.rake
@@ -15,8 +15,10 @@ namespace :git do
   task check: :'git:wrapper' do
     fetch(:branch)
     on release_roles :all do
-      with fetch(:git_environmental_variables) do
-        git_plugin.check_repo_is_reachable
+      within repo_path do
+        with fetch(:git_environmental_variables) do
+          git_plugin.check_repo_is_reachable
+        end
       end
     end
   end


### PR DESCRIPTION
### Summary

Checking reachability of git repo should be done inside git repo in order to utilize local git config.

For example, AWS CodeCommit [recommends](http://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-https-unixes.html#setting-up-https-unixes-credential-helper) setting up credential helper.
If config is saved locally, current `git:check` task fails.

