### PR TITLE
HostFilter: Fix regex for multi-host strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ gem "capistrano", :github => "capistrano/capistrano"
 
 * Your contribution here!
 
+### Fixes:
+
+* [#1954](https://github.com/capistrano/capistrano/pull/1954): Fix Host filtering when multi-host strings contain `0`
+
 ## [`3.10.0`] (2017-10-23)
 
 [`3.10.0`]: https://github.com/capistrano/capistrano/compare/v3.9.1...v3.10.0

--- a/lib/capistrano/configuration/host_filter.rb
+++ b/lib/capistrano/configuration/host_filter.rb
@@ -3,7 +3,7 @@ module Capistrano
     class HostFilter
       def initialize(values)
         av = Array(values).dup
-        av = av.flat_map { |v| v.is_a?(String) && v =~ /^(?<name>[-A-Za-z1-9.]+)(,\g<name>)*$/ ? v.split(",") : v }
+        av = av.flat_map { |v| v.is_a?(String) && v =~ /^(?<name>[-A-Za-z0-9.]+)(,\g<name>)*$/ ? v.split(",") : v }
         @rex = regex_matcher(av)
       end
 

--- a/spec/lib/capistrano/configuration/host_filter_spec.rb
+++ b/spec/lib/capistrano/configuration/host_filter_spec.rb
@@ -10,7 +10,7 @@ module Capistrano
          Server.new("server2"),
          Server.new("server3"),
          Server.new("server4"),
-         Server.new("server5")]
+         Server.new("server10")]
       end
 
       shared_examples "it filters hosts correctly" do |expected|
@@ -32,8 +32,8 @@ module Capistrano
         end
 
         context "with a comma separated string" do
-          let(:values) { "server1,server3" }
-          it_behaves_like "it filters hosts correctly", %w{server1 server3}
+          let(:values) { "server1,server10" }
+          it_behaves_like "it filters hosts correctly", %w{server1 server10}
         end
 
         context "with an array of strings" do
@@ -53,12 +53,12 @@ module Capistrano
 
         context "with a regexp with line boundaries" do
           let(:values) { "^server" }
-          it_behaves_like "it filters hosts correctly", %w{server1 server2 server3 server4 server5}
+          it_behaves_like "it filters hosts correctly", %w{server1 server2 server3 server4 server10}
         end
 
         context "with a regexp with a comma" do
           let(:values) { 'server\d{1,3}$' }
-          it_behaves_like "it filters hosts correctly", %w{server1 server2 server3 server4 server5}
+          it_behaves_like "it filters hosts correctly", %w{server1 server2 server3 server4 server10}
         end
 
         context "without number" do


### PR DESCRIPTION
https://github.com/capistrano/capistrano/pull/1928 introduced a
small bug in regex generation for multi-host strings, e.g.:

```
HOSTS=server1.com,server2.com bundle exec cap production deploy
```

This would be parsed and split correctly, however:

```
HOSTS=server9.com,server10.com bundle exec cap production deploy
```

would deploy to no hosts, because of the `0` in the hostname.

This commit fixes the regular expression used to split multi-host
strings, and updates the test suite to include `0` in the test
cases.

### Summary

(Guidelines for creating a bug report are available
here: https://github.com/capistrano/capistrano/blob/master/DEVELOPMENT.md)

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?
- [x] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file where indicated.

Thanks for helping improve Capistrano!

P.S. - Thanks to the whole capistrano team - this is an awesome tool that has been a pleasure to use for many years.  We really appreciate all the hard work that went into a great gem!