### PR TITLE
Add new default webpacker path to linked_dirs

### DIFF
--- a/lib/capistrano/templates/deploy.rb.erb
+++ b/lib/capistrano/templates/deploy.rb.erb
@@ -24,7 +24,7 @@ set :repo_url, "git@example.com:me/my_repo.git"
 # append :linked_files, "config/database.yml"
 
 # Default value for linked_dirs is []
-# append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"
+# append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "tmp/webpacker", "public/system"
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }


### PR DESCRIPTION
Rails default webpacker directory which contains a file with packs checksum digest will change it's location in order to be not affected by `Rails.cache.clear` command with filestore

After this PR https://github.com/rails/webpacker/pull/3002 will be merged, we'll need to update defaults here as well.

### Short checklist

- [x] run `bundle exec rubocop -a`
- [x] If relevant, did you create a test (not relevant, imo)
- [x] confirm that the RSpec tests pass?