### PR TITLE
Update docs to reflect true default for :local_user

### DIFF
--- a/docs/documentation/getting-started/configuration/index.markdown
+++ b/docs/documentation/getting-started/configuration/index.markdown
@@ -120,7 +120,7 @@ The following variables are settable:
   * If you have a shared web host, this setting may need to be set (e.g. /home/user/tmp/capistrano).
 
 * `:local_user`
-  * **default:** `-> { Etc.getlogin }`
+  * **default:** `-> { ENV["USER"] || ENV["LOGNAME"] || ENV["USERNAME"] }`
   * Username of the local machine used to update the revision log.
 
 * `:pty`


### PR DESCRIPTION
A change was made to the default for :local_user in

https://github.com/capistrano/capistrano/commit/d947b25aa2f788a9cf083ab3d8c2e92675507740

The docs weren't updated to reflect the new reality. They are now.
