### PR TITLE
[docs] Fix typo in "ignoring" article

### DIFF
--- a/docs/documentation/advanced-features/ignoring/index.markdown
+++ b/docs/documentation/advanced-features/ignoring/index.markdown
@@ -3,7 +3,7 @@ title: Ignoring
 layout: default
 ---
 
-Files commited to version control (i.e. not in .gitignore) can still be ignored when deploying.  To ignore these files or directories, simply add them to .gitattributes:
+Files committed to version control (i.e. not in .gitignore) can still be ignored when deploying.  To ignore these files or directories, simply add them to .gitattributes:
 
 ```bash
 config/deploy/deploy.rb   export-ignore


### PR DESCRIPTION
This PR fixes a tiny typo in a Markdown article.