### PR TITLE
Fix ruby 2.0 travis failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-  - 2.5.1
-  - 2.4.4
-  - 2.3.7
+  - 2.6.0
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
   - 2.2
   - 2.1
   - 2.0
@@ -15,8 +16,8 @@ matrix:
   include:
     - rvm: rbx-2
       script: bundle exec rake spec
-    # Run Danger only once, on 2.3.1
-    - rvm: 2.3.1
+    # Run Danger only once, on 2.5.3
+    - rvm: 2.5.3
       before_script: bundle exec danger
 
 script: bundle exec rake spec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -25,3 +25,8 @@ end
 if Gem::Requirement.new("< 2.1").satisfied_by?(Gem::Version.new(RUBY_VERSION))
   gem "public_suffix", "< 3.0.0"
 end
+
+# Latest versions of i18n don't support Ruby < 2.1
+if Gem::Requirement.new("< 2.1").satisfied_by?(Gem::Version.new(RUBY_VERSION))
+  gem "i18n", "< 1.3.0"
+end


### PR DESCRIPTION
Ruby 2.0 was failing on Travis because a new version of the i18n gem was released that is not compatible with Ruby 2.0. Pin to an older version of i18n when building against Ruby 2.0 as a workaround.

Also add latest Ruby versions to Travis matrix.