### PR TITLE
Enable dependabot for Bundler and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "16:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 10
+    labels:
+      - "🏠 Housekeeping"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "16:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 10
+    labels:
+      - "🏠 Housekeeping"


### PR DESCRIPTION
This PR enables dependabot updates (monthly) for our Bundler gems and GitHub Actions packages. This provides a couple benefits:

1. It keeps our dependencies up to date.
2. It serves as a periodic test for our CI infrastructure (dependabot PRs trigger CI checks).