### PR TITLE
Allow legacy-v2 test suite to run locally on modern Rubies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,7 @@ gemspec
 #
 group :development do
   gem "rake"
+  gem "rexml"
   gem "pry"
+  gem "test-unit"
 end


### PR DESCRIPTION
Mordern versions of Ruby are no longer bundled with `test-unit` and `rexml`. This was causing `rake test` in the legacy-v2 branch to fail with errors like these:

```
cannot load such file -- test/unit
```

and

```
cannot load such file -- rexml/xpath
```

Fix by explicitly including these gems in the Gemfile.

The test suite now runs successfully (albeit with many warnings) on Ruby 3.1.3:

```
Started
...............................................................................................................................................................
...............................................................................................................................................................
...............................................................................................................................................................
..............................................................................................................................................
Finished in 0.41697 seconds.
---------------------------------------------------------------------------------------------------------------------------------------------------------------
619 tests, 1536 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
0% passed
---------------------------------------------------------------------------------------------------------------------------------------------------------------
1484.52 tests/s, 3683.72 assertions/s
```