### PR TITLE
Remove Danger since it is no longer working reliably

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,19 +66,6 @@ jobs:
           bundler-cache: true
       - name: rake rubocop
         run: bundle exec rake rubocop
-  danger:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "ruby" # latest-stable
-          bundler-cache: true
-      - name: danger
-        env:
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
-        run: bundle exec danger
   features:
     needs: [spec, spec-legacy]
     runs-on: macos-12

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,9 +17,6 @@ Style/ClassAndModuleChildren:
   Enabled: false
 Style/DoubleNegation:
   Enabled: false
-Style/FileName:
-  Exclude:
-    - "Dangerfile"
 Style/IndentHeredoc:
   Enabled: false
 Style/SpaceAroundEqualsInParameterDefault:

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,1 +1,0 @@
-danger.import_dangerfile(github: "capistrano/danger", branch: "no-changelog")

--- a/Gemfile
+++ b/Gemfile
@@ -38,10 +38,9 @@ if Gem::Requirement.new("< 2.2").satisfied_by?(Gem::Version.new(RUBY_VERSION))
   gem "rake", "< 13.0.0"
 end
 
-# We only run danger and rubocop on a new-ish ruby; no need to install them otherwise
+# We only run rubocop and its dependencies on a new-ish ruby; no need to install them otherwise
 if Gem::Requirement.new("> 2.4").satisfied_by?(Gem::Version.new(RUBY_VERSION))
   gem "base64"
-  gem "danger"
   gem "psych", "< 4" # Ensures rubocop works on Ruby 3.1
   gem "racc"
   gem "rubocop", "0.48.1"


### PR DESCRIPTION
### Summary

Historically, we have used the `danger` gem to do some lightweight automatic PR review for this project. Mainly, danger was added to enforce a consistent format for CHANGELOG.md entries. However, we have long since moved away from a manually-maintained changelog in favor of GitHub Releases.

This left danger with not much to do, other than pester PR authors about writing tests, something we already have a checklist for in our PR template (see below).

Recently, danger has stopped working altogether, due to GitHub token issues. I spent about an hour troubleshooting, to no avail.

I think it is time to retire danger from this project, since it was not providing much value, and is currently broken with no clear fix.

This PR:

- removes danger from the Gemfile
- removes the `Dangerfile`
- removes the danger job from our GitHub Actions workflow

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] ~If relevant, did you create a test?~
- [x] Did you confirm that the RSpec tests pass?