### PR TITLE
Add opt-in cleanup for failed releases

### DIFF
--- a/docs/documentation/getting-started/configuration/index.markdown
+++ b/docs/documentation/getting-started/configuration/index.markdown
@@ -109,6 +109,11 @@ The following variables are settable:
   * The last `n` releases are kept for possible rollbacks.
   * The cleanup task detects outdated release folders and removes them if needed.
 
+* `:remove_failed_release`
+  * **default:** `false`
+  * Remove the failed `release_path` after `deploy:failed`, unless `current` points to that release.
+  * This can prevent failed releases from consuming `:keep_releases` slots.
+
 * `:tmp_dir`
   * **default:** `'/tmp'`
   * Temporary directory used during deployments to store data.

--- a/docs/documentation/getting-started/rollbacks/index.markdown
+++ b/docs/documentation/getting-started/rollbacks/index.markdown
@@ -35,6 +35,10 @@ end
 
 This is different from a specifically invoked rollback, and is application specific. *For reasons stated above, it can be dangerous to use this hook without careful testing.*
 
+If you want Capistrano to remove the failed release directory after a failed
+deployment, set `:remove_failed_release` to `true`. Capistrano will skip removal
+when `current` points to the failed release.
+
 ### `deploy:rollback ROLLBACK_RELEASE=release`
 
 Rollback to a specific release using the `ROLLBACK_RELEASE` environment variable.

--- a/features/remove_failed_release.feature
+++ b/features/remove_failed_release.feature
@@ -1,0 +1,25 @@
+Feature: Remove failed release
+
+  Background:
+    Given a test app with the default configuration
+    And servers with the roles app and web
+    And an empty deploy directory
+    And a custom task to create a failed release directory
+
+  Scenario: Failed releases are kept by default
+    When I run cap "deploy:create_failed_release_directory deploy:failed"
+    Then the task is successful
+    And 1 valid releases are kept
+
+  Scenario: Failed releases are removed when configured
+    Given config stage file has line "set :remove_failed_release, true"
+    When I run cap "deploy:create_failed_release_directory deploy:failed"
+    Then the task is successful
+    And 0 valid releases are kept
+
+  Scenario: Current release is not removed after publishing
+    Given config stage file has line "set :remove_failed_release, true"
+    When I run cap "deploy:create_failed_release_directory deploy:symlink:release deploy:failed"
+    Then the task is successful
+    And 1 valid releases are kept
+    And the current directory will be a symlink to the release

--- a/features/step_definitions/setup.rb
+++ b/features/step_definitions/setup.rb
@@ -11,6 +11,10 @@ Given(/^servers with the roles app and web$/) do
   wait_for_ssh_server
 end
 
+Given(/^an empty deploy directory$/) do
+  run_remote_ssh_command("rm -rf #{TestApp.deploy_to}")
+end
+
 Given(/^a linked file "(.*?)"$/) do |file|
   # ignoring other linked files
   TestApp.append_to_deploy_file("set :linked_files, ['#{file}']")
@@ -53,6 +57,10 @@ end
 Given(/^a custom task that will simulate a failure$/) do
   safely_remove_file(TestApp.shared_path.join("failed"))
   TestApp.copy_task_to_test_app("spec/support/tasks/fail.rake")
+end
+
+Given(/^a custom task to create a failed release directory$/) do
+  TestApp.copy_task_to_test_app("spec/support/tasks/create_failed_release_directory.rake")
 end
 
 Given(/^a custom task to run in the event of a failure$/) do

--- a/lib/capistrano/defaults.rb
+++ b/lib/capistrano/defaults.rb
@@ -27,6 +27,7 @@ set_if_empty :tmp_dir, "/tmp"
 
 set_if_empty :default_env, {}
 set_if_empty :keep_releases, 5
+set_if_empty :remove_failed_release, false
 
 set_if_empty :format, :airbrussh
 set_if_empty :log_level, :debug

--- a/lib/capistrano/i18n.rb
+++ b/lib/capistrano/i18n.rb
@@ -19,6 +19,8 @@ en = {
   wont_delete_current_release: "Current release was marked for being removed but it's going to be skipped on %{host}",
   no_current_release: "There is no current release present on %{host}",
   no_old_releases: "No old releases (keeping newest %{keep_releases}) on %{host}",
+  removing_failed_release: "Removing failed release %{release} on %{host}",
+  wont_delete_current_release_on_failure: "Failed release %{release} is current on %{host}; skipping removal",
   linked_file_does_not_exist: "linked file %{file} does not exist on %{host}",
   cannot_rollback: "There are no older releases to rollback to",
   cannot_found_rollback_release: "Cannot rollback because release %{release} does not exist",

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -196,6 +196,42 @@ namespace :deploy do
     end
   end
 
+  desc "Remove failed release if enabled"
+  task :remove_failed_release do
+    next unless fetch(:remove_failed_release)
+
+    failed_release_path = fetch(:release_path, nil)
+    next unless failed_release_path
+
+    on release_roles(:all) do |host|
+      next unless test "[ -d #{failed_release_path} ]"
+
+      if test "[ -d #{current_path} ]"
+        current_release = nil
+        failed_release = nil
+
+        # Use `pwd -P` instead of `readlink -f`.
+        # The `-f` option is not supported on macOS/BSD systems,
+        # so `pwd -P` ensures compatibility by resolving the physical path.
+        within current_path do
+          current_release = capture(:pwd, "-P").strip
+        end
+
+        within failed_release_path do
+          failed_release = capture(:pwd, "-P").strip
+        end
+
+        if current_release == failed_release
+          warn t(:wont_delete_current_release_on_failure, host: host.to_s, release: failed_release_path)
+          next
+        end
+      end
+
+      info t(:removing_failed_release, host: host.to_s, release: failed_release_path)
+      execute :rm, "-rf", failed_release_path
+    end
+  end
+
   desc "Log details of the deploy"
   task :log_revision do
     on release_roles(:all) do
@@ -278,3 +314,5 @@ namespace :deploy do
   task :restart
   task :failed
 end
+
+after "deploy:failed", "deploy:remove_failed_release"

--- a/lib/capistrano/templates/deploy.rb.erb
+++ b/lib/capistrano/templates/deploy.rb.erb
@@ -35,5 +35,8 @@ set :repo_url, "git@example.com:me/my_repo.git"
 # Default value for keep_releases is 5
 # set :keep_releases, 5
 
+# Default value for remove_failed_release is false
+# set :remove_failed_release, true
+
 # Uncomment the following to require manually verifying the host key before first deploy.
 # set :ssh_options, verify_host_key: :secure

--- a/spec/support/tasks/create_failed_release_directory.rake
+++ b/spec/support/tasks/create_failed_release_directory.rake
@@ -1,0 +1,9 @@
+namespace :deploy do
+  task :create_failed_release_directory do
+    set_release_path("20150101000000")
+
+    on release_roles(:all) do
+      execute :mkdir, "-p", shared_path, releases_path, release_path
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Add an opt-in `:remove_failed_release` setting, defaulting to `false`, to remove a failed `release_path` after `deploy:failed`.

This helps prevent failed release directories from consuming `:keep_releases` slots and causing older working releases to be cleaned up. The cleanup is conservative: Capistrano skips removal when `current` resolves to the same release, preserving a release that has already been published.

This PR also documents the new setting and adds Cucumber coverage for:

- default behavior, where failed releases are kept
- enabled cleanup, where failed releases are removed
- preserving the failed release when it is also the current release

Refs #2120.
Refs #1907.

### Short checklist

- [x] Did you run `bundle exec rubocop -a` to fix linter issues?
- [x] If relevant, did you create a test?
- [x] Did you confirm that the RSpec tests pass?

### Other Information

Verified locally with:

- `bundle exec cucumber features/remove_failed_release.feature`
- `bundle exec rake rubocop`
- `bundle exec rake spec`