### PR TITLE
Add :local_user setting to config and docs

### DIFF
--- a/docs/documentation/getting-started/structure/index.markdown
+++ b/docs/documentation/getting-started/structure/index.markdown
@@ -42,9 +42,9 @@ repository the content will be a  raw git repository (e.g. objects, refs,
 etc.).
 
 * `revisions.log` is used to log every deploy or rollback. Each entry is
-timestamped and the executing  user (username from local machine) is listed.
-Depending on your VCS data like branchnames or revision  numbers are listed as
-well.
+timestamped and the executing  user (`:local_user`, defaulting to the local
+username) is listed. Depending on your VCS data like branch names or revision
+numbers are listed as well.
 
 * `shared` contains the `linked_files` and `linked_dirs` which are symlinked
 into each release. This  data persists across deployments and releases. It

--- a/lib/capistrano/templates/deploy.rb.erb
+++ b/lib/capistrano/templates/deploy.rb.erb
@@ -29,5 +29,8 @@ set :repo_url, "git@example.com:me/my_repo.git"
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }
 
+# Default value for local_user is ENV['USER']
+# set :local_user, -> { `git config user.name`.chomp }
+
 # Default value for keep_releases is 5
 # set :keep_releases, 5


### PR DESCRIPTION
### Summary

This PR adds the `:local_user` setting to the generated `deploy.rb` to encourage users to pick a reasonable setting that identifies their team members and/or CI processes.

It also adds a mention of `:local_user` to the according section of the documentation that deals with the `revisions.log` file.

Partially resolves issue #1893, “Capistrano leaks local user account name to deployment log”.