### PR TITLE
Fix RuboCop in CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,9 @@ end
 
 # We only run danger and rubocop on a new-ish ruby; no need to install them otherwise
 if Gem::Requirement.new("> 2.4").satisfied_by?(Gem::Version.new(RUBY_VERSION))
+  gem "base64"
   gem "danger"
   gem "psych", "< 4" # Ensures rubocop works on Ruby 3.1
+  gem "racc"
   gem "rubocop", "0.48.1"
 end


### PR DESCRIPTION
RuboCop in CI is now running on Ruby 3.3.0. This version no longer includes `racc` as a default gem, so the old version of RuboCop that we are using fails with this error:

> LoadError: cannot load such file -- racc/parser (LoadError)

Fix by explicitly adding `racc` to our Gemfile.

I also added the `base64` gem to address a deprecation warning.
