### PR TITLE
Silence console output during the tests

### DIFF
--- a/spec/lib/capistrano/configuration/plugin_installer_spec.rb
+++ b/spec/lib/capistrano/configuration/plugin_installer_spec.rb
@@ -49,7 +49,7 @@ module Capistrano
           expect(task.prerequisites).to eq([:example_prerequisite])
         end
 
-        it "sets defaults when load:defaults is invoked" do
+        it "sets defaults when load:defaults is invoked", capture_io: true do
           expect(fetch(:example_variable)).to be_nil
           invoke "load:defaults"
           expect(fetch(:example_variable)).to eq("foo")

--- a/spec/lib/capistrano/configuration/question_spec.rb
+++ b/spec/lib/capistrano/configuration/question_spec.rb
@@ -58,7 +58,7 @@ module Capistrano
           end
         end
 
-        context "tty unavailable" do
+        context "tty unavailable", capture_io: true do
           before do
             $stdin.expects(:gets).never
             $stdin.expects(:tty?).returns(false)

--- a/spec/lib/capistrano/configuration/scm_resolver_spec.rb
+++ b/spec/lib/capistrano/configuration/scm_resolver_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "capistrano/scm"
 
 module Capistrano
   class Configuration
@@ -24,12 +25,12 @@ module Capistrano
           expect { resolver.resolve }.to output(/will not load the git scm/i).to_stderr
         end
 
-        it "activates the git scm" do
+        it "activates the git scm", capture_io: true do
           resolver.resolve
           expect(Rake::Task["git:wrapper"]).not_to be_nil
         end
 
-        it "sets :scm to :git" do
+        it "sets :scm to :git", capture_io: true do
           resolver.resolve
           expect(fetch(:scm)).to eq(:git)
         end

--- a/spec/lib/capistrano/doctor/environment_doctor_spec.rb
+++ b/spec/lib/capistrano/doctor/environment_doctor_spec.rb
@@ -29,7 +29,7 @@ module Capistrano
           Rake::Task.clear
         end
 
-        it "has an doctor:environment task that calls EnvironmentDoctor" do
+        it "has an doctor:environment task that calls EnvironmentDoctor", capture_io: true do
           EnvironmentDoctor.any_instance.expects(:call)
           Rake::Task["doctor:environment"].invoke
         end

--- a/spec/lib/capistrano/doctor/gems_doctor_spec.rb
+++ b/spec/lib/capistrano/doctor/gems_doctor_spec.rb
@@ -53,7 +53,7 @@ module Capistrano
           Rake::Task.clear
         end
 
-        it "has an doctor:gems task that calls GemsDoctor" do
+        it "has an doctor:gems task that calls GemsDoctor", capture_io: true do
           GemsDoctor.any_instance.expects(:call)
           Rake::Task["doctor:gems"].invoke
         end

--- a/spec/lib/capistrano/doctor/servers_doctor_spec.rb
+++ b/spec/lib/capistrano/doctor/servers_doctor_spec.rb
@@ -71,7 +71,7 @@ module Capistrano
           Rake::Task.clear
         end
 
-        it "has an doctor:servers task that calls ServersDoctor" do
+        it "has an doctor:servers task that calls ServersDoctor", capture_io: true do
           ServersDoctor.any_instance.expects(:call)
           Rake::Task["doctor:servers"].invoke
         end

--- a/spec/lib/capistrano/doctor/variables_doctor_spec.rb
+++ b/spec/lib/capistrano/doctor/variables_doctor_spec.rb
@@ -74,7 +74,7 @@ module Capistrano
           Rake::Task.clear
         end
 
-        it "has an doctor:variables task that calls VariablesDoctor" do
+        it "has an doctor:variables task that calls VariablesDoctor", capture_io: true do
           VariablesDoctor.any_instance.expects(:call)
           Rake::Task["doctor:variables"].invoke
         end

--- a/spec/lib/capistrano/dsl/task_enhancements_spec.rb
+++ b/spec/lib/capistrano/dsl/task_enhancements_spec.rb
@@ -35,7 +35,7 @@ module Capistrano
         end
       end
 
-      it "invokes in proper order if define after than before" do
+      it "invokes in proper order if define after than before", capture_io: true do
         task_enhancements.after("task", "after_task")
         task_enhancements.before("task", "before_task")
 
@@ -44,7 +44,7 @@ module Capistrano
         expect(order).to eq(%w(before_task task after_task))
       end
 
-      it "invokes in proper order if define before than after" do
+      it "invokes in proper order if define before than after", capture_io: true do
         task_enhancements.before("task", "before_task")
         task_enhancements.after("task", "after_task")
 
@@ -53,7 +53,7 @@ module Capistrano
         expect(order).to eq(%w(before_task task after_task))
       end
 
-      it "invokes in proper order when referring to as-yet undefined tasks" do
+      it "invokes in proper order when referring to as-yet undefined tasks", capture_io: true do
         task_enhancements.after("task", "not_loaded_task")
 
         Rake::Task.define_task("not_loaded_task") do
@@ -65,7 +65,7 @@ module Capistrano
         expect(order).to eq(%w(task not_loaded_task))
       end
 
-      it "invokes in proper order and with arguments and block" do
+      it "invokes in proper order and with arguments and block", capture_io: true do
         task_enhancements.after("task", "after_task_custom", :order) do |_t, _args|
           order.push "after_task"
         end
@@ -79,7 +79,7 @@ module Capistrano
         expect(order).to eq(%w(before_task task after_task))
       end
 
-      it "invokes using the correct namespace when defined within a namespace" do
+      it "invokes using the correct namespace when defined within a namespace", capture_io: true do
         Rake.application.in_namespace("namespace") do
           Rake::Task.define_task("task") do |t|
             order.push(t.name)
@@ -99,7 +99,7 @@ module Capistrano
         )
       end
 
-      it "raises a sensible error if the task isn't found" do
+      it "raises a sensible error if the task isn't found", capture_io: true do
         task_enhancements.after("task", "non_existent_task")
         expect { Rake::Task["task"].invoke order }.to raise_error(ArgumentError, 'Task "non_existent_task" not found')
       end

--- a/spec/lib/capistrano/dsl_spec.rb
+++ b/spec/lib/capistrano/dsl_spec.rb
@@ -60,7 +60,7 @@ module Capistrano
           end
         end
 
-        it "prints helpful message to stderr" do
+        it "prints helpful message to stderr", capture_io: true do
           expect do
             expect do
               task.invoke
@@ -72,7 +72,7 @@ module Capistrano
 
     describe "#invoke" do
       context "reinvoking" do
-        it "will not reenable invoking task" do
+        it "will not reenable invoking task", capture_io: true do
           counter = 0
 
           Rake::Task.define_task("A") do
@@ -85,7 +85,7 @@ module Capistrano
           end.to change { counter }.by(1)
         end
 
-        it "will print a message on stderr" do
+        it "will print a message on stderr", capture_io: true do
           Rake::Task.define_task("B")
 
           expect do
@@ -98,7 +98,7 @@ module Capistrano
 
     describe "#invoke!" do
       context "reinvoking" do
-        it "will reenable invoking task" do
+        it "will reenable invoking task", capture_io: true do
           counter = 0
 
           Rake::Task.define_task("C") do
@@ -111,7 +111,7 @@ module Capistrano
           end.to change { counter }.by(2)
         end
 
-        it "will not print a message on stderr" do
+        it "will not print a message on stderr", capture_io: true do
           Rake::Task.define_task("D")
 
           expect do

--- a/spec/lib/capistrano/plugin_spec.rb
+++ b/spec/lib/capistrano/plugin_spec.rb
@@ -62,14 +62,14 @@ module Capistrano
       dummy.expects(:set_defaults).never
     end
 
-    it "calls set_defaults during load:defaults" do
+    it "calls set_defaults during load:defaults", capture_io: true do
       dummy = DummyPlugin.new
       dummy.expects(:set_defaults).once
       install_plugin(dummy)
       Rake::Task["load:defaults"].invoke
     end
 
-    it "is able to load tasks from a .rake file" do
+    it "is able to load tasks from a .rake file", capture_io: true do
       install_plugin(ExternalTasksPlugin)
       Rake::Task["plugin_test"].invoke
       expect(fetch(:plugin_result)).to eq("hello")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,4 +13,17 @@ RSpec.configure do |config|
   config.raise_errors_for_deprecations!
   config.mock_framework = :mocha
   config.order = "random"
+
+  config.around(:example, capture_io: true) do |example|
+    begin
+      Rake.application.options.trace_output = StringIO.new
+      $stdout = StringIO.new
+      $stderr = StringIO.new
+      example.run
+    ensure
+      Rake.application.options.trace_output = STDERR
+      $stdout = STDOUT
+      $stderr = STDERR
+    end
+  end
 end


### PR DESCRIPTION
Adding Rspec config callback that temporary assigns fake io objects to collect and silence all output of the SUT and Rake.

### Short checklist

- [✔️] Did you run `bundle exec rubocop -a` to fix linter issues?
- [✔️] If relevant, did you create a test?
- [✔️] Did you confirm that the RSpec tests pass?
- [] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?

### Other Information

Currently, the test run output is really messy, but the guidelines generally suggest to keep it as concise as possible for the successful runs. 
Since capistrano does not feature a configurable logger facility and simply sends everything to `$stderr`, I propose to intercept all tty output from subjects under test by StringIO instead of sending it to the terminal.
After:
```
Randomized with seed 17975
..................................................................................................................................................................*...*...................................................................................................................................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Capistrano::Application provides a --format option which enables the choice of output formatting
     # Not yet implemented
     # ./spec/lib/capistrano/application_spec.rb:6

  2) Capistrano::Application provides a --trace option which enables SSHKit/NetSSH trace output
     # Not yet implemented
     # ./spec/lib/capistrano/application_spec.rb:4

Finished in 0.96937 seconds (files took 0.67015 seconds to load)
394 examples, 0 failures, 2 pending
```

Before(please note, all the warnings are expected): 
```
Randomized with seed 9553
.....................................................................................** Invoke plugin_test (first_time)
** Execute plugin_test
.....** Invoke load:defaults (first_time)
** Execute load:defaults
......................................................................** Invoke doctor:variables (first_time)
** Execute doctor:variables
...........** Invoke task (first_time)
** Execute task
.** Invoke namespace:task (first_time)
** Invoke namespace:before_task (first_time)
** Execute namespace:before_task
** Execute namespace:task
** Invoke namespace:after_task (first_time)
** Execute namespace:after_task
.** Invoke task (first_time)
** Invoke before_task (first_time)
** Execute before_task
** Execute task
** Invoke after_task (first_time)
** Execute after_task
.** Invoke task (first_time)
** Invoke before_task (first_time)
** Execute before_task
** Execute task
** Invoke after_task (first_time)
** Execute after_task
.** Invoke task (first_time)
** Invoke before_task_custom (first_time)
** Execute before_task_custom
** Execute task
** Invoke after_task_custom (first_time)
** Execute after_task_custom
.** Invoke task (first_time)
** Execute task
** Invoke not_loaded_task (first_time)
** Execute not_loaded_task
.....** Invoke doctor:environment (first_time)
** Execute doctor:environment
...........................................................[Deprecation Notice] Future versions of Capistrano will not load the Git SCM
plugin by default. To silence this deprecation warning, add the following to
your Capfile after `require "capistrano/deploy"`:

    require "capistrano/scm/git"
    install_plugin Capistrano::SCM::Git

..[Deprecation Notice] Future versions of Capistrano will not load the Git SCM
plugin by default. To silence this deprecation warning, add the following to
your Capfile after `require "capistrano/deploy"`:

    require "capistrano/scm/git"
    install_plugin Capistrano::SCM::Git

..................** Invoke doctor:gems (first_time)
** Execute doctor:gems
............** Invoke doctor:servers (first_time)
** Execute doctor:servers
...........Skipping task `A'.
Capistrano tasks may only be invoked once. Since task `A' was previously invoked, invoke("A") at /Users/nikolay/development/capistrano/spec/lib/capistrano/dsl_spec.rb:84 will be skipped.
If you really meant to run this task again, use invoke!("A")
THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF CAPISTRANO. Please join the conversation here if this affects you.
https://github.com/capistrano/capistrano/issues/1686
......*....*....Please enter branch (default): ...............................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Capistrano::Application provides a --trace option which enables SSHKit/NetSSH trace output
     # Not yet implemented
     # ./spec/lib/capistrano/application_spec.rb:4

  2) Capistrano::Application provides a --format option which enables the choice of output formatting
     # Not yet implemented
     # ./spec/lib/capistrano/application_spec.rb:6

Finished in 0.62209 seconds (files took 0.40613 seconds to load)
394 examples, 0 failures, 2 pending
```

