### PR TITLE
Simplify code on removing old directories by skipping `Array#join`

### DIFF
--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -168,8 +168,7 @@ namespace :deploy do
           debug t(:no_current_release, host: host.to_s)
         end
         if directories.any?
-          directories_str = directories.join(" ")
-          execute :rm, "-rf", directories_str
+          execute :rm, "-rf", *directories
         else
           info t(:no_old_releases, host: host.to_s, keep_releases: fetch(:keep_releases))
         end


### PR DESCRIPTION
### Summary

`execute(*)` provided by SSHKit internally joins arguments with space
for the command to be executed.

https://github.com/capistrano/sshkit/blob/e627f722881ba3178afaf3efc17449feff512928/lib/sshkit/command.rb#L214-L220

As it is the responsibility of SSHKit, we can skip the code at Capistrano layer.

I think the following existent test is enough to validate this change.
https://github.com/capistrano/capistrano/blob/220db8fabab15b9d5cd5c9ab1f2744e0aa346eb0/features/deploy.feature#L55-L61

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [ ] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?
- [ ] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?

### Other Information

