### PR TITLE
Add delete rollback source option

### DIFF
--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -43,7 +43,7 @@ namespace :deploy do
   end
 
   task :finishing_rollback do
-    invoke "deploy:cleanup_rollback"
+    invoke "deploy:cleanup_rollback" if fetch(:delete_rollback_source, true)
   end
 
   task :finished do


### PR DESCRIPTION
### Summary

I suggest delete source option when using deploy:rollback.

The reason is same as follow.

`When using unicorn and similar servers that do 0 downtime deploys by pre-loading a new set of server app instances - removing the old deployed directory will cause errors until the new ones have booted.`
issue #547 

- set :delete_rollback_source, true  #=> delete
- set :delete_rollback_source, false #=> not delete
- not set(default) #=> delete (same as current)

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [ ] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?
- [ ] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?

