### PR TITLE
Recommend `require: false` in Gemfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file, in reverse 
 **Capistrano uses a six-week release cadence.** Every six weeks, give or take, any changes in master will be published as a new rubygems version. If you'd like to use a feature or fix that is in master and you can't wait for the next planned release, put this in your project's Gemfile to use the master branch directly:
 
 ```ruby
-gem "capistrano", :github => "capistrano/capistrano"
+gem "capistrano", github: "capistrano/capistrano", require: false
 ```
 
 ## [master]

--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ Capistrano 3 expects a POSIX shell like Bash or Sh. Shells like tcsh, csh, and s
 
 ### Install the Capistrano gem
 
-Add Capistrano to your project's Gemfile:
+Add Capistrano to your project's Gemfile using `require: false`:
 
 ``` ruby
 group :development do
-  gem "capistrano", "~> 3.10"
+  gem "capistrano", "~> 3.10", require: false
 end
 ```
 

--- a/docs/documentation/getting-started/installation/index.markdown
+++ b/docs/documentation/getting-started/installation/index.markdown
@@ -36,7 +36,8 @@ Add the following lines to the Gemfile:
 
 ```ruby
 group :development do
-  gem 'capistrano-rails', '~> 1.1'
+  gem "capistrano", "~> 3.10", require: false
+  gem "capistrano-rails", "~> 1.3", require: false
 end
 ```
 


### PR DESCRIPTION
Capistrano gems shouldn't be loaded within a Rails (or any) app. They are intended to be used by the cap command, not within Rails itself. At best, `require: true` (the default) is unnecessary; at worst, it can cause conflicts as encountered here:

https://stackoverflow.com/q/48493332/4625365

Update our docs to recommend `require: false` just to be safe.

Fixes #1963