### PR TITLE
Update deploy.rb.erb

### DIFF
--- a/lib/capistrano/templates/deploy.rb.erb
+++ b/lib/capistrano/templates/deploy.rb.erb
@@ -21,10 +21,10 @@ set :repo_url, "git@example.com:me/my_repo.git"
 # set :pty, true
 
 # Default value for :linked_files is []
-# append :linked_files, "config/database.yml"
+# append :linked_files, "config/database.yml", 'config/master.key'
 
 # Default value for linked_dirs is []
-# append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "tmp/webpacker", "public/system"
+# append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "tmp/webpacker", "public/system", "vendor", "storage"
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }


### PR DESCRIPTION
Add missing linked files and dirs to deploy.rb template

### Summary
Not a bug fix, simply a text addendum to commented default template.
This text addition is to catch up to recent additions to rails folder architecture

### Short checklist
Nop

### Other Information
Nop
