### PR TITLE
Fix deprecated usage of open-uri so feature tests work on Ruby 3

### DIFF
--- a/spec/support/Vagrantfile
+++ b/spec/support/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure("2") do |config|
       primary.vm.network "forwarded_port", guest: 22, host: "222#{i}".to_i
       primary.vm.provision :shell, inline: "sudo apt-get -y install git-core"
 
-      vagrantkey = open("https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub", "r", &:read)
+      vagrantkey = URI.open("https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub", "r", &:read)
 
       primary.vm.provision :shell,
                            inline: <<-INLINE


### PR DESCRIPTION
### Summary

`rake features` was failing on Ruby 3 with the following error:

> No such file or directory @ rb_sysopen - https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub (Errno::ENOENT)

This is because the ability to pass a URL directly to `Kernel#open` was [deprecated in Ruby 2.7](https://github.com/ruby/ruby/commit/05aac90a1bcfeb180f5e78ea8b00a4d1b04d5eed) and fully removed in Ruby 3.

Fix by using `URI.open`, per the [open-uri documentation](https://ruby-doc.org/3.2.2/stdlibs/open-uri/OpenURI.html).

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [ ] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?
