### PR TITLE
Ensure rubocop can run under Ruby 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,5 +41,6 @@ end
 # We only run danger and rubocop on a new-ish ruby; no need to install them otherwise
 if Gem::Requirement.new("> 2.4").satisfied_by?(Gem::Version.new(RUBY_VERSION))
   gem "danger"
+  gem "psych", "< 4" # Ensures rubocop works on Ruby 3.1
   gem "rubocop", "0.48.1"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,10 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in capistrano.gemspec
 gemspec
 
+gem "mocha"
+gem "rspec"
+gem "rspec-core", "~> 3.4.4"
+
 group :cucumber do
   # Latest versions of cucumber don't support Ruby < 2.1
   # rubocop:disable Bundler/DuplicatedGem
@@ -12,8 +16,6 @@ group :cucumber do
     gem "cucumber"
   end
   # rubocop:enable Bundler/DuplicatedGem
-  gem "rspec"
-  gem "rspec-core", "~> 3.4.4"
 end
 
 # Latest versions of net-ssh don't support Ruby < 2.2.6
@@ -36,7 +38,8 @@ if Gem::Requirement.new("< 2.2").satisfied_by?(Gem::Version.new(RUBY_VERSION))
   gem "rake", "< 13.0.0"
 end
 
-# We only run danger once on a new-ish ruby; no need to install it otherwise
+# We only run danger and rubocop on a new-ish ruby; no need to install them otherwise
 if Gem::Requirement.new("> 2.4").satisfied_by?(Gem::Version.new(RUBY_VERSION))
   gem "danger"
+  gem "rubocop", "0.48.1"
 end

--- a/capistrano.gemspec
+++ b/capistrano.gemspec
@@ -31,8 +31,4 @@ Gem::Specification.new do |gem|
   gem.add_dependency "i18n"
   gem.add_dependency "rake", ">= 10.0.0"
   gem.add_dependency "sshkit", ">= 1.9.0"
-
-  gem.add_development_dependency "mocha"
-  gem.add_development_dependency "rspec"
-  gem.add_development_dependency "rubocop", "0.48.1"
 end


### PR DESCRIPTION
### Summary

Capistrano supports Ruby 2.0, which means we have to use a very old version of rubocop that supports analysis for Ruby 2.0 code.

Old versions of rubocop crash under Ruby 3.1. That is annoying for contributors to the project that are running Ruby 3.1 and want to lint their contributions.

The source of the crash is the newer version of the `psych` gem (4.0.0) that is built-into Ruby 3.1.

Fix by pinning `psych` to version `< 4`.

Fixes #2096.

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test? (N/A)
- [x] Did you confirm that the RSpec tests pass?
