### PR TITLE
Clarify message when require is in wrong config file. Fixes #1905

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ gem "capistrano", :github => "capistrano/capistrano"
 
 * Your contribution here!
 * As of this release, version 2.x of Capistrano is officially End of Life. No further releases of 2.x series are planned, and pull requests against 2.x are no longer accepted. The maintainers encourage you to upgrade to 3.x if possible.
-* Clarify error message when plugin is required in the wrong config file.
+* [#1937](https://github.com/capistrano/capistrano/pull/1937): Clarify error message when plugin is required in the wrong config file.
 
 ## [`3.9.1`] (2017-09-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ gem "capistrano", :github => "capistrano/capistrano"
 
 * Your contribution here!
 * As of this release, version 2.x of Capistrano is officially End of Life. No further releases of 2.x series are planned, and pull requests against 2.x are no longer accepted. The maintainers encourage you to upgrade to 3.x if possible.
+* Clarify error message when plugin is required in the wrong config file.
 
 ## [`3.9.1`] (2017-09-08)
 

--- a/lib/capistrano/immutable_task.rb
+++ b/lib/capistrano/immutable_task.rb
@@ -17,8 +17,9 @@ module Capistrano
 
     def enhance(*args, &block)
       $stderr.puts <<-MESSAGE
-WARNING: #{name} has already been invoked and can no longer be modified.
-Check that you haven't loaded a Capistrano plugin in deploy.rb by mistake.
+ERROR: #{name} has already been invoked and can no longer be modified.
+Check that you haven't loaded a Capistrano plugin in deploy.rb or a stage
+(e.g. deploy/production.rb) by mistake.
 Plugins must be loaded in the Capfile to initialize properly.
 MESSAGE
 

--- a/spec/lib/capistrano/immutable_task_spec.rb
+++ b/spec/lib/capistrano/immutable_task_spec.rb
@@ -16,7 +16,7 @@ module Capistrano
       load_defaults.extend(Capistrano::ImmutableTask)
 
       $stderr.expects(:puts).with do |message|
-        message =~ /^WARNING: load:defaults has already been invoked/
+        message =~ /^ERROR: load:defaults has already been invoked/
       end
 
       expect do


### PR DESCRIPTION
Fixes issues in https://github.com/capistrano/capistrano/issues/1905.