### PR TITLE
Add capistrano-nomad to third party plugins list

### DIFF
--- a/docs/documentation/third-party-plugins/index.markdown
+++ b/docs/documentation/third-party-plugins/index.markdown
@@ -58,3 +58,5 @@ You can help us expanding this list by sending us a pull request on
 <div class="github-widget" data-repo="danieltoader/capistrano-teams"></div>
 
 <div class="github-widget" data-repo="floydj/capistrano-mysql_tables"></div>
+
+<div class="github-widget" data-repo="axsuul/capistrano-nomad"></div>


### PR DESCRIPTION
### Summary

Added [capistrano-nomad](https://github.com/axsuul/capistrano-nomad) to website's third party list of plugins

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [ ] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?

### Other Information

N/A