### PR TITLE
Update gemspec with correct release notes URL, etc.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ Lint/AmbiguousBlockAssociation:
     false
 Metrics/BlockLength:
   Exclude:
+    - "*.gemspec"
     - "spec/**/*"
     - "lib/**/*.rake"
 Style/BarePercentLiterals:

--- a/capistrano.gemspec
+++ b/capistrano.gemspec
@@ -11,9 +11,13 @@ Gem::Specification.new do |gem|
   gem.email         = ["seenmyfate@gmail.com", "lee.hambley@gmail.com"]
   gem.description   = "Capistrano is a utility and framework for executing commands in parallel on multiple remote machines, via SSH."
   gem.summary       = "Capistrano - Welcome to easy deployment with Ruby over SSH"
-  gem.homepage      = "http://capistranorb.com/"
+  gem.homepage      = "https://capistranorb.com/"
   gem.metadata      = {
-    "changelog_uri" => "https://github.com/capistrano/capistrano/blob/master/CHANGELOG.md"
+    "bug_tracker_uri" => "https://github.com/capistrano/capistrano/issues",
+    "changelog_uri" => "https://github.com/capistrano/capistrano/releases",
+    "source_code_uri" => "https://github.com/capistrano/capistrano",
+    "homepage_uri" => "https://capistranorb.com/",
+    "documentation_uri" => "https://capistranorb.com/"
   }
   gem.files         = `git ls-files -z`.split("\x0").reject { |f| f =~ /^docs/ }
   gem.executables   = %w(cap capify)


### PR DESCRIPTION
- Switch homepage from http to https
- Switch from CHANGELOG.md to GitHub release notes
- Add other URLs: issues, home page, docs

This metadata is used by <https://rubygems.org> and other tools like <https://www.ruby-toolbox.com>.
