### PR TITLE
Fix intermittent test failure due to any? DSL

### DIFF
--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -47,10 +47,14 @@ module Capistrano
     def any?(key)
       value = fetch(key)
       if value && value.respond_to?(:any?)
-        value.any?
-      else
-        !fetch(key).nil?
+        begin
+          return value.any?
+        rescue ArgumentError # rubocop:disable Lint/HandleExceptions
+          # Gracefully ignore values whose `any?` method doesn't accept 0 args
+        end
       end
+
+      !value.nil?
     end
 
     def is_question?(key)


### PR DESCRIPTION
Capistrano's `any?` DSL method, as a convenience, will delegate a zero-
arity call to `any?` for the object stored in the variable that is being
interrogated. For example, `any?(:ssh_options)` will first fetch the
value of the variable `:ssh_options`, and then call `any?` on it with
zero arguments.

The bug stems from the fact that we were not checking the arity of
`any?` before calling it. So if the object being interrogated has an
`any?` method that requires an argument, the method invocation will fail
with an `ArgumentError`.

For whatever reason, under certain circumstances related to test order,
the stub object provided by Rspec would sometimes have an `any?` method
on it (inherited from `Capistrano::DSL`) that required an argument.
Hence we would occasionally see test failures.

~~This commit fixes the bug by checking the arity of `any?` before calling
it.~~

There isn't a reliable way to check the arity of `any?` (it is `-1` for
forwarded or native methods), so the fix is to simply rescue the
`ArgumentError` and fallback to non-`any?` behavior.

Fixes #1974

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] Did you confirm that the RSpec tests pass?