### PR TITLE
Fix capistrano 2.x on Ruby 3 due to removed File.exists? method

### DIFF
--- a/bin/capify
+++ b/bin/capify
@@ -22,7 +22,7 @@ end
 
 if ARGV.empty?
   abort "Please specify the directory to capify, e.g. `#{File.basename($0)} .'"
-elsif !File.exists?(ARGV.first)
+elsif !File.exist?(ARGV.first)
   abort "`#{ARGV.first}' does not exist."
 elsif !File.directory?(ARGV.first)
   abort "`#{ARGV.first}' is not a directory."
@@ -75,12 +75,12 @@ role :db,  "your slave db-server here"
 base = ARGV.shift
 files.each do |file, content|
   file = File.join(base, file)
-  if File.exists?(file)
+  if File.exist?(file)
     warn "[skip] '#{file}' already exists"
-  elsif File.exists?(file.downcase)
+  elsif File.exist?(file.downcase)
     warn "[skip] '#{file.downcase}' exists, which could conflict with `#{file}'"
   else
-    unless File.exists?(File.dirname(file))
+    unless File.exist?(File.dirname(file))
       puts "[add] making directory '#{File.dirname(file)}'"
       FileUtils.mkdir(File.dirname(file))
     end

--- a/lib/capistrano/ext/multistage.rb
+++ b/lib/capistrano/ext/multistage.rb
@@ -52,7 +52,7 @@ Capistrano::Configuration.instance.load do
       FileUtils.mkdir_p(location)
       stages.each do |name|
         file = File.join(location, name + ".rb")
-        unless File.exists?(file)
+        unless File.exist?(file)
           File.open(file, "w") do |f|
             f.puts "# #{name.upcase}-specific deployment configuration"
             f.puts "# please put general deployment config in config/deploy.rb"

--- a/lib/capistrano/recipes/deploy/strategy/copy.rb
+++ b/lib/capistrano/recipes/deploy/strategy/copy.rb
@@ -227,7 +227,7 @@ module Capistrano
           end
 
           def copy_repository_to_local_cache
-            return refresh_local_cache if File.exists?(copy_cache)
+            return refresh_local_cache if File.exist?(copy_cache)
             create_local_cache
           end
 

--- a/test/deploy/strategy/copy_test.rb
+++ b/test/deploy/strategy/copy_test.rb
@@ -222,7 +222,7 @@ class DeployStrategyCopyTest < Test::Unit::TestCase
     @config[:copy_cache] = true
 
     Dir.stubs(:tmpdir).returns("/temp/dir")
-    File.expects(:exists?).with("/temp/dir/captest").returns(false)
+    File.expects(:exist?).with("/temp/dir/captest").returns(false)
     Dir.expects(:chdir).with("/temp/dir/captest").yields
 
     @source.expects(:checkout).with("154", "/temp/dir/captest").returns(:local_checkout)
@@ -240,7 +240,7 @@ class DeployStrategyCopyTest < Test::Unit::TestCase
     @config[:copy_cache] = true
 
     Dir.stubs(:tmpdir).returns("/temp/dir")
-    File.expects(:exists?).with("/temp/dir/captest").returns(true)
+    File.expects(:exist?).with("/temp/dir/captest").returns(true)
     Dir.expects(:chdir).with("/temp/dir/captest").yields
 
     @source.expects(:sync).with("154", "/temp/dir/captest").returns(:local_sync)
@@ -258,7 +258,7 @@ class DeployStrategyCopyTest < Test::Unit::TestCase
     @config[:copy_cache] = "/u/caches/captest"
 
     Dir.stubs(:tmpdir).returns("/temp/dir")
-    File.expects(:exists?).with("/u/caches/captest").returns(true)
+    File.expects(:exist?).with("/u/caches/captest").returns(true)
     Dir.expects(:chdir).with("/u/caches/captest").yields
 
     @source.expects(:sync).with("154", "/u/caches/captest").returns(:local_sync)
@@ -277,7 +277,7 @@ class DeployStrategyCopyTest < Test::Unit::TestCase
 
     Dir.stubs(:pwd).returns("/u")
     Dir.stubs(:tmpdir).returns("/temp/dir")
-    File.expects(:exists?).with("/u/caches/captest").returns(true)
+    File.expects(:exist?).with("/u/caches/captest").returns(true)
     Dir.expects(:chdir).with("/u/caches/captest").yields
 
     @source.expects(:sync).with("154", "/u/caches/captest").returns(:local_sync)
@@ -296,7 +296,7 @@ class DeployStrategyCopyTest < Test::Unit::TestCase
     @config[:copy_exclude] = "*/bar.txt"
 
     Dir.stubs(:tmpdir).returns("/temp/dir")
-    File.expects(:exists?).with("/temp/dir/captest").returns(true)
+    File.expects(:exist?).with("/temp/dir/captest").returns(true)
     Dir.expects(:chdir).with("/temp/dir/captest").yields
 
     @source.expects(:sync).with("154", "/temp/dir/captest").returns(:local_sync)


### PR DESCRIPTION
I will not be surprised if you just close this 😅 but I saw that you've recently made some compatibility fixes and a bugfix release, so I thought it was worth a try.

Yesterday I tried to run `capify` from Capistrano 2 in a project on Ruby 3.2 and I got an error because of the `File.exists?` method, which was apparently long deprecated and was removed in 3.0:

https://github.com/ruby/ruby/commit/bf97415c02b11a8949f715431aca9eeb6311add2

This PR just replaces those few places in `capify` and elsewhere (+ tests) where that removed version of the method was used.
