### PR TITLE
Fix failing CI builds for Ruby < 2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ commands:
           name: Install OpenSSH 8.1p1 if necessary
           command: |
             if $(ssh -V 2>&1 | grep -q -v OpenSSH_8); then
-              apt-get update
-              apt-get install -y --force-yes libssl-dev
+              apt-get update || true
+              apt-get install -y --force-yes libssl-dev || true
               mkdir ~/tempdownload
               cd ~/tempdownload
               wget https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-8.1p1.tar.gz


### PR DESCRIPTION
## Problem

CI builds for Ruby 2.0, 2.1, and 2.3 are failing.

```
W: Failed to fetch http://httpredir.debian.org/debian/dists/jessie-updates/main/binary-amd64/Packages  404  Not Found
E: Some index files failed to download. They have been ignored, or old ones used instead.
```

It seems that the jessie generation of Ubuntu that is used in the old Ruby docker images is no longer receiving apt updates.

## Solution

Skip running `apt-get` for old rubies in CI.