### PR TITLE
Add Ruby 3.1 to CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 3.1
   - 3.0
   - 2.7
   - 2.6
@@ -18,11 +19,13 @@ matrix:
   include:
     - rvm: rbx-2
       script: bundle exec rake spec
-    # Run Danger only once, on 2.5
-    - rvm: 2.5
-      before_script: bundle exec danger
+    # Run Danger and Rubocop only once, on 2.7
+    - rvm: 2.7
+      before_script: |
+        bundle exec danger
+        bundle exec rake rubocop
 
-script: bundle exec rake spec rubocop
+script: bundle exec rake spec
 install: bundle install --jobs=1
 cache: bundler
 branches:


### PR DESCRIPTION
This PR adds Ruby 3.1 to the Travis CI testing matrix.

Also, since Rubocop currently fails to run on Ruby 3.1, limit Rubocop to running on a single Ruby version (2.7). Running Rubocop on multiple Ruby versions is overkill, anyway.

Finally, change the version we use for running Danger to 2.7 (instead of 2.5), in anticipation of older Ruby versions getting dropped eventually.
