### PR TITLE
fix: update RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,16 +13,13 @@ Metrics/BlockLength:
     - "lib/**/*.rake"
 Style/BarePercentLiterals:
   EnforcedStyle: percent_q
-Style/BracesAroundHashParameters:
-  Exclude:
-    - spec/integration/dsl_spec.rb
 Style/ClassAndModuleChildren:
   Enabled: false
 Style/DoubleNegation:
   Enabled: false
 Style/IndentHeredoc:
   Enabled: false
-Style/SpaceAroundEqualsInParameterDefault:
+Layout/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: no_space
 Style/StringLiterals:
   EnforcedStyle: double_quotes
@@ -48,7 +45,7 @@ Metrics/MethodLength:
   Enabled: false
 Style/PredicateName:
   Enabled: false
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false
@@ -58,5 +55,5 @@ Metrics/ClassLength:
   Enabled: false
 Metrics/ModuleLength:
   Enabled: false
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Enabled: false


### PR DESCRIPTION
### Summary
The RuboCop config is using outdated cop names. Running it with 3.19.2 produces the following warnings:
```
vendor/bundle/ruby/3.3.0/gems/capistrano-3.19.2/.rubocop.yml: Style/SpaceAroundEqualsInParameterDefault has the wrong namespace - replace it with Layout/SpaceAroundEqualsInParameterDefault
Error: The `Metrics/LineLength` cop has been moved to `Layout/LineLength`.
(obsolete configuration found in vendor/bundle/ruby/3.3.0/gems/capistrano-3.19.2/.rubocop.yml, please update it)
The `Style/AccessorMethodName` cop has been moved to `Naming/AccessorMethodName`.
(obsolete configuration found in vendor/bundle/ruby/3.3.0/gems/capistrano-3.19.2/.rubocop.yml, please update it)
The `Style/BracesAroundHashParameters` cop has been removed. Please use  and/or  instead.
(obsolete configuration found in vendor/bundle/ruby/3.3.0/gems/capistrano-3.19.2/.rubocop.yml, please update it)
```

This updates the cop names and eliminates the warnings.