### PR TITLE
Switch cucumber tests to use https instead of git://

### DIFF
--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -12,7 +12,7 @@ module TestApp
   def default_config
     <<-CONFIG
       set :deploy_to, '#{deploy_to}'
-      set :repo_url, 'git://github.com/capistrano/capistrano.git'
+      set :repo_url, 'https://github.com/capistrano/capistrano.git'
       set :branch, 'master'
       set :ssh_options, { keys: "\#{ENV['HOME']}/.vagrant.d/insecure_private_key", auth_methods: ['publickey'] }
       server 'vagrant@localhost:2220', roles: %w{web app}


### PR DESCRIPTION

### Summary

On my machine, when running `rake features`, the `git clone` operation in some of the cucumber tests hangs and eventually times out. It seems to be due to the repo URL using the `git://` protocol. When I switch to `https://`, it works fine.

_Edit: this is most likely because GitHub has dropped support for `git://`._

https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git


### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?