### PR TITLE
Remove the static path to ssh in the git ssh wrapper to allow for greater platform flexibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ gem "capistrano", github: "capistrano/capistrano", require: false
 
 [master]: https://github.com/capistrano/capistrano/compare/v3.11.0...HEAD
 
+* Remove the static path to ssh in the git ssh wrapper to allow for greater platform flexibility - [@signe](https://github.com/signe)
 * Your contribution here!
 
 ## [`3.11.0`] (2018-06-02)

--- a/lib/capistrano/scm/tasks/git.rake
+++ b/lib/capistrano/scm/tasks/git.rake
@@ -6,7 +6,7 @@ namespace :git do
   task :wrapper do
     on release_roles :all do
       execute :mkdir, "-p", File.dirname(fetch(:git_wrapper_path)).shellescape
-      upload! StringIO.new("#!/bin/sh -e\nexec /usr/bin/ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no \"$@\"\n"), fetch(:git_wrapper_path)
+      upload! StringIO.new("#!/bin/sh -e\nexec /usr/bin/env ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no \"$@\"\n"), fetch(:git_wrapper_path)
       execute :chmod, "700", fetch(:git_wrapper_path).shellescape
     end
   end


### PR DESCRIPTION
Rebase of https://github.com/capistrano/capistrano/pull/1492. See that for discussion.

Fixes #1221 

/CC @signe