### PR TITLE
There should not be an instance where a git revision should be appended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ gem "capistrano", github: "capistrano/capistrano", require: false
 [master]: https://github.com/capistrano/capistrano/compare/v3.10.1...HEAD
 
 * Your contribution here!
+* [#1977](https://github.com/capistrano/capistrano/pull/1977): Remove append operator when writing the git file - [@mmiller1](https://github.com/mmiller1)
 
 ## [`3.10.1`] (2017-12-08)
 

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -238,7 +238,7 @@ namespace :deploy do
   task :set_current_revision  do
     on release_roles(:all) do
       within release_path do
-        execute :echo, "\"#{fetch(:current_revision)}\" >> REVISION"
+        execute :echo, "\"#{fetch(:current_revision)}\" > REVISION"
       end
     end
   end


### PR DESCRIPTION
I ran into a situation where overriding the capistrano deployment version was necessary due to external dependencies. In this situation, it is possible that multiple deployments (after a failed/cancelled deployment) can append git revisions, making this file unable to be parsed. I'm aware this is a very small edge case, but cannot imagine a scenario where the append operator should be used.