### PR TITLE
Fix mocha deprecation warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,9 @@ Metrics/BlockLength:
     - "lib/**/*.rake"
 Style/BarePercentLiterals:
   EnforcedStyle: percent_q
+Style/BracesAroundHashParameters:
+  Exclude:
+    - spec/integration/dsl_spec.rb
 Style/ClassAndModuleChildren:
   Enabled: false
 Style/DoubleNegation:

--- a/spec/integration/dsl_spec.rb
+++ b/spec/integration/dsl_spec.rb
@@ -592,8 +592,8 @@ describe Capistrano::DSL do
 
     it "yields the properties for a single role" do
       recipient = mock("recipient")
-      recipient.expects(:doit).with("example1.com", :redis, port: 6379, type: :slave)
-      recipient.expects(:doit).with("example2.com", :redis, port: 6379, type: :master)
+      recipient.expects(:doit).with("example1.com", :redis, { port: 6379, type: :slave })
+      recipient.expects(:doit).with("example2.com", :redis, { port: 6379, type: :master })
       dsl.role_properties(:redis) do |host, role, props|
         recipient.doit(host, role, props)
       end
@@ -601,8 +601,8 @@ describe Capistrano::DSL do
 
     it "yields the properties for multiple roles" do
       recipient = mock("recipient")
-      recipient.expects(:doit).with("example1.com", :redis, port: 6379, type: :slave)
-      recipient.expects(:doit).with("example2.com", :redis, port: 6379, type: :master)
+      recipient.expects(:doit).with("example1.com", :redis, { port: 6379, type: :slave })
+      recipient.expects(:doit).with("example2.com", :redis, { port: 6379, type: :master })
       recipient.expects(:doit).with("example3.com", :app, nil)
       dsl.role_properties(:redis, :app) do |host, role, props|
         recipient.doit(host, role, props)
@@ -611,10 +611,10 @@ describe Capistrano::DSL do
 
     it "yields the merged properties for multiple roles" do
       recipient = mock("recipient")
-      recipient.expects(:doit).with("example1.com", :redis, port: 6379, type: :slave)
-      recipient.expects(:doit).with("example2.com", :redis, port: 6379, type: :master)
-      recipient.expects(:doit).with("example1.com", :web, port: 80)
-      recipient.expects(:doit).with("example2.com", :web, port: 81)
+      recipient.expects(:doit).with("example1.com", :redis, { port: 6379, type: :slave })
+      recipient.expects(:doit).with("example2.com", :redis, { port: 6379, type: :master })
+      recipient.expects(:doit).with("example1.com", :web, { port: 80 })
+      recipient.expects(:doit).with("example2.com", :web, { port: 81 })
       dsl.role_properties(:redis, :web) do |host, role, props|
         recipient.doit(host, role, props)
       end
@@ -622,8 +622,8 @@ describe Capistrano::DSL do
 
     it "honours a property filter before yielding" do
       recipient = mock("recipient")
-      recipient.expects(:doit).with("example1.com", :redis, port: 6379, type: :slave)
-      recipient.expects(:doit).with("example1.com", :web, port: 80)
+      recipient.expects(:doit).with("example1.com", :redis, { port: 6379, type: :slave })
+      recipient.expects(:doit).with("example1.com", :web, { port: 80 })
       dsl.role_properties(:redis, :web, select: :active) do |host, role, props|
         recipient.doit(host, role, props)
       end


### PR DESCRIPTION
### Summary

When running specs, mocha would print warnings like this:

> Mocha deprecation warning at /Users/mbrictson/Code/capistrano/capistrano/spec/integration/dsl_spec.rb:628:in 'block (4 levels) in <top (required)>': Expectation defined at /Users/mbrictson/Code/capistrano/capistrano/spec/integration/dsl_spec.rb:626:in 'block (3 levels) in <top (required)>' expected keyword arguments (:port => 80), but received positional hash ({:port => 80}). These will stop matching when strict keyword argument matching is enabled. See the documentation for Mocha::Configuration#strict_keyword_argument_matching=.

This commit tweaks the specs to make it explicit that we are existing a positional hash.

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] ~If relevant, did you create a test?~
- [x] Did you confirm that the RSpec tests pass?