### PR TITLE
Create `REVISION_TIME` with git commit timestamp upon deploy

### DIFF
--- a/docs/documentation/advanced-features/custom-scm/index.markdown
+++ b/docs/documentation/advanced-features/custom-scm/index.markdown
@@ -76,7 +76,7 @@ def register_hooks
 end
 ```
 
-### 3. Implement the set_current_revision task
+### 3. Implement the set_current_revision and set_current_revision_time tasks
 
 Similar to how you defined a `create_release`, you should also define a
 `set_current_revision` task. The purpose of this task is to set a special
@@ -89,6 +89,14 @@ set :current_revision, "..."
 # Register this hook to ensure your task runs
 before "deploy:set_current_revision", "foo:set_current_revision"
 ```
+
+Ideally you should also define a `set_current_revision_time` task, though this is
+not required for Capistrano to function. The purpose of this task is to set a 
+special variable which downstream users can use to have a version time that is
+independent of when the version was actually deployed, which can be useful when
+using scaling groups.
+
+The time should be a unix timestamp.
 
 ### 4. Use the plugin
 

--- a/features/deploy.feature
+++ b/features/deploy.feature
@@ -40,6 +40,11 @@ Feature: Deploy
     Then the repo is cloned
     And the release is created
 
+  Scenario: REVISION and REVISION_TIME files are present
+    Given I make 1 deployment
+    And the REVISION file is created in the release
+    And the REVISION_TIME file is created in the release
+
   Scenario: Symlink linked files
     When I run cap "deploy:symlink:linked_files deploy:symlink:release" as part of a release
     Then file symlinks are created in the new release
@@ -85,4 +90,3 @@ Feature: Deploy
     Given I make 3 deployments
     When I rollback to a specific release
     Then the current symlink points to that specific release
-

--- a/features/deploy.feature
+++ b/features/deploy.feature
@@ -41,9 +41,9 @@ Feature: Deploy
     And the release is created
 
   Scenario: REVISION and REVISION_TIME files are present
-    Given I make 1 deployment
-    And the REVISION file is created in the release
-    And the REVISION_TIME file is created in the release
+    When I make 1 deployment
+    Then the REVISION file is created in the release
+    Then the REVISION_TIME file is created in the release
 
   Scenario: Symlink linked files
     When I run cap "deploy:symlink:linked_files deploy:symlink:release" as part of a release

--- a/features/step_definitions/assertions.rb
+++ b/features/step_definitions/assertions.rb
@@ -51,15 +51,13 @@ end
 Then(/^the REVISION file is created in the release$/) do
   stdout, _stderr = run_remote_ssh_command("cat #{@release_paths[0]}/REVISION")
 
-  # TODO: confirm that this value is actually constant for everyone
-  expect(stdout.strip).to eq "3f41365139a0b3a408e96f13c781d9cedba8b4b8"
+  expect(stdout.strip).to match(/\h{40}/)
 end
 
 Then(/^the REVISION_TIME file is created in the release$/) do
   stdout, _stderr = run_remote_ssh_command("cat #{@release_paths[0]}/REVISION_TIME")
 
-  # TODO: confirm that this value is actually constant for everyone
-  expect(stdout.strip).to eq "1718251930"
+  expect(stdout.strip).to match(/\d{10}/)
 end
 
 Then(/^file symlinks are created in the new release$/) do

--- a/features/step_definitions/assertions.rb
+++ b/features/step_definitions/assertions.rb
@@ -48,6 +48,20 @@ Then(/^the release is created$/) do
   run_remote_ssh_command("ls -g #{TestApp.releases_path}")
 end
 
+Then(/^the REVISION file is created in the release$/) do
+  stdout, _stderr = run_remote_ssh_command("cat #{@release_paths[0]}/REVISION")
+
+  # TODO: confirm that this value is actually constant for everyone
+  expect(stdout.strip).to eq "3f41365139a0b3a408e96f13c781d9cedba8b4b8"
+end
+
+Then(/^the REVISION_TIME file is created in the release$/) do
+  stdout, _stderr = run_remote_ssh_command("cat #{@release_paths[0]}/REVISION_TIME")
+
+  # TODO: confirm that this value is actually constant for everyone
+  expect(stdout.strip).to eq "1718251930"
+end
+
 Then(/^file symlinks are created in the new release$/) do
   TestApp.linked_files.each do |file|
     run_remote_ssh_command(test_symlink_exists(TestApp.current_path.join(file)))

--- a/features/step_definitions/setup.rb
+++ b/features/step_definitions/setup.rb
@@ -64,7 +64,7 @@ Given(/^a stage file named (.+)$/) do |filename|
   TestApp.write_local_stage_file(filename)
 end
 
-Given(/^I make (\d+) deployments$/) do |count|
+Given(/^I make (\d+) deployments?$/) do |count|
   step "all linked files exists in shared path"
 
   @release_paths = (1..count.to_i).map do

--- a/lib/capistrano/scm/git.rb
+++ b/lib/capistrano/scm/git.rb
@@ -78,6 +78,10 @@ class Capistrano::SCM::Git < Capistrano::SCM::Plugin
     backend.capture(:git, "rev-list --max-count=1 #{fetch(:branch)}")
   end
 
+  def fetch_revision_time
+    backend.capture(:git, "log -1 --pretty=format:\"%ct\" #{fetch(:branch)}")
+  end
+
   def git(*args)
     args.unshift :git
     backend.execute(*args)

--- a/lib/capistrano/scm/git.rb
+++ b/lib/capistrano/scm/git.rb
@@ -26,6 +26,7 @@ class Capistrano::SCM::Git < Capistrano::SCM::Plugin
     after "deploy:new_release_path", "git:create_release"
     before "deploy:check", "git:check"
     before "deploy:set_current_revision", "git:set_current_revision"
+    before "deploy:set_current_revision_time", "git:set_current_revision_time"
   end
 
   def define_tasks

--- a/lib/capistrano/scm/tasks/git.rake
+++ b/lib/capistrano/scm/tasks/git.rake
@@ -70,4 +70,15 @@ namespace :git do
       end
     end
   end
+
+  desc "Determine the unix timestamp that the revision that will be deployed was created"
+  task :set_current_revision_time do
+    on release_roles(:all), in: :groups, limit: fetch(:git_max_concurrent_connections), wait: fetch(:git_wait_interval) do
+      within repo_path do
+        with fetch(:git_environmental_variables) do
+          set :current_revision, git_plugin.fetch_revision
+        end
+      end
+    end
+  end
 end

--- a/lib/capistrano/scm/tasks/git.rake
+++ b/lib/capistrano/scm/tasks/git.rake
@@ -76,7 +76,7 @@ namespace :git do
     on release_roles(:all), in: :groups, limit: fetch(:git_max_concurrent_connections), wait: fetch(:git_wait_interval) do
       within repo_path do
         with fetch(:git_environmental_variables) do
-          set :current_revision, git_plugin.fetch_revision
+          set :current_revision_time, git_plugin.fetch_revision_time
         end
       end
     end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -259,7 +259,9 @@ namespace :deploy do
   task :set_current_revision_time do
     on release_roles(:all) do
       within release_path do
-        execute :echo, "\"#{fetch(:current_revision_time)}\" > REVISION_TIME"
+        if fetch(:current_revision_time)
+          execute :echo, "\"#{fetch(:current_revision_time)}\" > REVISION_TIME"
+        end
       end
     end
   end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -3,6 +3,7 @@ namespace :deploy do
     invoke "deploy:print_config_variables" if fetch(:print_config_variables, false)
     invoke "deploy:check"
     invoke "deploy:set_previous_revision"
+    invoke "deploy:set_previous_revision_time"
   end
 
   task :print_config_variables do
@@ -27,6 +28,7 @@ namespace :deploy do
 
   task updating: :new_release_path do
     invoke "deploy:set_current_revision"
+    invoke "deploy:set_current_revision_time"
     invoke "deploy:symlink:shared"
   end
 
@@ -249,6 +251,24 @@ namespace :deploy do
       target = release_path.join("REVISION")
       if test "[ -f #{target} ]"
         set(:previous_revision, capture(:cat, target, "2>/dev/null"))
+      end
+    end
+  end
+
+  desc "Place a REVISION_TIME file with the current revision commit time in the current release path"
+  task :set_current_revision_time do
+    on release_roles(:all) do
+      within release_path do
+        execute :echo, "\"#{fetch(:current_revision_time)}\" > REVISION_TIME"
+      end
+    end
+  end
+
+  task :set_previous_revision_time do
+    on release_roles(:all) do
+      target = release_path.join("REVISION_TIME")
+      if test "[ -f #{target} ]"
+        set(:previous_revision_time, capture(:cat, target, "2>/dev/null"))
       end
     end
   end

--- a/spec/lib/capistrano/configuration/scm_resolver_spec.rb
+++ b/spec/lib/capistrano/configuration/scm_resolver_spec.rb
@@ -12,6 +12,7 @@ module Capistrano
         Rake::Task.define_task("deploy:check")
         Rake::Task.define_task("deploy:new_release_path")
         Rake::Task.define_task("deploy:set_current_revision")
+        Rake::Task.define_task("deploy:set_current_revision_time")
         set :scm, SCMResolver::DEFAULT_GIT
       end
 

--- a/spec/lib/capistrano/scm/git_spec.rb
+++ b/spec/lib/capistrano/scm/git_spec.rb
@@ -19,6 +19,7 @@ module Capistrano
       Rake::Task.define_task("deploy:new_release_path")
       Rake::Task.define_task("deploy:check")
       Rake::Task.define_task("deploy:set_current_revision")
+      Rake::Task.define_task("deploy:set_current_revision_time")
     end
 
     # Clean up any tasks or variables that the plugin defined.

--- a/spec/lib/capistrano/scm/git_spec.rb
+++ b/spec/lib/capistrano/scm/git_spec.rb
@@ -170,6 +170,15 @@ module Capistrano
       end
     end
 
+    describe "#fetch_revision_time" do
+      it "should capture git log" do
+        env.set(:branch, "branch")
+        backend.expects(:capture).with(:git, "log -1 --pretty=format:\"%ct\" branch").returns("1715828406")
+        revision_time = subject.fetch_revision_time
+        expect(revision_time).to eq("1715828406")
+      end
+    end
+
     describe "#verify_commit" do
       it "should run git verify-commit" do
         env.set(:branch, "branch")


### PR DESCRIPTION
### Summary

The general story behind this is outlined in #2153 - ultimately, this has Capistrano start to manage a `REVISION_TIME` file which holds a unix timestamp of when the release was committed, in the same way that it stores that releases SHA in `REVISION`.

Resolves #2153

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?

### Other Information

I think this is actually pretty close to being landable since I figured out the general "how" a while ago in another project, but I expect some tweaking will probably be required and it would be nice to support this for svn and hg if possible but I don't use those tools so will either need someone who does to provide insight or I'll see if I can google/chatgpt a solution.

Some general questions I have are:
  - do we want to have a dedicated set of tasks, or fold this into the current "revision" based ones?
  - in the context of custom SCMs, do we want to make this an optional extra or required?
  - if optional, do we need to have any custom/extra checks? (I noticed that there are some `NotImplementedError` methods but it didn't seem like they were actually being called by Capistrano itself)
  - if the revision time isn't available, do we want to create an `REVISION_TIME` file at all? (it'd be simpler, but an empty file)