### PR TITLE
Fix Bundler deprecation warning in `rake features`

### DIFF
--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -191,6 +191,11 @@ module TestApp
 
   def with_clean_bundler_env(&block)
     return yield unless defined?(Bundler)
-    Bundler.with_clean_env(&block)
+
+    if Bundler.respond_to?(:with_unbundled_env)
+      Bundler.with_unbundled_env(&block)
+    else
+      Bundler.with_clean_env(&block)
+    end
   end
 end


### PR DESCRIPTION
This fixes the following warning when running `rake features` using the latest version of Bundler (2.1.4):

```
[DEPRECATED] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`.
If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env`
(called at spec/support/test_app.rb:194)
```