### PR TITLE
Select appropriate SSHKit Backend. Fixes [#1822]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ gem "capistrano", github: "capistrano/capistrano", require: false
 
 * Your contribution here!
 
+### Fixes:
+
+* [#1822] Select appropriate SSHKit Backend inside run_locally to avoid dry-run to execute code.
+
 ## [`3.10.1`] (2017-12-08)
 
 [`3.10.1`]: https://github.com/capistrano/capistrano/compare/v3.10.0...v3.10.1

--- a/lib/capistrano/dsl.rb
+++ b/lib/capistrano/dsl.rb
@@ -73,7 +73,7 @@ module Capistrano
     # rubocop:enable Security/MarshalLoad
 
     def run_locally(&block)
-      SSHKit::Backend::Local.new(&block).run
+      fetch(:sshkit_backend, SSHKit::Backend::Local).new(SSHKit::Host.new(:local), &block).run
     end
 
     # Catch common beginner mistake and give a helpful error message on stderr


### PR DESCRIPTION
- run_locally ignores the --dry-run flag and runs anyway because the current sshkit backend is ignored.

Signed-off-by: Andres Garcia <andresgarcia@gmail.com>
