### PR TITLE
Change default `git_wait_interval` to 0 to fix git slowdown introduced in 3.12.0

### DIFF
--- a/docs/documentation/getting-started/configuration/index.markdown
+++ b/docs/documentation/getting-started/configuration/index.markdown
@@ -155,7 +155,7 @@ The following variables are settable:
   * Number of concurrent connections to Git repository - useful when your Git server limits the number of simultaneous connections while using SSH (like Gitlab CE).
 
 * `:git_wait_interval`
-  * **default:** `3`
+  * **default:** `0`
   * Number of seconds to wait after you reach the limit of concurrent connections to Git repository server and disconnect afterwards to initialize new connections. This prevents from being cut out of SSH server when you use `fail2ban` or similar software for limiting connections to server.
 
 Capistrano plugins can provide their own configuration variables. Please refer

--- a/lib/capistrano/scm/git.rb
+++ b/lib/capistrano/scm/git.rb
@@ -19,7 +19,7 @@ class Capistrano::SCM::Git < Capistrano::SCM::Plugin
       }
     }
     set_if_empty :git_max_concurrent_connections, 10
-    set_if_empty :git_wait_interval, 3
+    set_if_empty :git_wait_interval, 0
   end
 
   def register_hooks

--- a/spec/lib/capistrano/scm/git_spec.rb
+++ b/spec/lib/capistrano/scm/git_spec.rb
@@ -46,7 +46,7 @@ module Capistrano
 
       it "makes git_wait_interval" do
         subject.set_defaults
-        expect(env.fetch(:git_wait_interval)).to eq(3)
+        expect(env.fetch(:git_wait_interval)).to eq(0)
         env.set(:git_wait_interval, 5)
         expect(env.fetch(:git_wait_interval)).to eq(5)
       end


### PR DESCRIPTION
### Summary

Fix for issue #2049 