### PR TITLE
Batch rm -rf calls in deploy:cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ gem "capistrano", github: "capistrano/capistrano", require: false
 [master]: https://github.com/capistrano/capistrano/compare/v3.11.0...HEAD
 
 * Your contribution here!
+* [#2027](https://github.com/capistrano/capistrano/pull/2027): Batch rm -rf calls in deploy:cleanup. [@azin634](https://github.com/azin634)
 
 ## [`3.11.0`] (2018-06-02)
 

--- a/features/deploy.feature
+++ b/features/deploy.feature
@@ -70,6 +70,12 @@ Feature: Deploy
     Then 3 valid releases are kept
     And the current directory will be a symlink to the release
 
+  Scenario: Cleanup when there are more releases than arguments can handle
+    Given config stage file has line "set :keep_releases, 3"
+    And 5000 valid existing releases
+    When I run cap "deploy:cleanup"
+    Then 3 valid releases are kept
+
   Scenario: Rolling Back
     Given I make 2 deployments
     When I run cap "deploy:rollback"

--- a/features/step_definitions/setup.rb
+++ b/features/step_definitions/setup.rb
@@ -80,10 +80,12 @@ end
 
 Given(/^(\d+) valid existing releases$/) do |num|
   a_day = 86_400 # in seconds
-  offset = -(a_day * num.to_i)
-  num.to_i.times do
-    run_vagrant_command("mkdir -p #{TestApp.release_path(TestApp.timestamp(offset))}")
-    offset += a_day
+  (1...num).each_slice(100) do |num_batch|
+    dirs = num_batch.map do |i|
+      offset = -(a_day * i)
+      TestApp.release_path(TestApp.timestamp(offset))
+    end
+    run_vagrant_command("mkdir -p #{dirs.join(' ')}")
   end
 end
 

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -168,7 +168,9 @@ namespace :deploy do
           debug t(:no_current_release, host: host.to_s)
         end
         if directories.any?
-          execute :rm, "-rf", *directories
+          directories.each_slice(100) do |directories_batch|
+            execute :rm, "-rf", *directories_batch
+          end
         else
           info t(:no_old_releases, host: host.to_s, keep_releases: fetch(:keep_releases))
         end


### PR DESCRIPTION
### Summary

When there are too many releases, executing `rm -rf` blows up because `argument list too long`. This change will execute the `rm -rf` in batches of 100. Funny enough, I also had to batch the `mkdir` calls in https://github.com/capistrano/capistrano/pull/2027/files#diff-4dd6175d7696e78ae491054de8f1c6f2R83 for my test to run in a reasonable time.

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?
- [x] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?

Fixes #2026