### PR TITLE
Add capistrano-mysql_tables as 3rd party plugin

### DIFF
--- a/docs/documentation/third-party-plugins/index.markdown
+++ b/docs/documentation/third-party-plugins/index.markdown
@@ -56,3 +56,5 @@ You can help us expanding this list by sending us a pull request on
 <div class="github-widget" data-repo="aeroastro/capistrano-lazy_cleanup"></div>
 
 <div class="github-widget" data-repo="danieltoader/capistrano-teams"></div>
+
+<div class="github-widget" data-repo="floydj/capistrano-mysql_tables"></div>


### PR DESCRIPTION
### Summary

Same as title...

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [ ] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?

### Other Information
n/a