### PR TITLE
Add `linked_dirs` and `linked_files` to VariblesDoctor WHITELIST

### DIFF
--- a/lib/capistrano/doctor/variables_doctor.rb
+++ b/lib/capistrano/doctor/variables_doctor.rb
@@ -10,6 +10,8 @@ module Capistrano
       WHITELIST = %i(
         application
         current_directory
+        linked_dirs
+        linked_files
         releases_directory
         repo_url
         repo_tree


### PR DESCRIPTION
### Summary

This is a bug fix. `linked_dirs` and `linked_files` are valid settings, but `doctor` task says that they are "not a recognized Capistrano setting".

```
    :linked_dirs is not a recognized Capistrano setting (/home/y-yagi/.rbenv/versions/2.7.2/lib/ruby/2.7.0/delegate.rb:83)
    :linked_files is not a recognized Capistrano setting (/home/y-yagi/.rbenv/versions/2.7.2/lib/ruby/2.7.0/delegate.rb:83
```

This fixed that issue.

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [ ] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?

### Other Information

None
