### PR TITLE
Do not claim to follow SemVer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Capistrano 3.x Changelog
 
-All notable changes to this project will be documented in this file, in reverse chronological order. This project adheres to [Semantic Versioning](http://semver.org).
+All notable changes to this project will be documented in this file, in reverse chronological order.
 
 **Capistrano uses a six-week release cadence.** Every six weeks, give or take, any changes in master will be published as a new rubygems version. If you'd like to use a feature or fix that is in master and you can't wait for the next planned release, put this in your project's Gemfile to use the master branch directly:
 


### PR DESCRIPTION
Capistrano introduces breaking changes in minor versions. SemVer requires an update of the major version for such changes. Hence, Capistrano should not claim to follow SemVer.