### PR TITLE
CI: Use 2.4.6, 2.5.5, 2.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.6.0
-  - 2.5.3
-  - 2.4.5
+  - 2.6.3
+  - 2.5.5
+  - 2.4.6
   - 2.3.8
   - 2.2
   - 2.1
@@ -17,7 +17,7 @@ matrix:
     - rvm: rbx-2
       script: bundle exec rake spec
     # Run Danger only once, on 2.5.3
-    - rvm: 2.5.3
+    - rvm: 2.5.5
       before_script: bundle exec danger
 
 script: bundle exec rake spec rubocop
@@ -26,4 +26,3 @@ cache: bundler
 branches:
   except:
     - legacy-v2
-sudo: false


### PR DESCRIPTION
### Summary

This PR **updates the CI matrix** to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known

Also: 

  - drop defunct Travis option `sudo: false` - see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

