### PR TITLE
Add Capistrano::Teams to 3rd Party Plugin

### DIFF
--- a/docs/documentation/third-party-plugins/index.markdown
+++ b/docs/documentation/third-party-plugins/index.markdown
@@ -55,3 +55,4 @@ You can help us expanding this list by sending us a pull request on
 
 <div class="github-widget" data-repo="aeroastro/capistrano-lazy_cleanup"></div>
 
+<div class="github-widget" data-repo="danieltoader/capistrano-teams"></div>


### PR DESCRIPTION
### Summary

Add Capistrano::Teams to 3rd Party Plugin. 

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [ ] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?

### Other Information

Capistrano::Teams adds the ability to push notices to Microsoft Teams via an incoming webhook.