### PR TITLE
use credentials.yml.enc instead of secrets.yml

### DIFF
--- a/lib/capistrano/templates/deploy.rb.erb
+++ b/lib/capistrano/templates/deploy.rb.erb
@@ -21,7 +21,7 @@ set :repo_url, "git@example.com:me/my_repo.git"
 # set :pty, true
 
 # Default value for :linked_files is []
-# append :linked_files, "config/database.yml", "config/secrets.yml"
+# append :linked_files, "config/database.yml", "config/credentials.yml.enc"
 
 # Default value for linked_dirs is []
 # append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"


### PR DESCRIPTION
### Summary
secrets.yml*  will be deprecated and instead adopt config/credentials.yml.enc in Rails5.2.
https://github.com/rails/rails/pull/30067

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [ ] If relevant, did you create a test?
- [ ] Did you confirm that the RSpec tests pass?
- [ ] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?
  