### PR TITLE
Add a :verify_commit option

### DIFF
--- a/docs/documentation/getting-started/configuration/index.markdown
+++ b/docs/documentation/getting-started/configuration/index.markdown
@@ -158,10 +158,9 @@ The following variables are settable:
   * **default:** `0`
   * Number of seconds to wait after you reach the limit of concurrent connections to Git repository server and disconnect afterwards to initialize new connections. This prevents from being cut out of SSH server when you use `fail2ban` or similar software for limiting connections to server.
 
-* `:verify_commit`
+* `:git_verify_commit`
   * **default:** `false`
-  * Whether to check if a valid signature exists on the commit to be deployed.
-  * Currently only implemented for Git.
+  * Whether to check if a valid signature exists on the Git commit to be deployed.
 
 Capistrano plugins can provide their own configuration variables. Please refer
 to the plugin documentation for the specifics. Plugins are allowed to add or

--- a/docs/documentation/getting-started/configuration/index.markdown
+++ b/docs/documentation/getting-started/configuration/index.markdown
@@ -158,6 +158,11 @@ The following variables are settable:
   * **default:** `0`
   * Number of seconds to wait after you reach the limit of concurrent connections to Git repository server and disconnect afterwards to initialize new connections. This prevents from being cut out of SSH server when you use `fail2ban` or similar software for limiting connections to server.
 
+* `:verify_commit`
+  * **default:** `false`
+  * Whether to check if a valid signature exists on the commit to be deployed.
+  * Currently only implemented for Git.
+
 Capistrano plugins can provide their own configuration variables. Please refer
 to the plugin documentation for the specifics. Plugins are allowed to add or
 manipulate default values as well as already user-defined values after the

--- a/lib/capistrano/scm/git.rb
+++ b/lib/capistrano/scm/git.rb
@@ -60,6 +60,10 @@ class Capistrano::SCM::Git < Capistrano::SCM::Plugin
     end
   end
 
+  def verify_commit
+    git :"verify-commit", fetch_revision
+  end
+
   def archive_to_release_path
     if (tree = fetch(:repo_tree))
       tree = tree.slice %r#^/?(.*?)/?$#, 1

--- a/lib/capistrano/scm/tasks/git.rake
+++ b/lib/capistrano/scm/tasks/git.rake
@@ -42,7 +42,7 @@ namespace :git do
       within repo_path do
         with fetch(:git_environmental_variables) do
           git_plugin.update_mirror
-          git_plugin.verify_commit if fetch(:verify_commit)
+          git_plugin.verify_commit if fetch(:git_verify_commit)
         end
       end
     end

--- a/lib/capistrano/scm/tasks/git.rake
+++ b/lib/capistrano/scm/tasks/git.rake
@@ -42,6 +42,7 @@ namespace :git do
       within repo_path do
         with fetch(:git_environmental_variables) do
           git_plugin.update_mirror
+          git_plugin.verify_commit if fetch(:verify_commit)
         end
       end
     end

--- a/spec/lib/capistrano/scm/git_spec.rb
+++ b/spec/lib/capistrano/scm/git_spec.rb
@@ -169,5 +169,16 @@ module Capistrano
         expect(revision).to eq("81cec13b777ff46348693d327fc8e7832f79bf43")
       end
     end
+
+    describe "#verify_commit" do
+      it "should run git verify-commit" do
+        env.set(:branch, "branch")
+
+        backend.expects(:capture).with(:git, "rev-list --max-count=1 branch").returns("81cec13b777ff46348693d327fc8e7832f79bf43")
+        backend.expects(:execute).with(:git, :"verify-commit", "81cec13b777ff46348693d327fc8e7832f79bf43")
+
+        subject.verify_commit
+      end
+    end
   end
 end


### PR DESCRIPTION
When :verify_commit is set to true, after updating the mirror
`git verify-commit <revision>` will be run on the revision that is
about to be deployed to check if it has a valid signature. This
will allow a user to be certain that the code they are about to
deploy was signed by an authorized author, and that they are not
in danger of deploying malicious code in an attack scenario such as
https://github.blog/2012-03-04-public-key-security-vulnerability-and-mitigation/

discussed in https://github.com/capistrano/capistrano/issues/2074

### Short checklist

- [✔] Did you run `bundle exec rubocop -a` to fix linter issues?
- [✔] If relevant, did you create a test?
- [✔] Did you confirm that the RSpec tests pass?

