### PR TITLE
shell-escape supplied Subversion credentials

### DIFF
--- a/lib/capistrano/scm/svn.rb
+++ b/lib/capistrano/scm/svn.rb
@@ -1,4 +1,5 @@
 require "capistrano/scm/plugin"
+require "shellwords"
 
 class Capistrano::SCM::Svn < Capistrano::SCM::Plugin
   def register_hooks
@@ -13,9 +14,9 @@ class Capistrano::SCM::Svn < Capistrano::SCM::Plugin
 
   def svn(*args)
     args.unshift(:svn)
-    args.push "--username #{fetch(:svn_username)}" if fetch(:svn_username)
-    args.push "--password #{fetch(:svn_password)}" if fetch(:svn_password)
-    args.push "--revision #{fetch(:svn_revision)}" if fetch(:svn_revision)
+    args.push "--username #{Shellwords.escape(fetch(:svn_username))}" if fetch(:svn_username)
+    args.push "--password #{Shellwords.escape(fetch(:svn_password))}" if fetch(:svn_password)
+    args.push "--revision #{Shellwords.escape(fetch(:svn_revision))}" if fetch(:svn_revision)
     backend.execute(*args)
   end
 
@@ -24,8 +25,8 @@ class Capistrano::SCM::Svn < Capistrano::SCM::Plugin
   end
 
   def check_repo_is_reachable
-    svn_username = fetch(:svn_username) ? "--username #{fetch(:svn_username)}" : ""
-    svn_password = fetch(:svn_password) ? "--password #{fetch(:svn_password)}" : ""
+    svn_username = fetch(:svn_username) ? "--username #{Shellwords.escape(fetch(:svn_username))}" : ""
+    svn_password = fetch(:svn_password) ? "--password #{Shellwords.escape(fetch(:svn_password))}" : ""
     backend.test :svn, :info, repo_url, svn_username, svn_password
   end
 

--- a/spec/lib/capistrano/scm/svn_spec.rb
+++ b/spec/lib/capistrano/scm/svn_spec.rb
@@ -30,8 +30,8 @@ module Capistrano
     describe "#svn" do
       it "should call execute svn in the context, with arguments" do
         env.set(:svn_username, "someuser")
-        env.set(:svn_password, "somepassword")
-        backend.expects(:execute).with(:svn, :init, "--username someuser", "--password somepassword")
+        env.set(:svn_password, "some password")
+        backend.expects(:execute).with(:svn, :init, "--username someuser", "--password some\\ password")
         subject.svn(:init)
       end
     end
@@ -49,8 +49,8 @@ module Capistrano
       it "should test the repo url" do
         env.set(:repo_url, :url)
         env.set(:svn_username, "someuser")
-        env.set(:svn_password, "somepassword")
-        backend.expects(:test).with(:svn, :info, :url, "--username someuser", "--password somepassword").returns(true)
+        env.set(:svn_password, "some password")
+        backend.expects(:test).with(:svn, :info, :url, "--username someuser", "--password some\\ password").returns(true)
 
         subject.check_repo_is_reachable
       end
@@ -61,9 +61,9 @@ module Capistrano
         env.set(:repo_url, :url)
         env.set(:repo_path, "path")
         env.set(:svn_username, "someuser")
-        env.set(:svn_password, "somepassword")
+        env.set(:svn_password, "some password")
 
-        backend.expects(:execute).with(:svn, :checkout, :url, "path", "--username someuser", "--password somepassword")
+        backend.expects(:execute).with(:svn, :checkout, :url, "path", "--username someuser", "--password some\\ password")
 
         subject.clone_repo
       end
@@ -76,8 +76,8 @@ module Capistrano
         backend.expects(:capture).with(:svn, :info, "path").returns("URL: url\n")
 
         env.set(:svn_username, "someuser")
-        env.set(:svn_password, "somepassword")
-        backend.expects(:execute).with(:svn, :update, "--username someuser", "--password somepassword")
+        env.set(:svn_password, "some password")
+        backend.expects(:execute).with(:svn, :update, "--username someuser", "--password some\\ password")
 
         subject.update_mirror
       end
@@ -89,9 +89,9 @@ module Capistrano
           backend.expects(:capture).with(:svn, :info, "path").returns("URL: url\n")
 
           env.set(:svn_username, "someuser")
-          env.set(:svn_password, "somepassword")
+          env.set(:svn_password, "some password")
           env.set(:svn_revision, "12345")
-          backend.expects(:execute).with(:svn, :update, "--username someuser", "--password somepassword", "--revision 12345")
+          backend.expects(:execute).with(:svn, :update, "--username someuser", "--password some\\ password", "--revision 12345")
 
           subject.update_mirror
         end
@@ -103,9 +103,9 @@ module Capistrano
         backend.expects(:capture).with(:svn, :info, "path").returns("URL: old_url\n")
 
         env.set(:svn_username, "someuser")
-        env.set(:svn_password, "somepassword")
-        backend.expects(:execute).with(:svn, :switch, "url", "--username someuser", "--password somepassword")
-        backend.expects(:execute).with(:svn, :update, "--username someuser", "--password somepassword")
+        env.set(:svn_password, "some password")
+        backend.expects(:execute).with(:svn, :switch, "url", "--username someuser", "--password some\\ password")
+        backend.expects(:execute).with(:svn, :update, "--username someuser", "--password some\\ password")
 
         subject.update_mirror
       end
@@ -115,9 +115,9 @@ module Capistrano
       it "should run svn export" do
         env.set(:release_path, "path")
         env.set(:svn_username, "someuser")
-        env.set(:svn_password, "somepassword")
+        env.set(:svn_password, "some password")
 
-        backend.expects(:execute).with(:svn, :export, "--force", ".", "path", "--username someuser", "--password somepassword")
+        backend.expects(:execute).with(:svn, :export, "--force", ".", "path", "--username someuser", "--password some\\ password")
 
         subject.archive_to_release_path
       end


### PR DESCRIPTION
### Summary

Previously, if `svn_username` or `svn_password` contained e.g. whitespace, the SCM commands would fail.
This PR uses the `shellwords` library (part of `stdlib`) to properly escape them.

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [ ] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?
- [ ] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?
