### PR TITLE
Ruby 3.2 compatibility for Capistrano 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,7 @@ gemspec
 #
 group :development do
   gem "rake"
+  gem "rexml"
   gem "pry"
+  gem "test-unit"
 end

--- a/lib/capistrano/configuration/actions/invocation.rb
+++ b/lib/capistrano/configuration/actions/invocation.rb
@@ -248,7 +248,7 @@ module Capistrano
           prompt_host = nil
 
           Proc.new do |ch, stream, out|
-            if out =~ /^Sorry, try again/
+            if out.to_s =~ /^Sorry, try again/
               if prompt_host.nil? || prompt_host == ch[:server]
                 prompt_host = ch[:server]
                 logger.important out, "#{stream} :: #{ch[:server]}"
@@ -256,7 +256,7 @@ module Capistrano
               end
             end
 
-            if out =~ /^#{Regexp.escape(sudo_prompt)}/
+            if out.to_s =~ /^#{Regexp.escape(sudo_prompt)}/
               ch.send_data "#{self[:password]}\n"
             elsif fallback
               fallback.call(ch, stream, out)

--- a/lib/capistrano/logger.rb
+++ b/lib/capistrano/logger.rb
@@ -102,7 +102,7 @@ module Capistrano
 
           Logger.sorted_formatters.each do |formatter|
             if (formatter[:level] == level || formatter[:level].nil?)
-              if message =~ formatter[:match] || line_prefix =~ formatter[:match]
+              if message =~ formatter[:match] || formatter[:match] =~ line_prefix.to_s
                 color = formatter[:color] if formatter[:color]
                 style = formatter[:style] || formatter[:attribute] # (support original cap colors)
                 message.gsub!(formatter[:match], formatter[:replace]) if formatter[:replace]


### PR DESCRIPTION
In Ruby 3.2 the method "=~" [has been removed from Object](https://bugs.ruby-lang.org/issues/15231). Make sure receiver is a Regexp to avoid errors.