### PR TITLE
Fix %x typo in local tasks example

### DIFF
--- a/docs/documentation/getting-started/local-tasks/index.markdown
+++ b/docs/documentation/getting-started/local-tasks/index.markdown
@@ -21,7 +21,7 @@ Of course, you can always just use standard ruby syntax to run things locally:
 ```ruby
 desc 'Notify service of deployment'
 task :notify do
-  %x('RAILS_ENV=development bundle exec rake "service:notify"')
+  %x(RAILS_ENV=development bundle exec rake "service:notify")
 end
 ```
 


### PR DESCRIPTION
%x has 2 variations: 

- `%x(command)`
- `%x["command"]`

The one specified in the doc is none of the above, so I assume it's a mistake.
