### PR TITLE
Add commented out suggestion to default deploy.rb template. Fixes #1896

### DIFF
--- a/lib/capistrano/templates/deploy.rb.erb
+++ b/lib/capistrano/templates/deploy.rb.erb
@@ -34,3 +34,6 @@ set :repo_url, "git@example.com:me/my_repo.git"
 
 # Default value for keep_releases is 5
 # set :keep_releases, 5
+
+# Uncomment the following to require manually verifying the host key before first deploy.
+# set :ssh_options, verify_host_key: :secure


### PR DESCRIPTION
Fixes https://github.com/capistrano/capistrano/issues/1896 by adding a suggested default, commented out normally.