### PR TITLE
[Doc] Add Capistrano::LazyCleanup to 3rd Party Plugin

### DIFF
--- a/docs/documentation/third-party-plugins/index.markdown
+++ b/docs/documentation/third-party-plugins/index.markdown
@@ -52,3 +52,6 @@ You can help us expanding this list by sending us a pull request on
 <div class="github-widget" data-repo="dkdeploy/dkdeploy-php"></div>
 
 <div class="github-widget" data-repo="dkdeploy/dkdeploy-typo3-cms"></div>
+
+<div class="github-widget" data-repo="aeroastro/capistrano-lazy_cleanup"></div>
+


### PR DESCRIPTION
### Summary

I would like to add `Capistrano::LazyCleanup` to 3rd Party Plugin.
https://github.com/aeroastro/capistrano-lazy_cleanup

This gem makes deployment much faster by offloading heavy I/O
during `deploy:cleanup` and `deploy:cleanup_rollback`.
It replaces `rm -rf` with `mktemp` and `mv`.

https://github.com/aeroastro/capistrano-lazy_cleanup/blob/18df6ec21f3aa9538754714d3253ca8b4ad449f8/README.md#what-exactly-does-the-offloading-mean

In my environment, this gem reduces `deploy:cleanup` time from several minutes to
less than 1 second.