### PR TITLE
Configurable releases and shared folder name (rebase of #1890)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ gem "capistrano", :github => "capistrano/capistrano"
 [master]: https://github.com/capistrano/capistrano/compare/v3.9.1...HEAD
 
 * Your contribution here!
+* [#1943](https://github.com/capistrano/capistrano/issues/1943): Make 'releases' and 'shared' directory names configurable from deployment target
 * [#1922](https://github.com/capistrano/capistrano/pull/1922): Prevents last good release from being deleted during cleanup if there are too many subsequent failed deploys
 * As of this release, version 2.x of Capistrano is officially End of Life. No further releases of 2.x series are planned, and pull requests against 2.x are no longer accepted. The maintainers encourage you to upgrade to 3.x if possible.
 * [#1937](https://github.com/capistrano/capistrano/pull/1937): Clarify error message when plugin is required in the wrong config file.
@@ -61,8 +62,6 @@ gem "capistrano", :github => "capistrano/capistrano"
 * None
 
 ### Other changes:
-
-* [#1889](https://github.com/capistrano/capistrano/issues/1889): Make 'releases' and 'shared' directory names configurable from deployment target
 
 * [#1882](https://github.com/capistrano/capistrano/pull/1882): Explain where to add new Capfile lines in scm deprecation warning - [@robd](https://github.com/robd)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ gem "capistrano", :github => "capistrano/capistrano"
 
 ### Other changes:
 
+* [#1889](https://github.com/capistrano/capistrano/issues/1889): Make 'releases' and 'shared' directory names configurable from deployment target
+
 * [#1882](https://github.com/capistrano/capistrano/pull/1882): Explain where to add new Capfile lines in scm deprecation warning - [@robd](https://github.com/robd)
 
 ## [`3.8.1`] (2017-04-21)

--- a/docs/documentation/getting-started/configuration/index.markdown
+++ b/docs/documentation/getting-started/configuration/index.markdown
@@ -138,6 +138,18 @@ The following variables are settable:
   * Other available options are :dot and :pretty.
   * The default formatter :airbrussh will print the output even when :log_level is :warn or :error, while :dot and :pretty will use the defined :log_level.
 
+* `:shared_directory`
+  * **default:**  `shared`
+  * Name for shared directory, containing files and directories symlinked into the release directory during deployment.
+
+* `:releases_directory`
+  * **default:** `releases`
+  * Name for releases directory, target location for releases.
+
+* `:current_directory`
+  * **default:** `current`
+  * Name for `current` link pointing to the newest successful deployment's release folder.
+
 
 Capistrano plugins can provide their own configuration variables. Please refer
 to the plugin documentation for the specifics. Plugins are allowed to add or

--- a/lib/capistrano/doctor/variables_doctor.rb
+++ b/lib/capistrano/doctor/variables_doctor.rb
@@ -5,9 +5,16 @@ module Capistrano
     # Prints a table of all Capistrano variables and their current values. If
     # there are unrecognized variables, print warnings for them.
     class VariablesDoctor
-      # These are keys that have no default values in Capistrano, but are
-      # nonetheless expected to be set.
-      WHITELIST = %i(application repo_url repo_tree).freeze
+      # These are keys that are recognized by Capistrano, but do not have values
+      # set by default.
+      WHITELIST = %i(
+        application
+        current_directory
+        releases_directory
+        repo_url
+        repo_tree
+        shared_directory
+      ).freeze
       private_constant :WHITELIST
 
       include Capistrano::Doctor::OutputHelpers

--- a/lib/capistrano/dsl/paths.rb
+++ b/lib/capistrano/dsl/paths.rb
@@ -15,7 +15,7 @@ module Capistrano
       end
 
       def releases_path
-        deploy_path.join("releases")
+        deploy_path.join(fetch(:releases_directory, "releases"))
       end
 
       def release_path
@@ -44,7 +44,7 @@ module Capistrano
       end
 
       def shared_path
-        deploy_path.join("shared")
+        deploy_path.join(fetch(:shared_directory, "shared"))
       end
 
       def revision_log

--- a/spec/lib/capistrano/dsl/paths_spec.rb
+++ b/spec/lib/capistrano/dsl/paths_spec.rb
@@ -129,7 +129,7 @@ describe Capistrano::DSL::Paths do
 
     context "with custom releases directory" do
       before do
-        paths.expects(:fetch).with(:releases_directory,"releases").returns("test123")
+        paths.expects(:fetch).with(:releases_directory, "releases").returns("test123")
         paths.expects(:fetch).with(:deploy_to).returns("/var/www")
       end
 
@@ -145,7 +145,7 @@ describe Capistrano::DSL::Paths do
 
     context "with custom shared directory" do
       before do
-        paths.expects(:fetch).with(:shared_directory,"shared").returns("test123")
+        paths.expects(:fetch).with(:shared_directory, "shared").returns("test123")
         paths.expects(:fetch).with(:deploy_to).returns("/var/www")
       end
 

--- a/spec/lib/capistrano/dsl/paths_spec.rb
+++ b/spec/lib/capistrano/dsl/paths_spec.rb
@@ -121,7 +121,6 @@ describe Capistrano::DSL::Paths do
         expect(subject.to_s).to eq "/var/www/releases/timestamp"
       end
     end
-
   end
 
   describe "#releases_path" do
@@ -137,7 +136,6 @@ describe Capistrano::DSL::Paths do
         expect(subject.to_s).to eq "/var/www/test123"
       end
     end
-
   end
 
   describe "#shared_path" do
@@ -153,7 +151,6 @@ describe Capistrano::DSL::Paths do
         expect(subject.to_s).to eq "/var/www/test123"
       end
     end
-
   end
 
   describe "#deploy_config_path" do

--- a/spec/lib/capistrano/dsl/paths_spec.rb
+++ b/spec/lib/capistrano/dsl/paths_spec.rb
@@ -21,9 +21,9 @@ describe Capistrano::DSL::Paths do
 
     it "returns the full pathnames" do
       expect(subject).to eq [
-                                Pathname.new("/var/shared/log"),
-                                Pathname.new("/var/shared/public/system")
-                            ]
+        Pathname.new("/var/shared/log"),
+        Pathname.new("/var/shared/public/system")
+      ]
     end
   end
 
@@ -36,10 +36,10 @@ describe Capistrano::DSL::Paths do
 
     it "returns the full pathnames" do
       expect(subject).to eq [
-                                Pathname.new("/var/shared/config/database.yml"),
-                                Pathname.new("/var/shared/log/my.log"),
-                                Pathname.new("/var/shared/log/access.log")
-                            ]
+        Pathname.new("/var/shared/config/database.yml"),
+        Pathname.new("/var/shared/log/my.log"),
+        Pathname.new("/var/shared/log/access.log")
+      ]
     end
   end
 
@@ -52,9 +52,9 @@ describe Capistrano::DSL::Paths do
 
     it "returns the full paths names of the parent dirs" do
       expect(subject).to eq [
-                                Pathname.new("/var/shared/config"),
-                                Pathname.new("/var/shared/log")
-                            ]
+        Pathname.new("/var/shared/config"),
+        Pathname.new("/var/shared/log")
+      ]
     end
   end
 
@@ -67,9 +67,9 @@ describe Capistrano::DSL::Paths do
 
     it "returns the full paths names of the parent dirs" do
       expect(subject).to eq [
-                                Pathname.new("/var/shared"),
-                                Pathname.new("/var/shared/public")
-                            ]
+        Pathname.new("/var/shared"),
+        Pathname.new("/var/shared/public")
+      ]
     end
   end
 

--- a/spec/lib/capistrano/dsl/paths_spec.rb
+++ b/spec/lib/capistrano/dsl/paths_spec.rb
@@ -21,9 +21,9 @@ describe Capistrano::DSL::Paths do
 
     it "returns the full pathnames" do
       expect(subject).to eq [
-        Pathname.new("/var/shared/log"),
-        Pathname.new("/var/shared/public/system")
-      ]
+                                Pathname.new("/var/shared/log"),
+                                Pathname.new("/var/shared/public/system")
+                            ]
     end
   end
 
@@ -36,10 +36,10 @@ describe Capistrano::DSL::Paths do
 
     it "returns the full pathnames" do
       expect(subject).to eq [
-        Pathname.new("/var/shared/config/database.yml"),
-        Pathname.new("/var/shared/log/my.log"),
-        Pathname.new("/var/shared/log/access.log")
-      ]
+                                Pathname.new("/var/shared/config/database.yml"),
+                                Pathname.new("/var/shared/log/my.log"),
+                                Pathname.new("/var/shared/log/access.log")
+                            ]
     end
   end
 
@@ -52,9 +52,9 @@ describe Capistrano::DSL::Paths do
 
     it "returns the full paths names of the parent dirs" do
       expect(subject).to eq [
-        Pathname.new("/var/shared/config"),
-        Pathname.new("/var/shared/log")
-      ]
+                                Pathname.new("/var/shared/config"),
+                                Pathname.new("/var/shared/log")
+                            ]
     end
   end
 
@@ -67,9 +67,9 @@ describe Capistrano::DSL::Paths do
 
     it "returns the full paths names of the parent dirs" do
       expect(subject).to eq [
-        Pathname.new("/var/shared"),
-        Pathname.new("/var/shared/public")
-      ]
+                                Pathname.new("/var/shared"),
+                                Pathname.new("/var/shared/public")
+                            ]
     end
   end
 
@@ -121,6 +121,39 @@ describe Capistrano::DSL::Paths do
         expect(subject.to_s).to eq "/var/www/releases/timestamp"
       end
     end
+
+  end
+
+  describe "#releases_path" do
+    subject { paths.releases_path }
+
+    context "with custom releases directory" do
+      before do
+        paths.expects(:fetch).with(:releases_directory,"releases").returns("test123")
+        paths.expects(:fetch).with(:deploy_to).returns("/var/www")
+      end
+
+      it "returns the releases path with the custom directory" do
+        expect(subject.to_s).to eq "/var/www/test123"
+      end
+    end
+
+  end
+
+  describe "#shared_path" do
+    subject { paths.shared_path }
+
+    context "with custom shared directory" do
+      before do
+        paths.expects(:fetch).with(:shared_directory,"shared").returns("test123")
+        paths.expects(:fetch).with(:deploy_to).returns("/var/www")
+      end
+
+      it "returns the shared path with the custom directory" do
+        expect(subject.to_s).to eq "/var/www/test123"
+      end
+    end
+
   end
 
   describe "#deploy_config_path" do


### PR DESCRIPTION
This is a rebase of #1890 by @ShoobyBan

> Making 'releases' and 'shared' directory names configurable from deployment target.