### PR TITLE
Remove dead link from the sidebar.

### DIFF
--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -68,7 +68,6 @@
   <li><a href="/documentation/faq/how-can-i-check-for-existing-remote-file/">How can I check for existing remote file?</a></li>
   <li><a href="/documentation/faq/how-can-i-get-capistrano-to-prompt-for-a-password/">How can I get Capistrano to prompt for a password?</a></li>
   <li><a href="/documentation/faq/how-can-i-set-capistrano-configuration-paths/">How can I set Capistrano configuration paths?</a></li>
-  <li><a href="http://lee.hambley.name/2013/06/11/using-capistrano-v3-with-chef.html">Should I use Capistrano to provision my servers?</a></li>
   <li class="divider"></li>
 
   <h5>Legacy</h5>


### PR DESCRIPTION
Site is gone and the content seems lost. If someone has a mirror, that
could be re-added.

### Summary

Small fix for the documentation. In which a navigation-item that leads to a dead link, is removed.

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?
- [x] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?