### PR TITLE
Allow to invoke iterant tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,20 @@ gem "capistrano", :github => "capistrano/capistrano"
 
 ## master
 
-https://github.com/capistrano/capistrano/compare/v3.8.1...HEAD
+https://github.com/capistrano/capistrano/compare/v3.8.2...HEAD
 
 * Your contribution here!
 
 * Updated `deploy:cleanup` to continue rotating the releases and skip the invalid directory names instead of skipping the whole rotation of releases. The warning message has changed slightly due to the change of behavior.
+* [#1911](https://github.com/capistrano/capistrano/pull/1911): Add Capistrano::DSL#invoke! for repetetive tasks
+
+### Breaking changes:
+
+* None
+
+### Other changes:
+
+* None
 
 ## `3.8.2` (2017-06-16)
 

--- a/lib/capistrano/dsl.rb
+++ b/lib/capistrano/dsl.rb
@@ -19,10 +19,16 @@ module Capistrano
         colors = SSHKit::Color.new($stderr)
         $stderr.puts colors.colorize("Skipping task `#{task_name}'.", :yellow)
         $stderr.puts "Capistrano tasks may only be invoked once. Since task `#{task}' was previously invoked, invoke(\"#{task_name}\") at #{file}:#{line} will be skipped."
-        $stderr.puts "If you really meant to run this task again, first call Rake::Task[\"#{task_name}\"].reenable"
+        $stderr.puts "If you really meant to run this task again, use invoke!(\"#{task_name}\")"
         $stderr.puts colors.colorize("THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF CAPISTRANO. Please join the conversation here if this affects you.", :red)
         $stderr.puts colors.colorize("https://github.com/capistrano/capistrano/issues/1686", :red)
       end
+      task.invoke(*args)
+    end
+
+    def invoke!(task_name, *args)
+      task = Rake::Task[task_name]
+      task.reenable
       task.invoke(*args)
     end
 

--- a/spec/lib/capistrano/dsl_spec.rb
+++ b/spec/lib/capistrano/dsl_spec.rb
@@ -77,7 +77,7 @@ module Capistrano
         dsl.invoke("some_task")
         expect do
           dsl.invoke("some_task")
-        end.to output(/.*Capistrano tasks may only be invoked once.*/).to_stderr
+        end.to output(/If you really meant to run this task again, use invoke!/).to_stderr
       end
     end
   end

--- a/spec/lib/capistrano/dsl_spec.rb
+++ b/spec/lib/capistrano/dsl_spec.rb
@@ -71,13 +71,54 @@ module Capistrano
     end
 
     describe "#invoke" do
-      it "will print a message on stderr, when reinvoking task" do
-        Rake::Task.define_task("some_task")
+      context "reinvoking" do
+        it "will not reenable invoking task" do
+          counter = 0
 
-        dsl.invoke("some_task")
-        expect do
-          dsl.invoke("some_task")
-        end.to output(/If you really meant to run this task again, use invoke!/).to_stderr
+          Rake::Task.define_task("A") do
+            counter += 1
+          end
+
+          expect do
+            dsl.invoke("A")
+            dsl.invoke("A")
+          end.to change { counter }.by(1)
+        end
+
+        it "will print a message on stderr" do
+          Rake::Task.define_task("B")
+
+          expect do
+            dsl.invoke("B")
+            dsl.invoke("B")
+          end.to output(/If you really meant to run this task again, use invoke!/).to_stderr
+        end
+      end
+    end
+
+    describe "#invoke!" do
+      context "reinvoking" do
+        it "will reenable invoking task" do
+          counter = 0
+
+          Rake::Task.define_task("C") do
+            counter += 1
+          end
+
+          expect do
+            dsl.invoke!("C")
+            dsl.invoke!("C")
+          end.to change { counter }.by(2)
+        end
+
+        it "will not print a message on stderr" do
+          Rake::Task.define_task("D")
+
+          expect do
+            dsl.invoke!("D")
+            dsl.invoke!("D")
+          end.to_not output(/If you really meant to run this task again, use invoke!/).to_stderr
+        end
       end
     end
   end


### PR DESCRIPTION
### Summary

As far as some people have already implemented a hack to invoke repetetive tasks with re-enabling them through [Rake::Task#reenable](https://github.com/ruby/rake/blob/master/lib/rake/task.rb#L141) in their gems related to capistrano ([`capistrano-sidekiq`](https://github.com/seuros/capistrano-sidekiq/blob/master/lib/capistrano/tasks/sidekiq.rake#L157)), let's make it at capistrano level, as was agreed in #1686.

### Short checklist

- [+] Did you run `bundle exec rubocop -a` to fix linter issues?
- [+] If relevant, did you create a test?
- [+] Did you confirm that the RSpec tests pass?
- [+] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?

### Other Information

I have read CONTRIBUTION guide and I guess adhered requirements, but please let me know if I need to do anything else 🙇  I'm glad to adopt any reasonable critics, welcome to collaborate ^_^