### PR TITLE
Exclude danger to fix Ruby 2.0.0 CI error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,3 +30,8 @@ end
 if Gem::Requirement.new("< 2.1").satisfied_by?(Gem::Version.new(RUBY_VERSION))
   gem "i18n", "< 1.3.0"
 end
+
+# We only run danger once on a new-ish ruby; no need to install it otherwise
+if Gem::Requirement.new("> 2.4").satisfied_by?(Gem::Version.new(RUBY_VERSION))
+  gem "danger"
+end

--- a/capistrano.gemspec
+++ b/capistrano.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rake", ">= 10.0.0"
   gem.add_dependency "sshkit", ">= 1.9.0"
 
-  gem.add_development_dependency "danger"
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "rubocop", "0.48.1"


### PR DESCRIPTION
`danger` no longer installs cleanly on Ruby 2.0.0. Our CI only runs danger on Ruby 2.5, so there is no reason to install it for older versions.

Fixes #2029
