### PR TITLE
Fix #1979  by passing pattern to `split` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ gem "capistrano", github: "capistrano/capistrano", require: false
 
 [master]: https://github.com/capistrano/capistrano/compare/v3.11.0...HEAD
 
+* [#1979](https://github.com/capistrano/capistrano/issues/1979): Fixed issue where deploy:cleanup would be skipped when too many existing releases
+
 * Your contribution here!
 
 ## [`3.11.0`] (2018-06-02)

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -148,7 +148,7 @@ namespace :deploy do
   desc "Clean up old releases"
   task :cleanup do
     on release_roles :all do |host|
-      releases = capture(:ls, "-x", releases_path).split
+      releases = capture(:ls, "-x", releases_path).split(" ")
       valid, invalid = releases.partition { |e| /^\d{14}$/ =~ e }
 
       warn t(:skip_cleanup, host: host.to_s) if invalid.any?


### PR DESCRIPTION
Fixes issue #1979 where `deploy:cleanup` would be completely skipped if there were too many existing releases. This was due to the `split` method not working correctly when the string being split contained both `\n` and `\t` characters. This change passes a pattern to the `split` method
