### PR TITLE
fix typo

### DIFF
--- a/docs/documentation/getting-started/authentication-and-authorisation/index.markdown
+++ b/docs/documentation/getting-started/authentication-and-authorisation/index.markdown
@@ -359,7 +359,7 @@ root@remote $ chown deploy ${deploy_to}/{releases,shared}
 
 **Note:** The `chmod g+s` is a really handy, and little known Unix feature, it
 means that at the operating system level, without having to pay much attention
-to the permissions at runtime, all files an directories created inside the
+to the permissions at runtime, all files and directories created inside the
 `${deploy_to}` directory will inherit the group ownership, that means in this
 case even though we are root, the files will be created being owned by `root`
 with the group `deploy`, the `umask 0002` ensures that the files created


### PR DESCRIPTION
### Summary

Fixes minor typo in getting started doc.

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues? – Does not apply
- [x] If relevant, did you create a test? – Does not apply
- [x] Did you confirm that the RSpec tests pass? – Does not apply