### PR TITLE
Fix failing OpenSSL install on Ruby 2.3 CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,8 @@ commands:
           name: Install OpenSSH 8.1p1 if necessary
           command: |
             if $(ssh -V 2>&1 | grep -q -v OpenSSH_8); then
+              # Stretch packages have been moved to the archvie.debian.org domain as of April 2023
+              sed -E 's/^(deb http:\/\/)(security|deb)(\.debian\.org\S+ stretch)/\1archive\3/g' -i /etc/apt/sources.list
               apt-get update || true
               apt-get install -y --force-yes libssl-dev || true
               mkdir ~/tempdownload


### PR DESCRIPTION
The Ruby 2.3 CI build has been failing since April 2023.

This is because the Ruby 2.3 docker image is extremely old, and the repositories used by `apt-get` no longer exist in their original locations. They have been moved to `archive.debian.org`.

Fix by updating the `/etc/apt/sources.list` to point to the archive locations.
