### PR TITLE
Add custom prompt support for user input

### DIFF
--- a/docs/documentation/getting-started/user-input/index.markdown
+++ b/docs/documentation/getting-started/user-input/index.markdown
@@ -49,6 +49,12 @@ server 'example.com', user: 'ssh_user_name', port: 22, password: fetch(:password
 ```
 
 
+You can also show your own message by using `prompt` option:
+
+```ruby
+  ask(:breakfast, "pancakes", prompt: "What's for breakfast?")
+```
+
 **Important!** `ask` will not prompt the user immediately. The question is
 deferred until the first time `fetch` is used to obtain the setting. That means
 you can `ask` for many variables, but only the variables used by your task(s)

--- a/lib/capistrano/configuration/question.rb
+++ b/lib/capistrano/configuration/question.rb
@@ -49,7 +49,11 @@ module Capistrano
       end
 
       def question
-        if default.nil?
+        if prompt && default.nil?
+          I18n.t(:question_prompt, key: prompt, scope: :capistrano)
+        elsif prompt
+          I18n.t(:question_prompt_default, key: prompt, default_value: default, scope: :capistrano)
+        elsif default.nil?
           I18n.t(:question, key: key, scope: :capistrano)
         else
           I18n.t(:question_default, key: key, default_value: default, scope: :capistrano)
@@ -62,6 +66,10 @@ module Capistrano
 
       def stdin
         (options || {}).fetch(:stdin, $stdin)
+      end
+
+      def prompt
+        (options || {}).fetch(:prompt, nil)
       end
     end
   end

--- a/lib/capistrano/i18n.rb
+++ b/lib/capistrano/i18n.rb
@@ -12,6 +12,8 @@ en = {
   written_file: "create %{file}",
   question: "Please enter %{key}: ",
   question_default: "Please enter %{key} (%{default_value}): ",
+  question_prompt: "%{key}: ",
+  question_prompt_default: "%{key} (%{default_value}): ",
   keeping_releases: "Keeping %{keep_releases} of %{releases} deployed releases on %{host}",
   skip_cleanup: "Skipping cleanup of invalid releases on %{host}; unexpected foldername found (should be timestamp)",
   wont_delete_current_release: "Current release was marked for being removed but it's going to be skipped on %{host}",

--- a/spec/lib/capistrano/configuration/question_spec.rb
+++ b/spec/lib/capistrano/configuration/question_spec.rb
@@ -6,6 +6,8 @@ module Capistrano
       let(:question) { Question.new(key, default, stdin: stdin) }
       let(:question_without_echo) { Question.new(key, default, echo: false, stdin: stdin) }
       let(:question_without_default) { Question.new(key, nil, stdin: stdin) }
+      let(:question_prompt) { Question.new(key, default, stdin: stdin, prompt: "Your favorite branch") }
+      let(:question_prompt_without_default) { Question.new(key, nil, stdin: stdin, prompt: "Your favorite branch") }
       let(:default) { :default }
       let(:key) { :branch }
       let(:stdin) { stub(tty?: true) }
@@ -42,6 +44,22 @@ module Capistrano
             stdin.expects(:noecho).never
 
             expect(question_without_default.call).to eq(branch)
+          end
+
+          it "uses prompt and returns the value" do
+            $stdout.expects(:print).with("Your favorite branch (default): ")
+            stdin.expects(:gets).returns(branch)
+            stdin.expects(:noecho).never
+
+            expect(question_prompt.call).to eq(branch)
+          end
+
+          it "uses prompt and returns the value but has no default between parenthesis" do
+            $stdout.expects(:print).with("Your favorite branch: ")
+            stdin.expects(:gets).returns(branch)
+            stdin.expects(:noecho).never
+
+            expect(question_prompt_without_default.call).to eq(branch)
           end
         end
 


### PR DESCRIPTION
### Summary

Added `prompt` option for user input to support custom messages (mentioned in #1758).

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?