### PR TITLE
Fix uninitialized constant Capistrano::SCM::Git::StringIO

### DIFF
--- a/lib/capistrano/scm/git.rb
+++ b/lib/capistrano/scm/git.rb
@@ -2,6 +2,7 @@ require "capistrano/scm/plugin"
 require "cgi"
 require "securerandom"
 require "shellwords"
+require "stringio"
 require "uri"
 
 class Capistrano::SCM::Git < Capistrano::SCM::Plugin


### PR DESCRIPTION
### Summary

This Pull Request adds `require "stringio"` for `Capistrano::SCM::Git`, fix #2163.

Due to changes in psych v5.2.0, `require "stringio"` is now missing, causing failures when referencing StringIO.
https://github.com/ruby/psych/pull/686

#### Steps to reproduce
The `Capistrano::SCM::Git::StringIO` error occurs in the `cap git:check` task as follows.
```
$ bundle exec cap staging git:check
00:00 git:wrapper
      01 mkdir -p /tmp
    ✔ 01 deploy@198.51.100.1 0.382s
#<Thread:0x000000010a7260b8 /Users/taketo/rails-app/vendor/bundle/ruby/3.3.0/gems/sshkit-1.23.2/lib/sshkit/runners/parallel.rb:10 run> terminated with exception (report_on_exception is true):
/Users/taketo/rails-app/vendor/bundle/ruby/3.3.0/gems/sshkit-1.23.2/lib/sshkit/runners/parallel.rb:15:in `rescue in block (2 levels) in execute': Exception while executing as deploy@198.51.100.1: uninitialized constant Capistrano::SCM::Git::StringIO (SSHKit::Runner::ExecuteError)
	from /Users/taketo/rails-app/vendor/bundle/ruby/3.3.0/gems/sshkit-1.23.2/lib/sshkit/runners/parallel.rb:11:in `block (2 levels) in execute'
/Users/taketo/rails-app/vendor/bundle/ruby/3.3.0/gems/capistrano-3.19.1/lib/capistrano/scm/tasks/git.rake:9:in `block (3 levels) in eval_rakefile': uninitialized constant Capistrano::SCM::Git::StringIO (NameError)
	from /Users/taketo/rails-app/vendor/bundle/ruby/3.3.0/gems/sshkit-1.23.2/lib/sshkit/backends/abstract.rb:31:in `instance_exec'
	from /Users/taketo/rails-app/vendor/bundle/ruby/3.3.0/gems/sshkit-1.23.2/lib/sshkit/backends/abstract.rb:31:in `run'
	from /Users/taketo/rails-app/vendor/bundle/ruby/3.3.0/gems/sshkit-1.23.2/lib/sshkit/runners/parallel.rb:12:in `block (2 levels) in execute'
(Backtrace restricted to imported tasks)
cap aborted!
SSHKit::Runner::ExecuteError: Exception while executing as deploy@198.51.100.1: uninitialized constant Capistrano::SCM::Git::StringIO (SSHKit::Runner::ExecuteError)


Caused by:
NameError: uninitialized constant Capistrano::SCM::Git::StringIO (NameError)

Tasks: TOP => git:check => git:wrapper
(See full trace by running task with --trace)
```

- System configuration
  - ruby: 3.3.6
  - rails: 7.1.5
  - capistrano: 3.19.1 
  - psych: 5.2.0

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?

### Other Information

In the same environment as in the Steps to Reproduce, the error does not occur when psych is v5.1.2.
