### PR TITLE
Install newer SSH client to fix CI for old Rubies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ commands:
           command: |
             if $(ssh -V 2>&1 | grep -q -v OpenSSH_8); then
               apt-get update
+              apt-get install -y libssl-dev
               mkdir ~/tempdownload
               cd ~/tempdownload
               wget https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-8.1p1.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,20 @@ commands:
           paths:
             - ./vendor/bundle
           key: bundle-v1-{{ arch }}-<< parameters.version >>-{{ checksum "Gemfile.lock" }}
+  update_ssh_client:
+    description: Install recent SSH client for compatibility with GitHub
+    steps:
+      - run:
+          name: Install OpenSSH 8.1p1 if necessary
+          command: |
+            if $(ssh -V 2>&1 | grep -q -v OpenSSH_8); then
+              apt-get update
+              mkdir ~/tempdownload
+              cd ~/tempdownload
+              wget https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-8.1p1.tar.gz
+              tar zxvf openssh-8.1p1.tar.gz
+              cd openssh-8.1p1 && ./configure --prefix=/usr && make ssh && make install
+            fi
 
 jobs:
   danger:
@@ -58,6 +72,7 @@ jobs:
       name: ruby
       version: << parameters.version >>
     steps:
+      - update_ssh_client
       - checkout
       - bundle_install:
           version: << parameters.version >>


### PR DESCRIPTION
This fixes CI failing for Ruby 2.0, 2.1, and 2.2 with this error:

```
ERROR: You're using an RSA key with SHA-1, which is no longer allowed.
```

More background here:
https://discuss.circleci.com/t/discussion-and-resolution-for-error-youre-using-an-rsa-key-with-sha-1-which-is-no-longer-allowed/42572
