### PR TITLE
Fix "lambda method requires a literal block" error (Ruby 3.3)

### DIFF
--- a/lib/capistrano/configuration/validated_variables.rb
+++ b/lib/capistrano/configuration/validated_variables.rb
@@ -68,7 +68,7 @@ module Capistrano
       # works as expected.
       #
       def assert_valid_later(key, callable)
-        validation_callback = lambda do
+        validation_callback = proc do
           value = callable.call
           assert_valid_now(key, value)
           value


### PR DESCRIPTION
Running the test suite on Ruby 3.2 produces this validation warning:

```
$ RUBYOPT=-W bundle e rspec spec/lib/capistrano/configuration_spec.rb
...
warning: lambda without a literal block is deprecated; use the proc without lambda instead
```

On Ruby 3.3 (head), it crashes because the deprecation is now an error[^1]:

```
ArgumentError:
  the lambda method requires a literal block
```

This commit fixes the problem by replacing `lambda` with `proc`, as instructed in the deprecation warning.

[^1]: https://bugs.ruby-lang.org/issues/19777