### PR TITLE
Properly assert that release was created in feature test

### DIFF
--- a/features/step_definitions/assertions.rb
+++ b/features/step_definitions/assertions.rb
@@ -45,7 +45,9 @@ Then(/^the repo is cloned$/) do
 end
 
 Then(/^the release is created$/) do
-  run_remote_ssh_command("ls -g #{TestApp.releases_path}")
+  stdout, _stderr = run_remote_ssh_command("ls #{TestApp.releases_path}")
+
+  expect(stdout.strip).to match(/\A#{Time.now.utc.strftime("%Y%m%d")}\d{6}\Z/)
 end
 
 Then(/^file symlinks are created in the new release$/) do


### PR DESCRIPTION
### Summary

Follow up to https://github.com/capistrano/capistrano/pull/2155#issuecomment-2172283634 and https://github.com/capistrano/capistrano/pull/2155#issuecomment-2174466232

I've gone with expecting the year, month, day as for that to fail there'd need to be a 24 hour delay between steps which'd be a whole problem of its own - it might be possible that if you run the suite at midnight in a particular timezone it could also fail, but if so that should only be a ~30 second window of possibility...

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?

### Other Information

This is branched off #2159