### PR TITLE
Auto-bump version number in generated release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: "$NEXT_PATCH_VERSION"
-tag-template: "v$NEXT_PATCH_VERSION"
+name-template: "$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
 categories:
   - title: "⚠️ Breaking Changes"
     label: "⚠️ Breaking"
@@ -11,7 +11,15 @@ categories:
     label: "📚 Docs"
   - title: "🏠 Housekeeping"
     label: "🏠 Housekeeping"
+version-resolver:
+  minor:
+    labels:
+      - "⚠️ Breaking"
+      - "✨ Feature"
+  default: patch
 change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
 no-changes-template: "- No changes"
 template: |
   $CHANGES
+
+  **Full Changelog:** https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION


### PR DESCRIPTION
We are using Release Drafter[^1] to automatically write our release notes.

Before, Release Drafter was configured to increment the version number at the patch level, regardless of what was included in the release notes. For example, if the current version is 3.17.3, the draft of the next release would assume a version number of 3.17.4.

With this commit, Release Drafter will now bump the version number based on the concents of the release. A patch bump is the default, but if there is a new feature or breaking change in the release, it will now recommend a minor bump.

This commit also modifies the release notes template to add a link to the full diff of the release on GitHub.

[^1]: https://github.com/release-drafter/release-drafter