### PR TITLE
Add Ruby 4 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4", "head"]
+        ruby: ["3.1", "3.2", "3.3", "3.4", "4.0", "head"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby


### PR DESCRIPTION
Ruby 4.0 was released on Dec 25, 2025. This PR adds it to our CI matrix.