### PR TITLE
Replace flatten with flat map

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -71,7 +71,7 @@ Pull requests are awesome, and if they arrive with decent tests, and conform to 
 
 Your code should conform to these guidelines:
 
- * The code is MIT licenced, your code will fall under the same license if we merge it.
+ * The code is MIT licensed, your code will fall under the same license if we merge it.
  * We can't merge it without a [good commit message](http://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message). If you do this right, Github will use the commit message as the body of your pull request, double win.
  * If you are making an improvement/fix for an existing issue, make sure to mention the issue number (if we have not yet merged it )
  * Add an entry to the `CHANGELOG` under the `### master` section, but please don't mess with the version.

--- a/lib/capistrano/configuration/host_filter.rb
+++ b/lib/capistrano/configuration/host_filter.rb
@@ -3,8 +3,7 @@ module Capistrano
     class HostFilter
       def initialize(values)
         av = Array(values).dup
-        av.map! { |v| v.is_a?(String) && v =~ /^(?<name>[-A-Za-z0-9.]+)(,\g<name>)*$/ ? v.split(",") : v }
-        av.flatten!
+        av = av.flat_map { |v| v.is_a?(String) && v =~ /^(?<name>[-A-Za-z1-9.]+)(,\g<name>)*$/ ? v.split(",") : v }
         @rex = regex_matcher(av)
       end
 

--- a/lib/capistrano/configuration/role_filter.rb
+++ b/lib/capistrano/configuration/role_filter.rb
@@ -3,8 +3,7 @@ module Capistrano
     class RoleFilter
       def initialize(values)
         av = Array(values).dup
-        av.map! { |v| v.is_a?(String) ? v.split(",") : v }
-        av.flatten!
+        av = av.flat_map { |v| v.is_a?(String) ? v.split(",") : v }
         @rex = regex_matcher(av)
       end
 

--- a/lib/capistrano/doctor/servers_doctor.rb
+++ b/lib/capistrano/doctor/servers_doctor.rb
@@ -56,7 +56,7 @@ module Capistrano
         private
 
         def find_whitespace_roles
-          servers.map(&:roles).map(&:to_a).flatten.uniq
+          servers.map(&:roles).flat_map(&:to_a).uniq
                  .select { |role| include_whitespace?(role) }
         end
       end

--- a/spec/lib/capistrano/configuration/host_filter_spec.rb
+++ b/spec/lib/capistrano/configuration/host_filter_spec.rb
@@ -41,6 +41,11 @@ module Capistrano
           it_behaves_like "it filters hosts correctly", %w{server1 server3}
         end
 
+        context "with mixed splittable and unsplittable strings" do
+          let(:values) { %w{server1 server2,server3} }
+          it_behaves_like "it filters hosts correctly", %w{server1 server2 server3}
+        end
+
         context "with a regexp" do
           let(:values) { "server[13]$" }
           it_behaves_like "it filters hosts correctly", %w{server1 server3}


### PR DESCRIPTION
As mentioned in [this Rails PR](https://github.com/rails/rails/pull/14240), `#flat_map` is faster than `#map` and then `#flatten`.

### Summary

(Guidelines for creating a bug report are available
here: https://github.com/capistrano/capistrano/blob/master/DEVELOPMENT.md)

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [ ] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?
- [ ] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file where indicated.

Thanks for helping improve Capistrano!
