### PR TITLE
Use a stub for $stdin during testing

### DIFF
--- a/lib/capistrano/configuration/question.rb
+++ b/lib/capistrano/configuration/question.rb
@@ -36,12 +36,12 @@ module Capistrano
       end
 
       def gets
-        return unless $stdin.tty?
+        return unless stdin.tty?
 
         if echo?
-          $stdin.gets
+          stdin.gets
         else
-          $stdin.noecho(&:gets).tap { $stdout.print "\n" }
+          stdin.noecho(&:gets).tap { $stdout.print "\n" }
         end
       rescue Errno::EIO
         # when stdio gets closed
@@ -58,6 +58,10 @@ module Capistrano
 
       def echo?
         (options || {}).fetch(:echo, true)
+      end
+
+      def stdin
+        (options || {}).fetch(:stdin, $stdin)
       end
     end
   end

--- a/spec/integration/dsl_spec.rb
+++ b/spec/integration/dsl_spec.rb
@@ -356,14 +356,16 @@ describe Capistrano::DSL do
   end
 
   describe "asking for a variable" do
+    let(:stdin) { stub(tty?: true) }
+
     before do
-      dsl.ask(:scm, :svn)
+      dsl.ask(:scm, :svn, stdin: stdin)
       $stdout.stubs(:print)
     end
 
     context "variable is provided" do
       before do
-        $stdin.expects(:gets).returns("git")
+        stdin.expects(:gets).returns("git")
       end
 
       it "sets the input as the variable" do
@@ -373,7 +375,7 @@ describe Capistrano::DSL do
 
     context "variable is not provided" do
       before do
-        $stdin.expects(:gets).returns("")
+        stdin.expects(:gets).returns("")
       end
 
       it "sets the variable as the default" do

--- a/spec/lib/capistrano/configuration/question_spec.rb
+++ b/spec/lib/capistrano/configuration/question_spec.rb
@@ -3,12 +3,12 @@ require "spec_helper"
 module Capistrano
   class Configuration
     describe Question do
-      let(:question) { Question.new(key, default, options) }
-      let(:question_without_echo) { Question.new(key, default, echo: false) }
-      let(:question_without_default) { Question.new(key, nil) }
+      let(:question) { Question.new(key, default, stdin: stdin) }
+      let(:question_without_echo) { Question.new(key, default, echo: false, stdin: stdin) }
+      let(:question_without_default) { Question.new(key, nil, stdin: stdin) }
       let(:default) { :default }
       let(:key) { :branch }
-      let(:options) { nil }
+      let(:stdin) { stub(tty?: true) }
 
       describe ".new" do
         it "takes a key, default, options" do
@@ -22,15 +22,15 @@ module Capistrano
 
           it "returns the echoed value" do
             $stdout.expects(:print).with("Please enter branch (default): ")
-            $stdin.expects(:gets).returns(branch)
-            $stdin.expects(:noecho).never
+            stdin.expects(:gets).returns(branch)
+            stdin.expects(:noecho).never
 
             expect(question.call).to eq(branch)
           end
 
           it "returns the value but does not echo it" do
             $stdout.expects(:print).with("Please enter branch (default): ")
-            $stdin.expects(:noecho).returns(branch)
+            stdin.expects(:noecho).returns(branch)
             $stdout.expects(:print).with("\n")
 
             expect(question_without_echo.call).to eq(branch)
@@ -38,8 +38,8 @@ module Capistrano
 
           it "returns the value but has no default between parenthesis" do
             $stdout.expects(:print).with("Please enter branch: ")
-            $stdin.expects(:gets).returns(branch)
-            $stdin.expects(:noecho).never
+            stdin.expects(:gets).returns(branch)
+            stdin.expects(:noecho).never
 
             expect(question_without_default.call).to eq(branch)
           end
@@ -50,7 +50,7 @@ module Capistrano
 
           before do
             $stdout.expects(:print).with("Please enter branch (default): ")
-            $stdin.expects(:gets).returns("")
+            stdin.expects(:gets).returns("")
           end
 
           it "returns the default as the value" do
@@ -60,8 +60,8 @@ module Capistrano
 
         context "tty unavailable", capture_io: true do
           before do
-            $stdin.expects(:gets).never
-            $stdin.expects(:tty?).returns(false)
+            stdin.expects(:gets).never
+            stdin.expects(:tty?).returns(false)
           end
 
           it "returns the default as the value" do


### PR DESCRIPTION
### Summary

This allows the tests to run even in a situation where stdin isn't available, for example when the test is run with `< /dev/null` as is the case for some packaging scripts.

Fixes #2032

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?
- [ ] ~If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?~ (this is not a user-facing fix)
