### PR TITLE
Add opt-in cleanup for failed releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,5 @@
 Release notes for this project are kept here: https://github.com/capistrano/capistrano/releases
+
+### master
+
+* Add opt-in cleanup for failed release directories. (#2120)

--- a/docs/documentation/getting-started/configuration/index.markdown
+++ b/docs/documentation/getting-started/configuration/index.markdown
@@ -109,6 +109,11 @@ The following variables are settable:
   * The last `n` releases are kept for possible rollbacks.
   * The cleanup task detects outdated release folders and removes them if needed.
 
+* `:remove_failed_release`
+  * **default:** `false`
+  * Remove the failed `release_path` after `deploy:failed`, unless `current` points to that release.
+  * This can prevent failed releases from consuming `:keep_releases` slots.
+
 * `:tmp_dir`
   * **default:** `'/tmp'`
   * Temporary directory used during deployments to store data.

--- a/docs/documentation/getting-started/rollbacks/index.markdown
+++ b/docs/documentation/getting-started/rollbacks/index.markdown
@@ -35,6 +35,10 @@ end
 
 This is different from a specifically invoked rollback, and is application specific. *For reasons stated above, it can be dangerous to use this hook without careful testing.*
 
+If you want Capistrano to remove the failed release directory after a failed
+deployment, set `:remove_failed_release` to `true`. Capistrano will skip removal
+when `current` points to the failed release.
+
 ### `deploy:rollback ROLLBACK_RELEASE=release`
 
 Rollback to a specific release using the `ROLLBACK_RELEASE` environment variable.

--- a/features/remove_failed_release.feature
+++ b/features/remove_failed_release.feature
@@ -1,0 +1,28 @@
+Feature: Remove failed release
+
+  Background:
+    Given a test app with the default configuration
+    And servers with the roles app and web
+    And an empty deploy directory
+    And all linked files exists in shared path
+
+  Scenario: Failed releases are kept by default
+    Given a custom task that will fail after a release is created
+    When I run cap "deploy"
+    Then the task fails
+    And 1 valid releases are kept
+
+  Scenario: Failed releases are removed when configured
+    Given config stage file has line "set :remove_failed_release, true"
+    And a custom task that will fail after a release is created
+    When I run cap "deploy"
+    Then the task fails
+    And 0 valid releases are kept
+
+  Scenario: Current release is not removed after publishing
+    Given config stage file has line "set :remove_failed_release, true"
+    And a custom task that will fail after a release is published
+    When I run cap "deploy"
+    Then the task fails
+    And 1 valid releases are kept
+    And the current directory will be a symlink to the release

--- a/features/step_definitions/setup.rb
+++ b/features/step_definitions/setup.rb
@@ -11,6 +11,10 @@ Given(/^servers with the roles app and web$/) do
   wait_for_ssh_server
 end
 
+Given(/^an empty deploy directory$/) do
+  run_remote_ssh_command("rm -rf #{TestApp.deploy_to}")
+end
+
 Given(/^a linked file "(.*?)"$/) do |file|
   # ignoring other linked files
   TestApp.append_to_deploy_file("set :linked_files, ['#{file}']")
@@ -53,6 +57,14 @@ end
 Given(/^a custom task that will simulate a failure$/) do
   safely_remove_file(TestApp.shared_path.join("failed"))
   TestApp.copy_task_to_test_app("spec/support/tasks/fail.rake")
+end
+
+Given(/^a custom task that will fail after a release is created$/) do
+  TestApp.copy_task_to_test_app("spec/support/tasks/fail_after_release.rake")
+end
+
+Given(/^a custom task that will fail after a release is published$/) do
+  TestApp.copy_task_to_test_app("spec/support/tasks/fail_after_publish.rake")
 end
 
 Given(/^a custom task to run in the event of a failure$/) do

--- a/lib/capistrano/defaults.rb
+++ b/lib/capistrano/defaults.rb
@@ -27,6 +27,7 @@ set_if_empty :tmp_dir, "/tmp"
 
 set_if_empty :default_env, {}
 set_if_empty :keep_releases, 5
+set_if_empty :remove_failed_release, false
 
 set_if_empty :format, :airbrussh
 set_if_empty :log_level, :debug

--- a/lib/capistrano/i18n.rb
+++ b/lib/capistrano/i18n.rb
@@ -19,6 +19,8 @@ en = {
   wont_delete_current_release: "Current release was marked for being removed but it's going to be skipped on %{host}",
   no_current_release: "There is no current release present on %{host}",
   no_old_releases: "No old releases (keeping newest %{keep_releases}) on %{host}",
+  removing_failed_release: "Removing failed release %{release} on %{host}",
+  wont_delete_current_release_on_failure: "Failed release %{release} is current on %{host}; skipping removal",
   linked_file_does_not_exist: "linked file %{file} does not exist on %{host}",
   cannot_rollback: "There are no older releases to rollback to",
   cannot_found_rollback_release: "Cannot rollback because release %{release} does not exist",

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -196,6 +196,39 @@ namespace :deploy do
     end
   end
 
+  desc "Remove failed release if enabled"
+  task :remove_failed_release do
+    next unless fetch(:remove_failed_release)
+
+    failed_release_path = fetch(:release_path, nil)
+    next unless failed_release_path
+
+    on release_roles(:all) do |host|
+      next unless test "[ -d #{failed_release_path} ]"
+
+      if test "[ -d #{current_path} ]"
+        current_release = nil
+        failed_release = nil
+
+        within current_path do
+          current_release = capture(:pwd, "-P").strip
+        end
+
+        within failed_release_path do
+          failed_release = capture(:pwd, "-P").strip
+        end
+
+        if current_release == failed_release
+          warn t(:wont_delete_current_release_on_failure, host: host.to_s, release: failed_release_path)
+          next
+        end
+      end
+
+      info t(:removing_failed_release, host: host.to_s, release: failed_release_path)
+      execute :rm, "-rf", failed_release_path
+    end
+  end
+
   desc "Log details of the deploy"
   task :log_revision do
     on release_roles(:all) do
@@ -278,3 +311,5 @@ namespace :deploy do
   task :restart
   task :failed
 end
+
+after "deploy:failed", "deploy:remove_failed_release"

--- a/lib/capistrano/templates/deploy.rb.erb
+++ b/lib/capistrano/templates/deploy.rb.erb
@@ -35,5 +35,8 @@ set :repo_url, "git@example.com:me/my_repo.git"
 # Default value for keep_releases is 5
 # set :keep_releases, 5
 
+# Default value for remove_failed_release is false
+# set :remove_failed_release, true
+
 # Uncomment the following to require manually verifying the host key before first deploy.
 # set :ssh_options, verify_host_key: :secure

--- a/spec/support/tasks/fail_after_publish.rake
+++ b/spec/support/tasks/fail_after_publish.rake
@@ -1,0 +1,7 @@
+after "deploy:published", :fail_after_publish do
+  on release_roles(:all) do
+    execute :touch, release_path.join("fail")
+  end
+
+  raise "failure after publish"
+end

--- a/spec/support/tasks/fail_after_release.rake
+++ b/spec/support/tasks/fail_after_release.rake
@@ -1,0 +1,7 @@
+after "deploy:updated", :fail_after_release do
+  on release_roles(:all) do
+    execute :touch, release_path.join("fail")
+  end
+
+  raise "failure after release"
+end


### PR DESCRIPTION
## Summary
- Add a `:remove_failed_release` setting, defaulting to `false`, that removes the failed `release_path` after `deploy:failed`.
- Skip removal when `current` resolves to the same release, so a published release is preserved.
- Document the new setting and add Cucumber coverage for default behavior, enabled cleanup, and the current-release safety check.

Refs #2120.
Refs #1907.

## Tests
- `RBENV_VERSION=3.4.9 ~/.rbenv/bin/rbenv exec bundle exec rake spec`
- `RBENV_VERSION=3.4.9 ~/.rbenv/bin/rbenv exec bundle exec rake rubocop`
- `RBENV_VERSION=3.4.9 ~/.rbenv/bin/rbenv exec bundle exec cucumber features/remove_failed_release.feature --dry-run`

I could not run the full Cucumber scenario locally because Docker is not available in this WSL environment.