### PR TITLE
Make append(DSL) ignore value which inserted before

### DIFF
--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -37,7 +37,7 @@ module Capistrano
     end
 
     def append(key, *values)
-      set(key, Array(fetch(key)).concat(values))
+      set(key, Array(fetch(key)).concat(values).uniq)
     end
 
     def remove(key, *values)

--- a/spec/lib/capistrano/configuration_spec.rb
+++ b/spec/lib/capistrano/configuration_spec.rb
@@ -194,6 +194,15 @@ module Capistrano
             expect(subject).to eq ["string", "vendor/bundle"]
           end
         end
+
+        context "with duplicated value" do
+          before { config.set(:linked_dirs, "tmp") }
+          subject { config.append(:linked_dirs, "tmp") }
+
+          it "returns unique values" do
+            expect(subject).to eq ["tmp"]
+          end
+        end
       end
 
       context "removing" do


### PR DESCRIPTION
### Summary

I propose `append` dsl makes array to be unique.

This proposal makes below situations to be avoidable:

```
# in capistrano-puma gem
append :rbenv_map_bins, 'pumactl'

# deploy.rb
append :rbenv_map_bins, 'pumactl'
```

```
$HOME/.rbenv/bin/rbenv exec $HOME/.rbenv/bin/rbenv exec bundle exec bundle exec pumactl -S /home/deploy/application/shared/tmp/pids/puma.state -F ...
```

Please notice that command has duplicated `rbenv exec`.

I think these kind of problem don't occur frequently but hard to find. and also, until `append` introduced, there is gems used `set` accidently (I believe).
This problem may occur when a user tries to update gems which contains patch replacing `set` to `append`.

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?
- [ ] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?
  - I will do when this proposal confirmed. XD

Thanks to read this. Have a nice day :)