### PR TITLE
Allow access to SCM::Plugin instance from deploy scripts

### DIFF
--- a/lib/capistrano/configuration.rb
+++ b/lib/capistrano/configuration.rb
@@ -165,6 +165,10 @@ module Capistrano
       installer.scm_installed?
     end
 
+    def scm_plugin
+      installer.scm_plugin
+    end
+
     def servers
       @servers ||= Servers.new
     end

--- a/lib/capistrano/configuration/plugin_installer.rb
+++ b/lib/capistrano/configuration/plugin_installer.rb
@@ -35,7 +35,11 @@ module Capistrano
             plugin.set_defaults
           end
         end
+        @scm_plugin = plugin if provides_scm?(plugin)
+        plugin
       end
+
+      attr_reader :scm_plugin
 
       def scm_installed?
         @scm_installed

--- a/lib/capistrano/dsl/env.rb
+++ b/lib/capistrano/dsl/env.rb
@@ -8,7 +8,7 @@ module Capistrano
                      :configure_backend, :fetch, :set, :set_if_empty, :delete,
                      :ask, :role, :server, :primary, :validate, :append,
                      :remove, :dry_run?, :install_plugin, :any?, :is_question?,
-                     :configure_scm, :scm_plugin_installed?
+                     :configure_scm, :scm_plugin, :scm_plugin_installed?
 
       def roles(*names)
         env.roles_for(names.flatten)

--- a/spec/lib/capistrano/configuration/scm_resolver_spec.rb
+++ b/spec/lib/capistrano/configuration/scm_resolver_spec.rb
@@ -30,6 +30,11 @@ module Capistrano
           expect(Rake::Task["git:wrapper"]).not_to be_nil
         end
 
+        it "exposes the scm plugin instance in the DSL", capture_io: true do
+          resolver.resolve
+          expect(scm_plugin).to be_a(Capistrano::SCM::Git)
+        end
+
         it "sets :scm to :git", capture_io: true do
           resolver.resolve
           expect(fetch(:scm)).to eq(:git)
@@ -43,6 +48,11 @@ module Capistrano
 
         it "emits no warning" do
           expect { resolver.resolve }.not_to output.to_stderr
+        end
+
+        it "exposes the scm plugin instance in the DSL" do
+          resolver.resolve
+          expect(scm_plugin).to be_a(Capistrano::SCM::Git)
         end
 
         it "deletes :scm" do


### PR DESCRIPTION
Accessible via `scm_plugin` method.

### Summary
Provides a way to access the deployment's `Capistrano::SCM::Plugin` instance from within a deploy script. (via an `scm_plugin` method)

My use case for this was that I wanted to invoke `git:check` on my local machine, from which I trigger the deployment. As my local machine does not have a release role, it isn't possible to simply invoke the built-in rake task. 


### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?