### PR TITLE
Improve misleading example for ssh_options

### DIFF
--- a/lib/capistrano/templates/stage.rb.erb
+++ b/lib/capistrano/templates/stage.rb.erb
@@ -42,7 +42,7 @@
 # Global options
 # --------------
 #  set :ssh_options, {
-#    keys: %w(/home/rlisowski/.ssh/id_rsa),
+#    keys: %w(/home/user_name/.ssh/id_rsa),
 #    forward_agent: false,
 #    auth_methods: %w(password)
 #  }


### PR DESCRIPTION
Years ago when I was switching from Capistrano 2 to version 3 I introduced ssh_options #557. 
Unfortunately, as an example path, I pasted my own home path and from then on my Github handle pollutes 37K+ lines of code in random projects. 

![rlisowski](https://user-images.githubusercontent.com/7737/75862870-ddf3af80-5dff-11ea-9c1a-eaf092bd5790.jpg)

I would like to stop it.
