### PR TITLE
Don't use relative paths on lib load

### DIFF
--- a/spec/lib/capistrano/doctor/environment_doctor_spec.rb
+++ b/spec/lib/capistrano/doctor/environment_doctor_spec.rb
@@ -21,8 +21,8 @@ module Capistrano
 
       describe "Rake" do
         before do
-          load File.expand_path("../../../../../lib/capistrano/doctor.rb",
-                                __FILE__)
+          $:.unshift File.expand_path('../../../../../lib', __FILE__)
+          load 'capistrano/doctor.rb'
         end
 
         after do

--- a/spec/lib/capistrano/doctor/gems_doctor_spec.rb
+++ b/spec/lib/capistrano/doctor/gems_doctor_spec.rb
@@ -45,8 +45,8 @@ module Capistrano
 
       describe "Rake" do
         before do
-          load File.expand_path("../../../../../lib/capistrano/doctor.rb",
-                                __FILE__)
+          $:.unshift File.expand_path('../../../../../lib', __FILE__)
+          load 'capistrano/doctor.rb'
         end
 
         after do

--- a/spec/lib/capistrano/doctor/servers_doctor_spec.rb
+++ b/spec/lib/capistrano/doctor/servers_doctor_spec.rb
@@ -63,8 +63,8 @@ module Capistrano
 
       describe "Rake" do
         before do
-          load File.expand_path("../../../../../lib/capistrano/doctor.rb",
-                                __FILE__)
+          $:.unshift File.expand_path('../../../../../lib', __FILE__)
+          load 'capistrano/doctor.rb'
         end
 
         after do

--- a/spec/lib/capistrano/doctor/variables_doctor_spec.rb
+++ b/spec/lib/capistrano/doctor/variables_doctor_spec.rb
@@ -66,8 +66,8 @@ module Capistrano
 
       describe "Rake" do
         before do
-          load File.expand_path("../../../../../lib/capistrano/doctor.rb",
-                                __FILE__)
+          $:.unshift File.expand_path('../../../../../lib', __FILE__)
+          load 'capistrano/doctor.rb'
         end
 
         after do


### PR DESCRIPTION
### Summary

Debian-specific patch to fix some failures with testing in our infrastructure.

I understand this might not be desirable upstream, but decided to PR anyway
so you at least know that we are doing it.

The failure happens because the lib directory is removed during testing and
relative paths were used:
https://wiki.debian.org/Teams/Ruby/Packaging/Tests#Case_eight:_autopkgtest_failure

### Short checklist

- [ ] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test?
Not-applicable
- [x] Did you confirm that the RSpec tests pass?
Everthing is passing
- [x] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?
Not needed

Feel free to reject the PR in case it's not applicable.
