### PR TITLE
Explain how security issues should be reported

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,8 @@ Also include in your report:
 
 If you are an experienced Ruby programmer, take a few minutes to get the Capistrano test suite running (see [DEVELOPMENT.md][]), and do what you can to get a test case written that fails. *This will be a huge help!*
 
+If you think you may have discovered a security vulnerability in Capistrano, do not open a GitHub issue. Instead, please send a report to <security@capistranorb.com>.
+
 ## Requesting new features or improvements
 
 Capistrano continues to improve thanks to people like you! Feel free to open a GitHub issue for any or all of these ideas:

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ Related GitHub repositories:
 
 GitHub issues are for bug reports and feature requests. Please refer to the [CONTRIBUTING](CONTRIBUTING.md) document for guidelines on submitting GitHub issues.
 
+If you think you may have discovered a security vulnerability in Capistrano, do not open a GitHub issue. Instead, please send a report to <security@capistranorb.com>.
+
 ## How to contribute
 
 Contributions to Capistrano, in the form of code, documentation or idea, are gladly accepted. Read the [DEVELOPMENT](DEVELOPMENT.md) document to learn how to hack on Capistrano's code, run the tests, and contribute your first pull request.


### PR DESCRIPTION
Security issues should not be reported through GitHub; they should go to <security@capistranorb.com>.