### PR TITLE
feat: fallback ask to default when used in non interactive session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ gem "capistrano", github: "capistrano/capistrano", require: false
 [master]: https://github.com/capistrano/capistrano/compare/v3.10.1...HEAD
 
 * Your contribution here!
+* [#1972](https://github.com/capistrano/capistrano/pull/1972): fallback ask to default when used in non interactive session
 
 ## [`3.10.1`] (2017-12-08)
 

--- a/lib/capistrano/configuration/question.rb
+++ b/lib/capistrano/configuration/question.rb
@@ -36,6 +36,8 @@ module Capistrano
       end
 
       def gets
+        return unless $stdin.tty?
+
         if echo?
           $stdin.gets
         else

--- a/spec/lib/capistrano/configuration/question_spec.rb
+++ b/spec/lib/capistrano/configuration/question_spec.rb
@@ -57,6 +57,17 @@ module Capistrano
             expect(question.call).to eq(branch)
           end
         end
+
+        context "tty unavailable" do
+          before do
+            $stdin.expects(:gets).never
+            $stdin.expects(:tty?).returns(false)
+          end
+
+          it "returns the default as the value" do
+            expect(question.call).to eq(default)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Summary

Maybe related/fixing: #1463

The intention of this code change is to fallback to the default value of `ask` when used in a non interactive session. 

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?
- [x] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?
