### PR TITLE
Use env to find ssh path

### DIFF
--- a/lib/capistrano/scm/tasks/git.rake
+++ b/lib/capistrano/scm/tasks/git.rake
@@ -6,7 +6,7 @@ namespace :git do
   task :wrapper do
     on release_roles(:all), in: :groups, limit: fetch(:git_max_concurrent_connections), wait: fetch(:git_wait_interval) do
       execute :mkdir, "-p", File.dirname(fetch(:git_wrapper_path)).shellescape
-      upload! StringIO.new("#!/bin/sh -e\nexec /usr/bin/ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no \"$@\"\n"), fetch(:git_wrapper_path)
+      upload! StringIO.new("#!/bin/sh -e\nexec /usr/bin/env ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no \"$@\"\n"), fetch(:git_wrapper_path)
       execute :chmod, "700", fetch(:git_wrapper_path).shellescape
     end
   end


### PR DESCRIPTION
### Summary
Changed the call to /usr/bin/ssh in to /usr/bin/env ssh to make capistrano nixos compatible.
Nixos does not keep the binaries in /usr/bin.

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [ ] If relevant, did you create a test?  **not applicable**
- [x] Did you confirm that the RSpec tests pass? - **Didn't run the  `bundle exec rake features` ones, I got some problem with virtualbox on my system at the moment that would require rebuilding the kernel**
- [ ] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?  -- **is the changelog still used? It's empty**
