### PR TITLE
fix PuTTY link in index.markdown

### DIFF
--- a/docs/documentation/getting-started/authentication-and-authorisation/index.markdown
+++ b/docs/documentation/getting-started/authentication-and-authorisation/index.markdown
@@ -50,7 +50,7 @@ correct, we are allowed to login.
   2. Open "Git Bash" and follow next instructions always inside Git Bash prompt.
   3. Activate ssh-agent: ```$ eval "$(ssh-agent -s)" ```
 
-**Note:** If you want to use [Putty tool](https://www.putty.org/) to connect to remote server (from Windows) with ssh keys, then you need to generate ppk file, through puttygen tool.
+**Note:** If you want to use [Putty tool](https://putty.software/) to connect to remote server (from Windows) with ssh keys, then you need to generate ppk file, through puttygen tool.
 
 
 **Hint:** If you have more than one developer in your team, they should all add their


### PR DESCRIPTION
The link to PuTTY was pointing to putty.org. This domain has no relation to the PuTTY project! Instead, the website run by the actual PuTTY team can be found under https://putty.software , see https://hachyderm.io/@simontatham/115025974777386803
