### PR TITLE
Fix failing Ruby 2.0 CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ commands:
           command: |
             if $(ssh -V 2>&1 | grep -q -v OpenSSH_8); then
               apt-get update
-              apt-get install -y libssl-dev
+              apt-get install -y --force-yes libssl-dev
               mkdir ~/tempdownload
               cd ~/tempdownload
               wget https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-8.1p1.tar.gz


### PR DESCRIPTION
### Summary

The following warning was preventing libssl from being installed, which is a prerequisite for the Ruby 2.0 build in CI:

```
WARNING: The following packages cannot be authenticated!
  libssl-dev libssl1.0.0
```

Fix by passing `--force-yes` to ignore the warning.
