### PR TITLE
Fix warnings and errors in cucumber feature tests

### DIFF
--- a/spec/support/Vagrantfile
+++ b/spec/support/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure("2") do |config|
   [:app].each_with_index do |role, i|
     config.vm.define(role, primary: true) do |primary|
       primary.vm.define role
-      primary.vm.box = "hashicorp/precise64"
+      primary.vm.box = "hashicorp/bionic64"
       primary.vm.network "forwarded_port", guest: 22, host: "222#{i}".to_i
       primary.vm.provision :shell, inline: "sudo apt-get -y install git-core"
 

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -40,6 +40,7 @@ module TestApp
     FileUtils.mkdir(test_app_path)
 
     File.open(gemfile, "w+") do |file|
+      file.write "source 'https://rubygems.org'\n"
       file.write "gem 'capistrano', path: '#{path_to_cap}'"
     end
 


### PR DESCRIPTION
### Summary

The `hashicorp/precise64` VM image that we use for cucumber feature tests is a very old version of Ubuntu. The `apt-get install` command no longer works, apparently because the download sources for packages are no longer available for that version. As a result, feature tests would fail because the `git-core` package could not be installed:

```
[vagrant] ==> app: Running provisioner: shell...
[vagrant]     app: Running: inline script
[vagrant]     app: Reading package lists...
[vagrant]     app: Building dependency tree...
[vagrant]     app: Reading state information...
[vagrant]     app: The following extra packages will be installed:
[vagrant]     app:   git git-man liberror-perl patch
[vagrant]     app: Suggested packages:
[vagrant]     app:   git-daemon-run git-daemon-sysvinit git-doc git-el git-arch git-cvs git-svn
[vagrant]     app:   git-email git-gui gitk gitweb diffutils-doc
[vagrant]     app: The following NEW packages will be installed:
[vagrant]     app:   git git-core git-man liberror-perl patch
[vagrant]     app: 0 upgraded, 5 newly installed, 0 to remove and 66 not upgraded.
[vagrant]     app: Need to get 6,822 kB of archives.
[vagrant]     app: After this operation, 15.5 MB of additional disk space will be used.
[vagrant]     app: Err http://us.archive.ubuntu.com/ubuntu/ precise/main liberror-perl all 0.17-1
[vagrant]     app:   404  Not Found [IP: 91.189.91.38 80]
[vagrant]     app: Err http://us.archive.ubuntu.com/ubuntu/ precise/main git-man all 1:1.7.9.5-1
[vagrant]     app:   404  Not Found [IP: 91.189.91.38 80]
[vagrant]     app: Err http://us.archive.ubuntu.com/ubuntu/ precise/main git amd64 1:1.7.9.5-1
[vagrant]     app:   404  Not Found [IP: 91.189.91.38 80]
[vagrant]     app: Err http://us.archive.ubuntu.com/ubuntu/ precise/main git-core all 1:1.7.9.5-1
[vagrant]     app:   404  Not Found [IP: 91.189.91.38 80]
[vagrant]     app: Err http://us.archive.ubuntu.com/ubuntu/ precise/main patch amd64 2.6.1-3
[vagrant]     app:   404  Not Found [IP: 91.189.91.38 80]
[vagrant]     app: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/libe/liberror-perl/liberror-perl_0.17-1_all.deb  404  Not Found [IP: 91.189.91.38 80]
[vagrant]     app: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/g/git/git-man_1.7.9.5-1_all.deb  404  Not Found [IP: 91.189.91.38 80]
[vagrant]     app: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/g/git/git_1.7.9.5-1_amd64.deb  404  Not Found [IP: 91.189.91.38 80]
[vagrant]     app: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/g/git/git-core_1.7.9.5-1_all.deb  404  Not Found [IP: 91.189.91.38 80]
[vagrant]     app: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/p/patch/patch_2.6.1-3_amd64.deb  404  Not Found [IP: 91.189.91.38 80]
[vagrant]     app: E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

Fix by upgrading to `hashicorp/bionic64`.

Also, newer versions of bundler print a warning if a Gemfile is missing a `source` directive:

> [DEPRECATED] This Gemfile does not include an explicit global source. Not using an explicit global source may result in a different lockfile being generated depending on the gems you have installed locally before bundler is run. Instead, define a global source in your Gemfile like this: source "https://rubygems.org".

Fix these warnings in our cucumber feature tests by adding a `source` to the Gemfile that we generate.

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test? [N/A]
- [x] Did you confirm that the RSpec tests pass?
