### PR TITLE
(#1058) Update git.rake - configurable max concurrent connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ gem "capistrano", :github => "capistrano/capistrano"
 
 [master]: https://github.com/capistrano/capistrano/compare/v3.10.1...HEAD
 
-* Your contribution here!
+### New features:
+
+* [#1058](https://github.com/capistrano/capistrano/pull/1058): Update git plugin rake tasks - configurable max concurrent connections and wait interval settings
 
 ## [`3.10.1`] (2017-12-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ gem "capistrano", :github => "capistrano/capistrano"
 
 [master]: https://github.com/capistrano/capistrano/compare/v3.10.1...HEAD
 
+* Your contribution here!
 ### New features:
 
 * [#1058](https://github.com/capistrano/capistrano/pull/1058): Update git plugin rake tasks - configurable max concurrent connections and wait interval settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ gem "capistrano", :github => "capistrano/capistrano"
 * Your contribution here!
 ### New features:
 
-* [#1058](https://github.com/capistrano/capistrano/pull/1058): Update git plugin rake tasks - configurable max concurrent connections and wait interval settings
+* [#1957](https://github.com/capistrano/capistrano/pull/1957): Update git plugin rake tasks - configurable max concurrent connections and wait interval settings
 
 ## [`3.10.1`] (2017-12-08)
 

--- a/lib/capistrano/scm/git.rb
+++ b/lib/capistrano/scm/git.rb
@@ -18,6 +18,8 @@ class Capistrano::SCM::Git < Capistrano::SCM::Plugin
         git_ssh: fetch(:git_wrapper_path)
       }
     }
+    set_if_empty :git_max_concurrent_connections, 10
+    set_if_empty :git_wait_interval, 3
   end
 
   def register_hooks

--- a/lib/capistrano/scm/tasks/git.rake
+++ b/lib/capistrano/scm/tasks/git.rake
@@ -4,7 +4,7 @@ git_plugin = self
 namespace :git do
   desc "Upload the git wrapper script, this script guarantees that we can script git without getting an interactive prompt"
   task :wrapper do
-    on release_roles :all do
+    on release_roles(:all), in: :groups, limit: fetch(:git_max_concurrent_connections), wait: fetch(:git_wait_interval) do
       execute :mkdir, "-p", File.dirname(fetch(:git_wrapper_path)).shellescape
       upload! StringIO.new("#!/bin/sh -e\nexec /usr/bin/ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no \"$@\"\n"), fetch(:git_wrapper_path)
       execute :chmod, "700", fetch(:git_wrapper_path).shellescape
@@ -14,7 +14,7 @@ namespace :git do
   desc "Check that the repository is reachable"
   task check: :'git:wrapper' do
     fetch(:branch)
-    on release_roles :all do
+    on release_roles(:all), in: :groups, limit: fetch(:git_max_concurrent_connections), wait: fetch(:git_wait_interval) do
       with fetch(:git_environmental_variables) do
         git_plugin.check_repo_is_reachable
       end
@@ -23,7 +23,7 @@ namespace :git do
 
   desc "Clone the repo to the cache"
   task clone: :'git:wrapper' do
-    on release_roles :all do
+    on release_roles(:all), in: :groups, limit: fetch(:git_max_concurrent_connections), wait: fetch(:git_wait_interval) do
       if git_plugin.repo_mirror_exists?
         info t(:mirror_exists, at: repo_path)
       else
@@ -38,7 +38,7 @@ namespace :git do
 
   desc "Update the repo mirror to reflect the origin state"
   task update: :'git:clone' do
-    on release_roles :all do
+    on release_roles(:all), in: :groups, limit: fetch(:git_max_concurrent_connections), wait: fetch(:git_wait_interval) do
       within repo_path do
         with fetch(:git_environmental_variables) do
           git_plugin.update_mirror
@@ -49,7 +49,7 @@ namespace :git do
 
   desc "Copy repo to releases"
   task create_release: :'git:update' do
-    on release_roles :all do
+    on release_roles(:all), in: :groups, limit: fetch(:git_max_concurrent_connections), wait: fetch(:git_wait_interval) do
       with fetch(:git_environmental_variables) do
         within repo_path do
           execute :mkdir, "-p", release_path
@@ -61,7 +61,7 @@ namespace :git do
 
   desc "Determine the revision that will be deployed"
   task :set_current_revision do
-    on release_roles :all do
+    on release_roles(:all), in: :groups, limit: fetch(:git_max_concurrent_connections), wait: fetch(:git_wait_interval) do
       within repo_path do
         with fetch(:git_environmental_variables) do
           set :current_revision, git_plugin.fetch_revision

--- a/spec/lib/capistrano/scm/git_spec.rb
+++ b/spec/lib/capistrano/scm/git_spec.rb
@@ -36,6 +36,20 @@ module Capistrano
         subject.set_defaults
         expect(env.fetch(:git_wrapper_path)).to eq("/tmp/git-ssh-my_app-staging-(Git Web User) via ShipIt.sh")
       end
+
+      it "makes git_max_concurrent_connections" do
+        subject.set_defaults
+        expect(env.fetch(:git_max_concurrent_connections)).to eq(10)
+        env.set(:git_max_concurrent_connections, 7)
+        expect(env.fetch(:git_max_concurrent_connections)).to eq(7)
+      end
+
+      it "makes git_wait_interval" do
+        subject.set_defaults
+        expect(env.fetch(:git_wait_interval)).to eq(3)
+        env.set(:git_wait_interval, 5)
+        expect(env.fetch(:git_wait_interval)).to eq(5)
+      end
     end
 
     describe "#git" do


### PR DESCRIPTION
Default git_max_concurrent_connections is set to 10 hosts per group.

Default git_wait_interval is set to 3 seconds.

This enables deployments for large number of servers with default Gitlab or similar git server configuration with default SSH settings (max 10 concurrent connections).
