### PR TITLE
fix: explicitly request that `git log` does not use a pager

### DIFF
--- a/lib/capistrano/scm/git.rb
+++ b/lib/capistrano/scm/git.rb
@@ -80,7 +80,7 @@ class Capistrano::SCM::Git < Capistrano::SCM::Plugin
   end
 
   def fetch_revision_time
-    backend.capture(:git, "log -1 --pretty=format:\"%ct\" #{fetch(:branch)}")
+    backend.capture(:git, "--no-pager log -1 --pretty=format:\"%ct\" #{fetch(:branch)}")
   end
 
   def git(*args)

--- a/spec/lib/capistrano/scm/git_spec.rb
+++ b/spec/lib/capistrano/scm/git_spec.rb
@@ -172,9 +172,9 @@ module Capistrano
     end
 
     describe "#fetch_revision_time" do
-      it "should capture git log" do
+      it "should capture git log without a pager" do
         env.set(:branch, "branch")
-        backend.expects(:capture).with(:git, "log -1 --pretty=format:\"%ct\" branch").returns("1715828406")
+        backend.expects(:capture).with(:git, "--no-pager log -1 --pretty=format:\"%ct\" branch").returns("1715828406")
         revision_time = subject.fetch_revision_time
         expect(revision_time).to eq("1715828406")
       end


### PR DESCRIPTION
### Summary

Resolves #2161

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?

### Other Information

I wanted to write a feature test for this but couldn't come up with a way to have `git` use a pager in a manner that didn't cut across the actual tests themselves - I plan to have a second crack at this later this week, but don't think that should block landing the fix.
