### PR TITLE
Fix cucumber `puts` deprecation warnings

### DIFF
--- a/features/support/vagrant_helpers.rb
+++ b/features/support/vagrant_helpers.rb
@@ -30,6 +30,12 @@ module VagrantHelpers
     return [stdout, stderr] if status.success?
     raise VagrantSSHCommandError, status
   end
+
+  def puts(message)
+    # Attach log messages to the current cucumber feature (`log`),
+    # or simply puts to the console (`super`) if we are outside of cucumber.
+    respond_to?(:log) ? log(message) : super(message)
+  end
 end
 
 World(VagrantHelpers)


### PR DESCRIPTION
Cucumber has deprecated `puts` in favor of `log` for logging messages to the current cucumber formatter. In our case we actually want it both ways: we want to log messages using the cucumber formatter when cucumber is running, but use `Kernel#puts` otherwise.

So, use `respond_to?` to see if cucumber's `log` is available, and if not, fall back to `puts`.

#### Before

```
  Scenario: Deploying with configuration in a custom location # features/configuration.feature:12

WARNING: #puts(message) is deprecated and will be removed after version 6.0.0. Messages emitted with "puts" will no longer be caught by Cucumber and sent to the formatter. If you want message to be in the formatted output, please use log(message) instead.
If you simply want it in the console, keep using "puts" (or Kernel.puts to avoid this message).
(Called from /Users/mbrictson/Code/capistrano/capistrano/features/support/vagrant_helpers.rb:18:in `vagrant_cli_command')

WARNING: #puts(message) is deprecated and will be removed after version 6.0.0. Messages emitted with "puts" will no longer be caught by Cucumber and sent to the formatter. If you want message to be in the formatted output, please use log(message) instead.
If you simply want it in the console, keep using "puts" (or Kernel.puts to avoid this message).
(Called from /Users/mbrictson/Code/capistrano/capistrano/features/support/vagrant_helpers.rb:23:in `block in vagrant_cli_command')

WARNING: #puts(message) is deprecated and will be removed after version 6.0.0. Messages emitted with "puts" will no longer be caught by Cucumber and sent to the formatter. If you want message to be in the formatted output, please use log(message) instead.
If you simply want it in the console, keep using "puts" (or Kernel.puts to avoid this message).
(Called from /Users/mbrictson/Code/capistrano/capistrano/features/support/vagrant_helpers.rb:23:in `block in vagrant_cli_command')

WARNING: #puts(message) is deprecated and will be removed after version 6.0.0. Messages emitted with "puts" will no longer be caught by Cucumber and sent to the formatter. If you want message to be in the formatted output, please use log(message) instead.
If you simply want it in the console, keep using "puts" (or Kernel.puts to avoid this message).
(Called from /Users/mbrictson/Code/capistrano/capistrano/features/support/vagrant_helpers.rb:23:in `block in vagrant_cli_command')

WARNING: #puts(message) is deprecated and will be removed after version 6.0.0. Messages emitted with "puts" will no longer be caught by Cucumber and sent to the formatter. If you want message to be in the formatted output, please use log(message) instead.
If you simply want it in the console, keep using "puts" (or Kernel.puts to avoid this message).
(Called from /Users/mbrictson/Code/capistrano/capistrano/features/support/vagrant_helpers.rb:23:in `block in vagrant_cli_command')
      [vagrant] up
      [vagrant] Bringing machine 'app' up with 'virtualbox' provider...
      [vagrant] ==> app: Checking if box 'hashicorp/precise64' version '1.1.0' is up to date...
      [vagrant] ==> app: Machine already provisioned. Run `vagrant provision` or use the `--provision`
      [vagrant] ==> app: flag to force provisioning. Provisioners marked to run always will still run.
    But the configuration is in a custom location             # features/step_definitions/setup.rb:52
    When I run "cap test"                                     # features/step_definitions/cap_commands.rb:13
    Then the task is successful                               # features/step_definitions/assertions.rb:106
```

#### After

```
  Scenario: Deploying with configuration in a custom location # features/configuration.feature:12
      [vagrant] up
      [vagrant] Bringing machine 'app' up with 'virtualbox' provider...
      [vagrant] ==> app: Checking if box 'hashicorp/precise64' version '1.1.0' is up to date...
      [vagrant] ==> app: Machine already provisioned. Run `vagrant provision` or use the `--provision`
      [vagrant] ==> app: flag to force provisioning. Provisioners marked to run always will still run.
    But the configuration is in a custom location             # features/step_definitions/setup.rb:52
    When I run "cap test"                                     # features/step_definitions/cap_commands.rb:13
    Then the task is successful                               # features/step_definitions/assertions.rb:106
```

Fixes #2073 