### PR TITLE
Prevents last good release from being deleted on cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ gem "capistrano", :github => "capistrano/capistrano"
 [master]: https://github.com/capistrano/capistrano/compare/v3.9.1...HEAD
 
 * Your contribution here!
+* [#1922](https://github.com/capistrano/capistrano/pull/1922): Prevents last good release from being deleted during cleanup if there are too many subsequent failed deploys
 * As of this release, version 2.x of Capistrano is officially End of Life. No further releases of 2.x series are planned, and pull requests against 2.x are no longer accepted. The maintainers encourage you to upgrade to 3.x if possible.
-* Prevents last good release from being deleted during cleanup if there are too many subsequent failed deploys
 
 ## [`3.9.1`] (2017-09-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ gem "capistrano", :github => "capistrano/capistrano"
 
 * Your contribution here!
 * As of this release, version 2.x of Capistrano is officially End of Life. No further releases of 2.x series are planned, and pull requests against 2.x are no longer accepted. The maintainers encourage you to upgrade to 3.x if possible.
+* Prevents last good release from being deleted during cleanup if there are too many subsequent failed deploys
 
 ## [`3.9.1`] (2017-09-08)
 

--- a/features/deploy.feature
+++ b/features/deploy.feature
@@ -60,6 +60,16 @@ Feature: Deploy
     Then 3 valid releases are kept
     And the invalid "new" release is ignored
 
+  Scenario: Cleanup after many failed releases doesn't remove last good release
+    Given config stage file has line "set :keep_releases, 2"
+    And I make 2 deployments
+    And an invalid release named "77777777777777"
+    And an invalid release named "88888888888888"
+    And an invalid release named "99999999999999"
+    When I run cap "deploy:cleanup"
+    Then 3 valid releases are kept
+    And the current directory will be a symlink to the release
+
   Scenario: Rolling Back
     Given I make 2 deployments
     When I run cap "deploy:rollback"

--- a/features/step_definitions/assertions.rb
+++ b/features/step_definitions/assertions.rb
@@ -66,7 +66,7 @@ Then(/^directory symlinks are created in the new release$/) do
 end
 
 Then(/^the current directory will be a symlink to the release$/) do
-  run_vagrant_command(test_symlink_exists(TestApp.current_path))
+  run_vagrant_command(exists?("e", TestApp.current_path))
 end
 
 Then(/^the deploy\.rb file is created$/) do

--- a/lib/capistrano/i18n.rb
+++ b/lib/capistrano/i18n.rb
@@ -14,6 +14,8 @@ en = {
   question_default: "Please enter %{key} (%{default_value}): ",
   keeping_releases: "Keeping %{keep_releases} of %{releases} deployed releases on %{host}",
   skip_cleanup: "Skipping cleanup of invalid releases on %{host}; unexpected foldername found (should be timestamp)",
+  wont_delete_current_release: "Current release was marked for being removed but it's going to be skipped on %{host}",
+  no_current_release: "There is no current release present on %{host}",
   no_old_releases: "No old releases (keeping newest %{keep_releases}) on %{host}",
   linked_file_does_not_exist: "linked file %{file} does not exist on %{host}",
   cannot_rollback: "There are no older releases to rollback to",

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -158,13 +158,13 @@ namespace :deploy do
         directories = (valid - valid.last(fetch(:keep_releases))).map do |release|
           releases_path.join(release).to_s
         end
-        begin
+        if test("[ -d #{current_path} ]")
           current_release = capture(:readlink, current_path).to_s
           if directories.include?(current_release)
             warn t(:wont_delete_current_release, host: host.to_s)
             directories.delete(current_release)
           end
-        rescue SSHKit::Command::Failed
+        else
           debug t(:no_current_release, host: host.to_s)
         end
         if directories.any?

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -155,11 +155,20 @@ namespace :deploy do
 
       if valid.count >= fetch(:keep_releases)
         info t(:keeping_releases, host: host.to_s, keep_releases: fetch(:keep_releases), releases: valid.count)
-        directories = (valid - valid.last(fetch(:keep_releases)))
+        directories = (valid - valid.last(fetch(:keep_releases))).map do |release|
+          releases_path.join(release).to_s
+        end
+        begin
+          current_release = capture(:readlink, current_path).to_s
+          if directories.include?(current_release)
+            warn t(:wont_delete_current_release, host: host.to_s)
+            directories.delete(current_release)
+          end
+        rescue SSHKit::Command::Failed
+          debug t(:no_current_release, host: host.to_s)
+        end
         if directories.any?
-          directories_str = directories.map do |release|
-            releases_path.join(release)
-          end.join(" ")
+          directories_str = directories.join(" ")
           execute :rm, "-rf", directories_str
         else
           info t(:no_old_releases, host: host.to_s, keep_releases: fetch(:keep_releases))


### PR DESCRIPTION
### Summary

Issue: https://github.com/capistrano/capistrano/issues/1907

If there are many failed deployments the relese folders will
still be left there and eventually if deploy:cleanup is
executed it will delete the release that is referenced by the
"current" symlink, potentially causing downtime.

That change will prevent the "current release" from ever being
removed during cleanup.

### Short checklist

- [X] Did you run `bundle exec rubocop -a` to fix linter issues?
- [X] If relevant, did you create a test?
- [X] Did you confirm that the RSpec tests pass?
- [X] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?

### Other Information

As of now it will keep the current release IN ADDITION to the last X releases.
